### PR TITLE
CMR-8424: Adds two new ENV variables and spacing in a test file

### DIFF
--- a/bin/deploy-bamboo.sh
+++ b/bin/deploy-bamboo.sh
@@ -28,18 +28,20 @@ dockerRun() {
         -e "AWS_SECRET_ACCESS_KEY=$bamboo_AWS_SECRET_ACCESS_KEY" \
         -e "CLOUDFRONT_BUCKET_NAME=$bamboo_CLOUDFRONT_BUCKET_NAME" \
         -e "CMR_ROOT_URL=$bamboo_CMR_ROOT_URL" \
-        -e "GRAPHDB_HOST=$bamboo_GRAPHDB_HOST" \
-        -e "GRAPHDB_PORT=$bamboo_GRAPHDB_PORT" \
-        -e "GRAPHDB_PATH=$bamboo_GRAPHDB_PATH" \
         -e "DRAFT_MMT_ROOT_URL=$bamboo_DRAFT_MMT_ROOT_URL" \
+        -e "EDL_JWK=$bamboo_EDL_JWK" \
+        -e "EDL_KEY_ID=$bamboo_EDL_KEY_ID" \
+        -e "GRAPHDB_HOST=$bamboo_GRAPHDB_HOST" \
+        -e "GRAPHDB_PATH=$bamboo_GRAPHDB_PATH" \
+        -e "GRAPHDB_PORT=$bamboo_GRAPHDB_PORT" \
         -e "LAMBDA_TIMEOUT=$bamboo_LAMBDA_TIMEOUT" \
         -e "LOG_DESTINATION_ARN=$bamboo_LOG_DESTINATION_ARN" \
         -e "MMT_ROOT_URL=$bamboo_MMT_ROOT_URL" \
         -e "NODE_ENV=production" \
+        -e "SSL_CERT_FILE=$bamboo_SSL_CERT_FILE" \
         -e "SUBNET_ID_A=$bamboo_SUBNET_ID_A" \
         -e "SUBNET_ID_B=$bamboo_SUBNET_ID_B" \
         -e "VPC_ID=$bamboo_VPC_ID" \
-        -e "SSL_CERT_FILE=$bamboo_SSL_CERT_FILE" \
         $dockerTag "$@"
 }
 

--- a/src/utils/__tests__/getUserPermittedGroups.test.js
+++ b/src/utils/__tests__/getUserPermittedGroups.test.js
@@ -40,6 +40,7 @@ describe('Retrieve data from EDL on the user groups', () => {
           }
         ]
       })
+
     const returnObject = await getUserPermittedGroups('headers', 'SomeUid')
 
     // This single quote inside of string is how graphDb parses http requests
@@ -53,6 +54,7 @@ describe('Retrieve data from EDL on the user groups', () => {
       .reply(200, {
         user_groups: []
       })
+
     const returnObject = await getUserPermittedGroups('headers', 'SomeUid')
 
     // This single quote inside of string is how graphDb parses http requests
@@ -64,6 +66,7 @@ describe('Retrieve data from EDL on the user groups', () => {
     nock(/example/)
       .get(/user_groups/)
       .reply(400, null)
+
     const returnObject = await getUserPermittedGroups('headers', 'SomeUid')
 
     // Only guest group is added
@@ -75,6 +78,7 @@ describe('Retrieve data from EDL on the user groups', () => {
     nock(/example/)
       .get(/user_groups/)
       .reply(400, null)
+
     const returnObject = await getUserPermittedGroups('headers', '')
 
     // Only guest group is added


### PR DESCRIPTION
Adds two environment variables to the deploy script to be picked up from Bamboo. (Also sorted the list of variables so the diff is a bit misleading)