### PR TITLE
EDSC-3556: Removes encoding of parameters

### DIFF
--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -437,7 +437,7 @@ describe('collection', () => {
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .post(/collections\.json/, 'data_center%5B%5D=EDSC')
+        .post(/collections\.json/, 'data_center[]=EDSC')
         .reply(200, {
           feed: {
             entry: [{
@@ -454,7 +454,7 @@ describe('collection', () => {
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .post(/collections\.umm_json/, 'data_center%5B%5D=EDSC')
+        .post(/collections\.umm_json/, 'data_center[]=EDSC')
         .reply(200, {
           items: [{
             meta: {

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -690,7 +690,7 @@ describe('Collection', () => {
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719%2C41.746426050239336%2C-82.33992004394531%2C47.84755587105307&collection_concept_id=C100000-EDSC')
+        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100000-EDSC')
         .reply(200, {
           feed: {
             entry: [{
@@ -706,7 +706,7 @@ describe('Collection', () => {
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
-        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719%2C41.746426050239336%2C-82.33992004394531%2C47.84755587105307&collection_concept_id=C100001-EDSC')
+        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100001-EDSC')
         .reply(200, {
           feed: {
             entry: [{
@@ -907,7 +907,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/services\.json/, 'concept_id%5B%5D=S100000-EDSC&concept_id%5B%5D=S100001-EDSC&page_size=2')
+            .post(/services\.json/, 'concept_id[]=S100000-EDSC&concept_id[]=S100001-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'S100000-EDSC'
@@ -921,7 +921,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/services\.json/, 'concept_id%5B%5D=S100002-EDSC&concept_id%5B%5D=S100003-EDSC&page_size=2')
+            .post(/services\.json/, 'concept_id[]=S100002-EDSC&concept_id[]=S100003-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'S100002-EDSC'
@@ -1209,7 +1209,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/tools\.json/, 'concept_id%5B%5D=T100000-EDSC&concept_id%5B%5D=T100001-EDSC&page_size=2')
+            .post(/tools\.json/, 'concept_id[]=T100000-EDSC&concept_id[]=T100001-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'T100000-EDSC'
@@ -1223,7 +1223,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/tools\.json/, 'concept_id%5B%5D=T100002-EDSC&concept_id%5B%5D=T100003-EDSC&page_size=2')
+            .post(/tools\.json/, 'concept_id[]=T100002-EDSC&concept_id[]=T100003-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'T100002-EDSC'
@@ -1421,7 +1421,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/variables\.json/, 'concept_id%5B%5D=V100000-EDSC&concept_id%5B%5D=V100001-EDSC&page_size=2')
+            .post(/variables\.json/, 'concept_id[]=V100000-EDSC&concept_id[]=V100001-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'V100000-EDSC'
@@ -1435,7 +1435,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/variables\.json/, 'concept_id%5B%5D=V100002-EDSC&concept_id%5B%5D=V100003-EDSC&page_size=2')
+            .post(/variables\.json/, 'concept_id[]=V100002-EDSC&concept_id[]=V100003-EDSC&page_size=2')
             .reply(200, {
               items: [{
                 concept_id: 'V100002-EDSC'

--- a/src/utils/__tests__/prepKeysForCmr.test.js
+++ b/src/utils/__tests__/prepKeysForCmr.test.js
@@ -7,7 +7,7 @@ describe('prepKeysForCmr', () => {
     }
     const nonIndexedKeys = ['a']
 
-    expect(prepKeysForCmr(params, nonIndexedKeys)).toEqual('a%5B%5D=a&a%5B%5D=b')
+    expect(prepKeysForCmr(params, nonIndexedKeys)).toEqual('a[]=a&a[]=b')
   })
 
   test('does not remove the index of parameters', () => {
@@ -15,6 +15,6 @@ describe('prepKeysForCmr', () => {
       a: ['a', 'b']
     }
 
-    expect(prepKeysForCmr(params)).toEqual('a%5B0%5D=a&a%5B1%5D=b')
+    expect(prepKeysForCmr(params)).toEqual('a[0]=a&a[1]=b')
   })
 })

--- a/src/utils/prepKeysForCmr.js
+++ b/src/utils/prepKeysForCmr.js
@@ -16,7 +16,11 @@ export const prepKeysForCmr = (queryParams, nonIndexedKeys = []) => {
   })
 
   return [
-    stringify(indexedAttrs),
-    stringify(nonIndexedAttrs, { indices: false, arrayFormat: 'brackets' })
+    stringify(indexedAttrs, { encode: false }),
+    stringify(nonIndexedAttrs, {
+      encode: false,
+      indices: false,
+      arrayFormat: 'brackets'
+    })
   ].filter(Boolean).join('&')
 }


### PR DESCRIPTION
# Overview

### What is the feature?

When performing a collection search export in EDSC, selecting an organization facet with spaces results in 0 exported collections. EDSC is passing url encoded values to cmr-graphql, and cmr-graphql was encoding them a second time. 

### What is the Solution?

Remove the encoding of CMR parameters. Passing non-encoded values is acceptable by CMR, and if cmr-graphql is given encoded values, passing them through as received will be accepted by CMR

### What areas of the application does this impact?

Querying with encoded values

# Testing

Query:
`query Collections($params: CollectionsInput) {
  collections(params: $params) {
    count
    items {
      conceptId
    }
  }
}`
Variables (in prod, will not return results):
`{
  "params": {
    "dataCenterH": "Advanced+Spaceborne+Thermal+Emission+and+Reflection+Radiometer+%28ASTER%29"
  }
}`
Variables (locally, will return results):
`{
  "params": {
    "dataCenterH": "Advanced+Spaceborne+Thermal+Emission+and+Reflection+Radiometer+%28ASTER%29"
  }
}`
Variables (locally, un-encoded, will return results):
`{
  "params": {
    "dataCenterH": "Advanced Spaceborne Thermal Emission and Reflection Radiometer (ASTER)"
  }
}`

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
