### PR TITLE
EDSC-3420: Adds support for collection subscriptions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,7 @@ provider:
     ummCollectionVersion: '1.17.0'
     ummGranuleVersion: '1.5'
     ummServiceVersion: '1.3.4'
-    ummSubscriptionVersion: '1.0'
+    ummSubscriptionVersion: '1.1'
     ummToolVersion: '1.1'
     ummVariableVersion: '1.7'
 

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -344,7 +344,8 @@ export default class Concept {
     this.response = cmrIngest(
       this.getConceptType(),
       data,
-      providedHeaders
+      providedHeaders,
+      this.ingestPath
     )
   }
 
@@ -364,7 +365,8 @@ export default class Concept {
     this.response = cmrDelete(
       this.getConceptType(),
       data,
-      providedHeaders
+      providedHeaders,
+      this.ingestPath
     )
   }
 

--- a/src/cmr/concepts/subscription.js
+++ b/src/cmr/concepts/subscription.js
@@ -12,6 +12,13 @@ export default class Subscription extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('subscriptions', headers, requestInfo, params)
+
+    this.ingestPath = 'subscriptions'
+    this.metadataSpecification = {
+      URL: `https://cdn.earthdata.nasa.gov/umm/subscription/v${process.env.ummSubscriptionVersion}`,
+      Name: 'UMM-Sub',
+      Version: process.env.ummSubscriptionVersion
+    }
   }
 
   /**
@@ -34,7 +41,8 @@ export default class Subscription extends Concept {
       ...super.getPermittedJsonSearchParams(),
       'collection_concept_id',
       'provider',
-      'subscriber_id'
+      'subscriber_id',
+      'type'
     ]
   }
 
@@ -46,7 +54,8 @@ export default class Subscription extends Concept {
       ...super.getPermittedUmmSearchParams(),
       'collection_concept_id',
       'provider',
-      'subscriber_id'
+      'subscriber_id',
+      'type'
     ]
   }
 
@@ -100,6 +109,10 @@ export default class Subscription extends Concept {
       'CMR-Request-Id',
       'Echo-Token'
     ])
+
+    // Add MetadataSpecification to the data
+    // eslint-disable-next-line no-param-reassign
+    data.metadataSpecification = this.metadataSpecification
 
     super.ingest(data, requestedKeys, permittedHeaders)
   }

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -114,7 +114,7 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -147,7 +147,7 @@ describe('subscription#fetch', () => {
             }]
           })
 
-        const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+        const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -196,7 +196,7 @@ describe('subscription#fetch', () => {
           .post('/search/clear-scroll', { scroll_id: '-98726357' })
           .reply(204)
 
-        const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+        const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
         expect(response).toEqual({
           count: 0,
@@ -241,7 +241,7 @@ describe('subscription#fetch', () => {
           .reply(500)
 
         await expect(
-          subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+          subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
         ).rejects.toThrow(Error)
       })
     })
@@ -262,7 +262,7 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -289,7 +289,7 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -349,7 +349,7 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -371,7 +371,7 @@ describe('subscription#fetch', () => {
       })
 
     await expect(
-      subscriptionSourceFetch({ params: { conceptId: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      subscriptionSourceFetch({ params: { conceptId: 'SUB100000-EDSC' } }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })
@@ -427,7 +427,7 @@ describe('subscription#ingest', () => {
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': '1'
@@ -440,7 +440,7 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -455,7 +455,7 @@ describe('subscription#ingest', () => {
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/test-guid/)
+        .put(/ingest\/subscriptions\/test-guid/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': '1'
@@ -470,7 +470,7 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -481,7 +481,7 @@ describe('subscription#ingest', () => {
 
   test('catches errors received from ingestCmr', async () => {
     nock(/example/)
-      .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+      .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
       .reply(500, {
         errors: ['HTTP Error']
       }, {
@@ -497,7 +497,7 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })
@@ -551,7 +551,7 @@ describe('subscription#delete', () => {
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .delete(/ingest\/providers\/EDSC\/subscriptions\/test-guid/)
+        .delete(/ingest\/subscriptions\/test-guid/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': '1'
@@ -562,7 +562,7 @@ describe('subscription#delete', () => {
           conceptId: 'SUB100000-EDSC',
           nativeId: 'test-guid'
         }
-      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -573,7 +573,7 @@ describe('subscription#delete', () => {
 
   test('catches errors received from cmrDelete', async () => {
     nock(/example/)
-      .delete(/ingest\/providers\/EDSC\/subscriptions\/test-guid/)
+      .delete(/ingest\/subscriptions\/test-guid/)
       .reply(500, {
         errors: ['HTTP Error']
       }, {
@@ -586,7 +586,7 @@ describe('subscription#delete', () => {
           conceptId: 'C100000-EDSC',
           nativeId: 'test-guid'
         }
-      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'subscription')
+      }, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/resolvers/__tests__/subscription.test.js
+++ b/src/resolvers/__tests__/subscription.test.js
@@ -337,7 +337,7 @@ describe('Subscription', () => {
           $collectionConceptId: String
           $name: String!
           $query: String!
-          $subscriberId: String!
+          $subscriberId: String
           $type: String!
         ) {
           createSubscription(
@@ -393,7 +393,7 @@ describe('Subscription', () => {
         query: `mutation CreateSubscription (
           $name: String!
           $query: String!
-          $subscriberId: String!
+          $subscriberId: String
           $type: String!
         ) {
           createSubscription(
@@ -446,7 +446,7 @@ describe('Subscription', () => {
           $name: String!
           $nativeId: String!
           $query: String!
-          $subscriberId: String!
+          $subscriberId: String
           $type: String!
         ) {
           updateSubscription(

--- a/src/types/subscription.graphql
+++ b/src/types/subscription.graphql
@@ -17,6 +17,8 @@ type Subscription {
   revisionId: String
   "The EDL userid of the subscriber."
   subscriberId: String
+  "The type of the subscription."
+  type: String
 
   collection: Collection
 }
@@ -47,6 +49,8 @@ input SubscriptionsInput {
   subscriberId: String
   "Zero based offset of individual results."
   offset: Int
+  "The type of the subscription."
+  type: String
 }
 
 input SubscriptionInput {
@@ -86,7 +90,7 @@ type Query {
 
 input CreateSubscriptionInput {
   "The concept id of the parent CMR collection."
-  collectionConceptId: String!
+  collectionConceptId: String
   "The email address that notifications will be delivered to."
   name: String!
   "The native id to set on the subscription."
@@ -95,11 +99,13 @@ input CreateSubscriptionInput {
   subscriberId: String!
   "The query used to retrieve data for the subscription."
   query: String!
+  "The type of the subscription."
+  type: String!
 }
 
 input UpdateSubscriptionInput {
   "The concept id of the parent CMR collection."
-  collectionConceptId: String!
+  collectionConceptId: String
   "The email address that notifications will be delivered to."
   name: String!
   "The native id to set on the subscription."
@@ -108,6 +114,8 @@ input UpdateSubscriptionInput {
   subscriberId: String!
   "The query used to retrieve data for the subscription."
   query: String!
+  "The type of the subscription."
+  type: String!
 }
 
 input DeleteSubscriptionInput {

--- a/src/types/subscription.graphql
+++ b/src/types/subscription.graphql
@@ -96,7 +96,7 @@ input CreateSubscriptionInput {
   "The native id to set on the subscription."
   nativeId: String
   "The EDL userid of the subscriber."
-  subscriberId: String!
+  subscriberId: String
   "The query used to retrieve data for the subscription."
   query: String!
   "The type of the subscription."
@@ -111,7 +111,7 @@ input UpdateSubscriptionInput {
   "The native id to set on the subscription."
   nativeId: String!
   "The EDL userid of the subscriber."
-  subscriberId: String!
+  subscriberId: String
   "The query used to retrieve data for the subscription."
   query: String!
   "The type of the subscription."

--- a/src/utils/__tests__/cmrDelete.test.js
+++ b/src/utils/__tests__/cmrDelete.test.js
@@ -25,7 +25,7 @@ describe('cmrDelete', () => {
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       }
     })
-      .delete(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+      .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
       .reply(201, {
         'concept-id': 'SUB100000-EDSC',
         'revision-id': 1
@@ -37,7 +37,8 @@ describe('cmrDelete', () => {
         conceptId: 'SUB100000-EDSC',
         nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
       },
-      { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }
+      { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+      'subscriptions'
     )
 
     const { data, headers } = response
@@ -67,7 +68,7 @@ describe('cmrDelete', () => {
           'Echo-Token': 'test-token'
         }
       })
-        .delete(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -79,7 +80,8 @@ describe('cmrDelete', () => {
           conceptId: 'SUB100000-EDSC',
           nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678', 'Echo-Token': 'test-token' }
+        { 'CMR-Request-Id': 'abcd-1234-efgh-5678', 'Echo-Token': 'test-token' },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -110,7 +112,7 @@ describe('cmrDelete', () => {
           Authorization: 'test-token'
         }
       })
-        .delete(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -125,7 +127,8 @@ describe('cmrDelete', () => {
         {
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
           Authorization: 'test-token'
-        }
+        },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -156,7 +159,7 @@ describe('cmrDelete', () => {
           Authorization: 'authorization-token'
         }
       })
-        .delete(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -172,7 +175,8 @@ describe('cmrDelete', () => {
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
           Authorization: 'authorization-token',
           'Echo-Token': 'echo-token'
-        }
+        },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -199,7 +203,7 @@ describe('cmrDelete', () => {
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
-        .delete(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(500, {
           errors: ['HTTP Error']
         })
@@ -210,7 +214,8 @@ describe('cmrDelete', () => {
           conceptId: 'SUB100000-EDSC',
           nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }
+        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        'subscriptions'
       )
 
       await expect(response).rejects.toThrow()

--- a/src/utils/__tests__/cmrIngest.test.js
+++ b/src/utils/__tests__/cmrIngest.test.js
@@ -28,7 +28,7 @@ describe('cmrIngest', () => {
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       }
     })
-      .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+      .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
       .reply(201, {
         'concept-id': 'SUB100000-EDSC',
         'revision-id': 1
@@ -40,7 +40,8 @@ describe('cmrIngest', () => {
       {
         'CMR-Request-Id': 'abcd-1234-efgh-5678',
         'Content-Type': 'application/vnd.nasa.cmr.umm+json; version=1.0'
-      }
+      },
+      'subscriptions'
     )
 
     const { data, headers } = response
@@ -69,7 +70,7 @@ describe('cmrIngest', () => {
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/provided-native-id/)
+        .put(/ingest\/subscriptions\/provided-native-id/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -81,7 +82,8 @@ describe('cmrIngest', () => {
           collectionConceptId: 'C100000-EDSC',
           nativeId: 'provided-native-id'
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }
+        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -112,7 +114,7 @@ describe('cmrIngest', () => {
           'Echo-Token': 'test-token'
         }
       })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -121,7 +123,8 @@ describe('cmrIngest', () => {
       const response = await cmrIngest(
         'subscriptions',
         { collectionConceptId: 'C100000-EDSC' },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678', 'Echo-Token': 'test-token' }
+        { 'CMR-Request-Id': 'abcd-1234-efgh-5678', 'Echo-Token': 'test-token' },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -152,7 +155,7 @@ describe('cmrIngest', () => {
           Authorization: 'test-token'
         }
       })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -164,7 +167,8 @@ describe('cmrIngest', () => {
         {
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
           Authorization: 'test-token'
-        }
+        },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -195,7 +199,7 @@ describe('cmrIngest', () => {
           Authorization: 'authorization-token'
         }
       })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(201, {
           'concept-id': 'SUB100000-EDSC',
           'revision-id': 1
@@ -208,7 +212,8 @@ describe('cmrIngest', () => {
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
           Authorization: 'authorization-token',
           'Echo-Token': 'echo-token'
-        }
+        },
+        'subscriptions'
       )
 
       const { data, headers } = response
@@ -235,7 +240,7 @@ describe('cmrIngest', () => {
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
-        .put(/ingest\/providers\/EDSC\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
         .reply(500, {
           errors: ['HTTP Error']
         })
@@ -243,7 +248,8 @@ describe('cmrIngest', () => {
       const response = cmrIngest(
         'subscriptions',
         { collectionConceptId: 'C100000-EDSC' },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }
+        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        'subscriptions'
       )
 
       await expect(response).rejects.toThrow()

--- a/src/utils/cmrDelete.js
+++ b/src/utils/cmrDelete.js
@@ -6,11 +6,12 @@ import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
  * Make a DELETE request to CMR and return the promise
- * @param {String} conceptType Concept type to search
+ * @param {String} conceptType Concept type to delete
  * @param {Object} data Parameters to send to CMR
  * @param {Object} headers Headers to send to CMR
+ * @param {String} ingestPath CMR path to call to delete concept
  */
