### PR TITLE
EDSC-3478: Updates paging to use search after instead of scroll sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When querying for multiple items there are three high level parameters that can 
 
 ##### Cursor
 
-`cursor` tells CMR that you'd like to initiate a scroll session with the intent of harvesting data. If you request this key without providing cursor as a search parameter GraphQL will ask CMR to start a new scroll session and return the value as a cursor in the response. To take advantage of the cursor you can then include it in subsequent queries until no data is returned.
+`cursor` tells CMR that you'd like to fetch the search after identifier out of the header with the intent of harvesting data. If you request this key without providing cursor as a search parameter GraphQL will ask CMR to start a new search after search and return the value as a cursor in the response. To take advantage of the cursor you can then include it in subsequent queries until no data is returned.
 
 ###### First Request:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When querying for multiple items there are three high level parameters that can 
 
 ##### Cursor
 
-`cursor` tells CMR that you'd like to fetch the search after identifier out of the header with the intent of harvesting data. If you request this key without providing cursor as a search parameter GraphQL will ask CMR to start a new search after search and return the value as a cursor in the response. To take advantage of the cursor you can then include it in subsequent queries until no data is returned.
+`cursor` tells GraphQL that you'd like to fetch the search after identifier out of the response header with the intent of harvesting data. To take advantage of the cursor you can then include it in subsequent queries until no data is returned.
 
 ###### First Request:
 

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -106,7 +106,7 @@ describe('collection', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-29834750'
+          'CMR-Search-After': '["abc", 123, 444]'
         })
         .post(/collections\.json/)
         .reply(200, {
@@ -123,7 +123,7 @@ describe('collection', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/collections\.umm_json/)
         .reply(200, {
@@ -143,7 +143,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
+        cursor: 'eyJqc29uIjoiW1wiYWJjXCIsIDEyMywgNDQ0XSIsInVtbSI6IltcInh5elwiLCA3ODksIDk5OV0ifQ==',
         items: [{
           conceptId: 'C100000-EDSC',
           doi: {
@@ -161,9 +161,9 @@ describe('collection', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
+            'CMR-Search-After': '["abc", 123, 444]'
           })
-          .post(/collections\.json/, 'scroll=true')
+          .post(/collections\.json/)
           .reply(200, {
             feed: {
               entry: [{
@@ -178,9 +178,9 @@ describe('collection', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/collections\.umm_json/, 'scroll=true')
+          .post(/collections\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -198,7 +198,7 @@ describe('collection', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
+          cursor: 'eyJqc29uIjoiW1wiYWJjXCIsIDEyMywgNDQ0XSIsInVtbSI6IltcInh5elwiLCA3ODksIDk5OV0ifQ==',
           items: [{
             conceptId: 'C100000-EDSC',
             doi: {
@@ -207,92 +207,6 @@ describe('collection', () => {
             onlineAccessFlag: false
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/collections\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/collections\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await collectionDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'collection')
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/collections\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/collections\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          collectionDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'collection')
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -232,7 +232,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'C100000-EDSC'
         }]
@@ -271,7 +271,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'C100000-EDSC',
           tags: {
@@ -371,7 +371,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'C100000-EDSC',
           doi: {
@@ -472,7 +472,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'C100000-EDSC',
           dataCenter: 'EDSC',
@@ -549,7 +549,7 @@ describe('collection', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           abstract: 'Lorem ipsum dolor sit amet, consectetur adipiscing',
           associations: {

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -100,7 +100,7 @@ describe('granule', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-29834750'
+          'CMR-Search-After': '["abc", 123, 444]'
         })
         .post(/granules\.json/)
         .reply(200, {
@@ -117,7 +117,7 @@ describe('granule', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/granules\.umm_json/)
         .reply(200, {
@@ -135,7 +135,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
+        cursor: 'eyJqc29uIjoiW1wiYWJjXCIsIDEyMywgNDQ0XSIsInVtbSI6IltcInh5elwiLCA3ODksIDk5OV0ifQ==',
         items: [{
           conceptId: 'G100000-EDSC',
           dayNightFlag: 'UNSPECIFIED',
@@ -151,9 +151,9 @@ describe('granule', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
+            'CMR-Search-After': '["abc", 123, 444]'
           })
-          .post(/granules\.json/, 'scroll=true')
+          .post(/granules\.json/)
           .reply(200, {
             feed: {
               entry: [{
@@ -168,9 +168,9 @@ describe('granule', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/granules\.umm_json/, 'scroll=true')
+          .post(/granules\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -186,99 +186,13 @@ describe('granule', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
+          cursor: 'eyJqc29uIjoiW1wiYWJjXCIsIDEyMywgNDQ0XSIsInVtbSI6IltcInh5elwiLCA3ODksIDk5OV0ifQ==',
           items: [{
             conceptId: 'G100000-EDSC',
             dayNightFlag: 'UNSPECIFIED',
             granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/granules\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/granules\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await granuleDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'granule')
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/granules\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/granules\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          granuleDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'granule')
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -218,7 +218,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'G100000-EDSC'
         }]
@@ -247,7 +247,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'G100000-EDSC'
         }]
@@ -327,7 +327,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           links: [{
             href: 'https://example.com/data_link',
@@ -425,7 +425,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'G100000-EDSC',
           browseFlag: true,
@@ -493,7 +493,7 @@ describe('granule', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
         }]

--- a/src/datasources/__tests__/service.test.js
+++ b/src/datasources/__tests__/service.test.js
@@ -174,7 +174,7 @@ describe('service', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'S100000-EDSC'
         }]
@@ -201,7 +201,7 @@ describe('service', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'S100000-EDSC'
         }]
@@ -267,7 +267,7 @@ describe('service', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           type: 'OPeNDAP'
         }]

--- a/src/datasources/__tests__/service.test.js
+++ b/src/datasources/__tests__/service.test.js
@@ -94,7 +94,7 @@ describe('service', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/services\.umm_json/)
         .reply(200, {
@@ -112,7 +112,7 @@ describe('service', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
         items: [{
           conceptId: 'S100000-EDSC',
           type: 'OPeNDAP'
@@ -127,9 +127,9 @@ describe('service', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/services\.umm_json/, 'scroll=true')
+          .post(/services\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -145,98 +145,12 @@ describe('service', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+          cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
           items: [{
             conceptId: 'S100000-EDSC',
             type: 'OPeNDAP'
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/services\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/services\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await serviceDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'service')
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/services\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/services\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          serviceDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'service')
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -100,7 +100,7 @@ describe('subscription#fetch', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/subscriptions\.umm_json/)
         .reply(200, {
@@ -118,7 +118,7 @@ describe('subscription#fetch', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
         items: [{
           conceptId: 'SUB100000-EDSC',
           emailAddress: 'test@example.com'
@@ -133,9 +133,9 @@ describe('subscription#fetch', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/subscriptions\.umm_json/, 'scroll=true')
+          .post(/subscriptions\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -151,98 +151,12 @@ describe('subscription#fetch', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+          cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
           items: [{
             conceptId: 'SUB100000-EDSC',
             emailAddress: 'test@example.com'
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/subscriptions\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/subscriptions\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/subscriptions\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/subscriptions\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          subscriptionSourceFetch({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo)
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -180,7 +180,7 @@ describe('subscription#fetch', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'SUB100000-EDSC'
         }]
@@ -207,7 +207,7 @@ describe('subscription#fetch', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'SUB100000-EDSC'
         }]
@@ -267,7 +267,7 @@ describe('subscription#fetch', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           emailAddress: 'test@example.com'
         }]

--- a/src/datasources/__tests__/tool.test.js
+++ b/src/datasources/__tests__/tool.test.js
@@ -174,7 +174,7 @@ describe('tool', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'T100000-EDSC'
         }]
@@ -201,7 +201,7 @@ describe('tool', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'T100000-EDSC'
         }]
@@ -267,7 +267,7 @@ describe('tool', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           type: 'Downloadable Tool'
         }]

--- a/src/datasources/__tests__/tool.test.js
+++ b/src/datasources/__tests__/tool.test.js
@@ -94,7 +94,7 @@ describe('tool', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/tools\.umm_json/)
         .reply(200, {
@@ -112,7 +112,7 @@ describe('tool', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
         items: [{
           conceptId: 'T100000-EDSC',
           type: 'Downloadable Tool'
@@ -127,9 +127,9 @@ describe('tool', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/tools\.umm_json/, 'scroll=true')
+          .post(/tools\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -145,98 +145,12 @@ describe('tool', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+          cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
           items: [{
             conceptId: 'T100000-EDSC',
             type: 'Downloadable Tool'
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/tools\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/tools\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await toolDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'tool')
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/tools\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/tools\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          toolDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'tool')
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/datasources/__tests__/variable.test.js
+++ b/src/datasources/__tests__/variable.test.js
@@ -174,7 +174,7 @@ describe('variable', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'V100000-EDSC'
         }]
@@ -201,7 +201,7 @@ describe('variable', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           conceptId: 'V100000-EDSC'
         }]
@@ -267,7 +267,7 @@ describe('variable', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'e30=',
+        cursor: null,
         items: [{
           variableType: 'SCIENCE_VARIABLE'
         }]

--- a/src/datasources/__tests__/variable.test.js
+++ b/src/datasources/__tests__/variable.test.js
@@ -94,7 +94,7 @@ describe('variable', () => {
           'CMR-Hits': 84,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Scroll-Id': '-98726357'
+          'CMR-Search-After': '["xyz", 789, 999]'
         })
         .post(/variables\.umm_json/)
         .reply(200, {
@@ -112,7 +112,7 @@ describe('variable', () => {
 
       expect(response).toEqual({
         count: 84,
-        cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
         items: [{
           conceptId: 'V100000-EDSC',
           variableType: 'SCIENCE_VARIABLE'
@@ -127,9 +127,9 @@ describe('variable', () => {
             'CMR-Hits': 84,
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
+            'CMR-Search-After': '["xyz", 789, 999]'
           })
-          .post(/variables\.umm_json/, 'scroll=true')
+          .post(/variables\.umm_json/)
           .reply(200, {
             items: [{
               meta: {
@@ -145,98 +145,12 @@ describe('variable', () => {
 
         expect(response).toEqual({
           count: 84,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
+          cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
           items: [{
             conceptId: 'V100000-EDSC',
             variableType: 'SCIENCE_VARIABLE'
           }]
         })
-      })
-    })
-
-    describe('when a cursor returns no results', () => {
-      test('calls CMR to clear the scroll session', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/variables\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/variables\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(204)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(204)
-
-        const response = await variableDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'variable')
-
-        expect(response).toEqual({
-          count: 0,
-          cursor: 'eyJ1bW0iOiItOTg3MjYzNTcifQ==',
-          items: []
-        })
-      })
-
-      test('catches errors received from CMR', async () => {
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-29834750'
-          })
-          .post(/variables\.json/, 'scroll=true')
-          .reply(200, {
-            feed: {
-              entry: []
-            }
-          })
-
-        nock(/example/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 0,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678',
-            'CMR-Scroll-Id': '-98726357'
-          })
-          .post(/variables\.umm_json/, 'scroll=true')
-          .reply(200, {
-            items: []
-          })
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-29834750' })
-          .reply(500)
-
-        nock(/example/)
-          .post('/search/clear-scroll', { scroll_id: '-98726357' })
-          .reply(500)
-
-        await expect(
-          variableDatasource({}, { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, requestInfo, 'variable')
-        ).rejects.toThrow(Error)
       })
     })
   })

--- a/src/utils/cmrQuery.js
+++ b/src/utils/cmrQuery.js
@@ -38,7 +38,7 @@ export const cmrQuery = ({
     'Authorization',
     'Client-Id',
     'CMR-Request-Id',
-    'CMR-Scroll-Id'
+    'CMR-Search-After'
   ])
 
   const cmrParameters = prepKeysForCmr(snakeCaseKeys(params), nonIndexedKeys)


### PR DESCRIPTION
# Overview

### What is the feature?

Updates GraphQL to utilize Search After paging with CMR instead of Scroll Sessions which are being deprecated.

### What areas of the application does this impact?

End users will have no impact, the back-end HTTP requests now utilize a different header.

# Testing

1. Initiate a request providing parameters that bring results to a reasonable amount, including a page size that will minimize the number of pages. This request should also ask for the `cursor` to be returned
2. Run the request as many times as necessary, each time, updating the cursor parameter being sent with the one that comes back in the request.
3. When no results come back you should also notice the cursor comes back as `null`.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
