### PR TITLE
EDSC-3417: Adds cloudHosted as boolean field to Collection type

### DIFF
--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -73,6 +73,7 @@ describe('Collection', () => {
               archive_center: 'CONDIMENTUM/TELLUS/PHARETRA',
               boxes: [],
               browse_flag: true,
+              cloud_hosted: false,
               coordinate_system: 'CARTESIAN',
               data_center: 'PORTA',
               dataset_id: 'Condimentum Quam Mattis Cursus Pharetra',
@@ -245,6 +246,7 @@ describe('Collection', () => {
               associatedDois
               boxes
               browseFlag
+              cloudHosted
               collectionCitations
               collectionProgress
               conceptId
@@ -370,6 +372,7 @@ describe('Collection', () => {
             }],
             boxes: [],
             browseFlag: true,
+            cloudHosted: false,
             collectionCitations: [],
             collectionProgress: 'ACTIVE',
             conceptId: 'C100000-EDSC',

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -17,6 +17,8 @@ type Collection {
   boxes: [String]
   "True if the metadata contains browse imagery."
   browseFlag: Boolean
+  "Data hosted in the cloud."
+  cloudHosted: Boolean
   "The unique concept id assigned to the collection."
   conceptId: String!
   "Information required to properly cite the collection in professional scientific literature."


### PR DESCRIPTION
# Overview
Adds cloudHosted as a new field to the Collection type.

### What is the feature?
Queried collections now include a cloudHosted property, so a user can easily tell if a collection is hosted "in the cloud" or "on premise."  This is the same cloud_hosted field provided by https://cmr.earthdata.nasa.gov/search/collections.json and documented ([here](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-cloud-hosted)) this is now being made available via the CMR GraphQL service.

Please summarize the feature or fix.

### What is the Solution?
Add cloudHosted to the Collection type.

### What areas of the application does this impact?
No direct impact yet, but will be used by EDSC in later work on EDSC-3417 to notify users whether a duplicate collection is on-premise or in the cloud.

# Testing

### Reproduction steps
run `npm test` as tests have been updated

### Attachments
- https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-cloud-hosted
- https://cmr.earthdata.nasa.gov/search/collections.json

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