-export const cmrDelete = async (conceptType, data, headers) => {
+export const cmrDelete = async (conceptType, data, headers, ingestPath) => {
   // Default headers
   const defaultHeaders = {
     Accept: 'application/json',
@@ -39,10 +40,7 @@ export const cmrDelete = async (conceptType, data, headers) => {
   }
 
   // Use the provided native id
-  const { conceptId, nativeId } = data
-
-  // Use the string after '-' to determine the provider
-  const [, provider] = conceptId.split('-')
+  const { nativeId } = data
 
   // Remove native id as it is not a supported key in umm
   // eslint-disable-next-line no-param-reassign
@@ -56,7 +54,7 @@ export const cmrDelete = async (conceptType, data, headers) => {
     data: cmrParameters,
     headers: permittedHeaders,
     method: 'DELETE',
-    url: `${process.env.cmrRootUrl}/ingest/providers/${provider}/${conceptType}/${nativeId}`
+    url: `${process.env.cmrRootUrl}/ingest/${ingestPath}/${nativeId}`
   }
 
   // Interceptors require an instance of axios

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -8,11 +8,12 @@ import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
  * Make a request to CMR and return the promise
- * @param {String} conceptType Concept type to search
+ * @param {String} conceptType Concept type to ingest
  * @param {Object} data Parameters to send to CMR
  * @param {Object} headers Headers to send to CMR
+ * @param {String} ingestPath CMR path to call to ingest concept
  */
-export const cmrIngest = async (conceptType, data, headers) => {
+export const cmrIngest = async (conceptType, data, headers, ingestPath) => {
   // Default headers
   const defaultHeaders = {
     Accept: 'application/json'
@@ -40,10 +41,7 @@ export const cmrIngest = async (conceptType, data, headers) => {
   }
 
   // Use the provided native id if one is provided, default to a guid
-  const { collectionConceptId, nativeId = uuidv4() } = data
-
-  // Use the string after '-' to determine the provider
-  const [, provider] = collectionConceptId.split('-')
+  const { nativeId = uuidv4() } = data
 
   // Remove native id as it is not a supported key in umm
   // eslint-disable-next-line no-param-reassign
@@ -57,7 +55,7 @@ export const cmrIngest = async (conceptType, data, headers) => {
     data: cmrParameters,
     headers: permittedHeaders,
     method: 'PUT',
-    url: `${process.env.cmrRootUrl}/ingest/providers/${provider}/${conceptType}/${nativeId}`
+    url: `${process.env.cmrRootUrl}/ingest/${ingestPath}/${nativeId}`
   }
 
   // Interceptors require an instance of axios

--- a/src/utils/mergeParams.js
+++ b/src/utils/mergeParams.js
@@ -5,8 +5,14 @@
 export const mergeParams = (fullParams) => {
   const { params = {} } = fullParams
 
-  return {
+  const returnParams = {
     ...fullParams,
     ...params
   }
+
+  // Delete the params key, those values have been moved to the top level
+  // This ensures ingest validation does not fail on a `params` key
+  delete returnParams.params
+
+  return returnParams
 }

--- a/src/utils/umm/subscriptionKeyMap.json
+++ b/src/utils/umm/subscriptionKeyMap.json
@@ -16,6 +16,7 @@
     "providerId": "meta.provider-id",
     "query": "umm.Query",
     "revisionId": "meta.revision-id",
-    "subscriberId": "umm.SubscriberId"
+    "subscriberId": "umm.SubscriberId",
+    "type": "umm.Type"
   }
 }


### PR DESCRIPTION
Adds `type` field to subscriptions, removed requirement of collectionConceptId field

Changed the subscription ingest path to the new path from CMR-8269

Added values for MetadataSpecification for ingesting subscriptions