### PR TITLE
EDSC-3423: Adds creationDate and revisionDate fields to Subscription type

### DIFF
--- a/src/resolvers/__tests__/subscription.test.js
+++ b/src/resolvers/__tests__/subscription.test.js
@@ -65,8 +65,10 @@ describe('Subscription', () => {
           items: [{
             meta: {
               'concept-id': 'SUB100000-EDSC',
+              'creation-date': '2022-05-26T18:47:26.351Z',
               'native-id': 'test-guid',
               'provider-id': 'EDSC',
+              'revision-date': '2022-05-27T15:18:00.920Z',
               'revision-id': '1'
             },
             umm: {
@@ -88,11 +90,13 @@ describe('Subscription', () => {
             items {
               collectionConceptId
               conceptId
+              creationDate
               emailAddress
               name
               nativeId
               providerId
               query
+              revisionDate
               revisionId
               subscriberId
               type
@@ -109,11 +113,13 @@ describe('Subscription', () => {
           items: [{
             collectionConceptId: 'C100000-EDSC',
             conceptId: 'SUB100000-EDSC',
+            creationDate: '2022-05-26T18:47:26.351Z',
             emailAddress: 'test@example.com',
             name: 'Test Subscription',
             nativeId: 'test-guid',
             providerId: 'EDSC',
             query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
+            revisionDate: '2022-05-27T15:18:00.920Z',
             revisionId: '1',
             subscriberId: 'testuser',
             type: 'granule'
@@ -304,9 +310,47 @@ describe('Subscription', () => {
         }
       })
     })
-  })
 
-  describe('Subscription', () => {
+    test('collection when collectionConceptId does not exist', async () => {
+      nock(/example/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .post(/subscriptions\.json/)
+        .reply(200, {
+          items: [{
+            concept_id: 'SUB100000-EDSC',
+            type: 'collection'
+          }]
+        })
+
+      const response = await server.executeOperation({
+        variables: {},
+        query: `{
+          subscriptions {
+            items {
+              conceptId
+              collection {
+                conceptId
+              }
+            }
+          }
+        }`
+      })
+
+      const { data } = response
+
+      expect(data).toEqual({
+        subscriptions: {
+          items: [{
+            conceptId: 'SUB100000-EDSC',
+            collection: null
+          }]
+        }
+      })
+    })
+
     test('createSubscription for a granule subscription', async () => {
       nock(/example/, {
         reqheaders: {

--- a/src/resolvers/subscription.js
+++ b/src/resolvers/subscription.js
@@ -27,6 +27,10 @@ export default {
         collectionConceptId
       } = source
 
+      // If the subscription doesn't have a collectionConceptId, like when the type requested was `collection`
+      // return null for the collection
+      if (!collectionConceptId) return null
+
       const requestedParams = handlePagingParams({
         conceptId: collectionConceptId,
         ...args

--- a/src/types/subscription.graphql
+++ b/src/types/subscription.graphql
@@ -3,6 +3,8 @@ type Subscription {
   collectionConceptId: String
   "The unique concept id assigned to the subscription."
   conceptId: String!
+  "The date the subscription was created."
+  creationDate: String
   "The email address that notifications will be delivered to."
   emailAddress: String
   "The name of a subscription."
@@ -13,6 +15,8 @@ type Subscription {
   providerId: String
   "The query used to retrieve data for the subscription."
   query: String
+  "The date the subscription was updated."
+  revisionDate: String
   "The revision associated with this subscription."
   revisionId: String
   "The EDL userid of the subscriber."

--- a/src/utils/umm/subscriptionKeyMap.json
+++ b/src/utils/umm/subscriptionKeyMap.json
@@ -10,11 +10,13 @@
   "ummKeyMappings": {
     "collectionConceptId": "umm.CollectionConceptId",
     "conceptId": "meta.concept-id",
+    "creationDate": "meta.creation-date",
     "emailAddress": "umm.EmailAddress",
     "name": "umm.Name",
     "nativeId": "meta.native-id",
     "providerId": "meta.provider-id",
     "query": "umm.Query",
+    "revisionDate": "meta.revision-date",
     "revisionId": "meta.revision-id",
     "subscriberId": "umm.SubscriberId",
     "type": "umm.Type"


### PR DESCRIPTION
# Overview

### What is the feature?

Adds creationDate and revisionDate fields to Subscription type.

Also fixes a bug where a collection was being returned if the subscription had no collectionConceptId, like when the subscription type is 'collection'

### What areas of the application does this impact?

Subscription queries

# Testing

### Reproduction steps

query:
```
query Subscriptions($params: SubscriptionsInput) {
  subscriptions(params: $params) {
    count
    items {
      conceptId
      type
      creationDate
      revisionDate 
      collectionConceptId
      collection {
        conceptId
        title
      }
    }
  }
}
```

variables: 
```
{
  "params": {
    "type": "collection"
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
