### PR TITLE
EDSC-3587: Ensures a Client-Id is always sent for external request

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ provider:
     edlKeyId: ${self:custom.variables.edlKeyId}
     edlJwk: ${self:custom.variables.edlJwk}
     dmmtSslCert: ${self:custom.variables.dmmtSslCert}
+    stage: ${self:provider.stage}
 
     # Timeout for lambda
     lambdaTimeout: ${env:LAMBDA_TIMEOUT, '30'}

--- a/src/cmr/concepts/collectionDraft.js
+++ b/src/cmr/concepts/collectionDraft.js
@@ -31,6 +31,18 @@ export default class CollectionDraft extends Concept {
     ]
   }
 
+  /**
+   * Retrieve the request id header from the request
+   * @param {Object} headers The provided headers from the query
+   */
+  getRequestId() {
+    const {
+      'X-Request-Id': requestId
+    } = this.headers
+
+    return requestId
+  }
+
   async parse(requestInfo, params) {
     const { id } = params
 

--- a/src/cmr/concepts/collectionDraft.js
+++ b/src/cmr/concepts/collectionDraft.js
@@ -34,6 +34,7 @@ export default class CollectionDraft extends Concept {
   /**
    * Retrieve the request id header from the request
    * @param {Object} headers The provided headers from the query
+   * @return {String} Request ID defined in the headers
    */
   getRequestId() {
     const {

--- a/src/cmr/concepts/collectionDraftProposal.js
+++ b/src/cmr/concepts/collectionDraftProposal.js
@@ -31,6 +31,18 @@ export default class CollectionDraftProposal extends Concept {
     ]
   }
 
+  /**
+   * Retrieve the request id header from the request
+   * @param {Object} headers The provided headers from the query
+   */
+  getRequestId() {
+    const {
+      'X-Request-Id': requestId
+    } = this.headers
+
+    return requestId
+  }
+
   async parse(requestInfo, params) {
     const { id } = params
 

--- a/src/cmr/concepts/collectionDraftProposal.js
+++ b/src/cmr/concepts/collectionDraftProposal.js
@@ -34,6 +34,7 @@ export default class CollectionDraftProposal extends Concept {
   /**
    * Retrieve the request id header from the request
    * @param {Object} headers The provided headers from the query
+   * @return {String} Request ID defined in the headers
    */
   getRequestId() {
     const {

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -296,6 +296,18 @@ export default class Concept {
   }
 
   /**
+   * Retrieve the client id header from the request
+   * @param {Object} headers The provided headers from the query
+   */
+  getClientId() {
+    const {
+      'Client-Id': clientId
+    } = this.headers
+
+    return clientId
+  }
+
+  /**
    * Return the response from the query to CMR
    */
   async getResponse() {
@@ -380,7 +392,7 @@ export default class Concept {
     const filteredKeys = keys.filter((field) => CONCEPT_TYPES.indexOf(field) === -1)
 
     filteredKeys.forEach((key) => {
-      console.log(`Request ${this.getRequestId()} to [concept: ${this.getConceptType()}] requested [format: ${format}, key: ${key}]`)
+      console.log(`Request ${this.getRequestId()} from ${this.getClientId()} to [concept: ${this.getConceptType()}] requested [format: ${format}, key: ${key}]`)
     })
   }
 

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -286,6 +286,7 @@ export default class Concept {
   /**
    * Retrieve the request id header from the request
    * @param {Object} headers The provided headers from the query
+   * @return {String} Request ID defined in the headers
    */
   getRequestId() {
     const {
@@ -298,6 +299,7 @@ export default class Concept {
   /**
    * Retrieve the client id header from the request
    * @param {Object} headers The provided headers from the query
+   * @return {String} Client ID defined in the headers
    */
   getClientId() {
     const {

--- a/src/dataloaders/__tests__/getCollectionsById.test.js
+++ b/src/dataloaders/__tests__/getCollectionsById.test.js
@@ -61,7 +61,10 @@ describe('getCollectionsById', () => {
       })
 
     const context = {
-      headers: { 'CMR-Request-Id': '4a557d1a-d592-48fb-9833-685aecfb2501' }
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': '4a557d1a-d592-48fb-9833-685aecfb2501'
+      }
     }
 
     const parsedInfo = {

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -139,7 +139,16 @@ describe('collection', () => {
           }]
         })
 
-      const response = await collectionDatasource({ params: { cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({
+        params: {
+          cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0='
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -194,7 +203,12 @@ describe('collection', () => {
             }]
           })
 
-        const response = await collectionDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await collectionDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -228,7 +242,12 @@ describe('collection', () => {
           }
         })
 
-      const response = await collectionDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -267,7 +286,16 @@ describe('collection', () => {
           }
         })
 
-      const response = await collectionDatasource({ params: { conceptId: 'C100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({
+        params: {
+          conceptId: 'C100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -367,7 +395,16 @@ describe('collection', () => {
           }]
         })
 
-      const response = await collectionDatasource({ params: { conceptId: 'C100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({
+        params: {
+          conceptId: 'C100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -468,7 +505,16 @@ describe('collection', () => {
           }]
         })
 
-      const response = await collectionDatasource({ params: { dataCenters: ['EDSC'] } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({
+        params: {
+          dataCenters: ['EDSC']
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -545,7 +591,16 @@ describe('collection', () => {
           }]
         })
 
-      const response = await collectionDatasource({ params: { conceptId: 'C100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await collectionDatasource({
+        params: {
+          conceptId: 'C100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -573,7 +628,16 @@ describe('collection', () => {
       })
 
     await expect(
-      collectionDatasource({ params: { conceptId: 'C100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      collectionDatasource({
+        params: {
+          conceptId: 'C100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/collectionDraft.test.js
+++ b/src/datasources/__tests__/collectionDraft.test.js
@@ -55,7 +55,16 @@ describe('collectionDraft', () => {
         ShortName: 'Mock ShortName'
       })
 
-    const response = await collectionDraftDatasource({ params: { id: '123' } }, { headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+    const response = await collectionDraftDatasource({
+      params: {
+        id: '123'
+      }
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'X-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
 
     expect(response).toEqual([{
       abstract: 'Mock Abstract',
@@ -73,7 +82,16 @@ describe('collectionDraft', () => {
       })
 
     await expect(
-      collectionDraftDatasource({ params: { id: '123' } }, { headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      collectionDraftDatasource({
+        params: {
+          id: '123'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/collectionDraftProposal.test.js
+++ b/src/datasources/__tests__/collectionDraftProposal.test.js
@@ -56,7 +56,16 @@ describe('collectionDraftProposal', () => {
         ShortName: 'Mock ShortName'
       })
 
-    const response = await collectionDraftProposalDatasource({ params: { id: '123' } }, { headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+    const response = await collectionDraftProposalDatasource({
+      params: {
+        id: '123'
+      }
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'X-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
 
     expect(response).toEqual([{
       abstract: 'Mock Abstract',
@@ -74,7 +83,16 @@ describe('collectionDraftProposal', () => {
       })
 
     await expect(
-      collectionDraftProposalDatasource({ params: { id: '123' } }, { headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      collectionDraftProposalDatasource({
+        params: {
+          id: '123'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -131,7 +131,14 @@ describe('granule', () => {
           }]
         })
 
-      const response = await granuleDatasource({ cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0=' }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await granuleDatasource({
+        cursor: 'eyJqc29uIjoiLTI5ODM0NzUwIiwidW1tIjoiLTk4NzI2MzU3In0='
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -182,7 +189,12 @@ describe('granule', () => {
             }]
           })
 
-        const response = await granuleDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await granuleDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -214,7 +226,12 @@ describe('granule', () => {
           }
         })
 
-      const response = await granuleDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await granuleDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -243,7 +260,16 @@ describe('granule', () => {
           }
         })
 
-      const response = await granuleDatasource({ params: { concept_id: 'G100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await granuleDatasource({
+        params: {
+          concept_id: 'G100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -320,7 +346,10 @@ describe('granule', () => {
           collectionConceptId: 'C100000-EDSC',
           linkTypes: ['data', 's3']
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         requestInfo,
         'granule'
       )
@@ -421,7 +450,16 @@ describe('granule', () => {
           }]
         })
 
-      const response = await granuleDatasource({ params: { concept_id: 'G100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await granuleDatasource({
+        params: {
+          concept_id: 'G100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -489,7 +527,16 @@ describe('granule', () => {
           }]
         })
 
-      const response = await granuleDatasource({ params: { concept_id: 'G100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await granuleDatasource({
+        params: {
+          concept_id: 'G100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -511,7 +558,16 @@ describe('granule', () => {
       })
 
     await expect(
-      granuleDatasource({ params: { conceptId: 'G100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      granuleDatasource({
+        params: {
+          conceptId: 'G100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -347,8 +347,10 @@ describe('granule', () => {
           linkTypes: ['data', 's3']
         },
         {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
         },
         requestInfo,
         'granule'

--- a/src/datasources/__tests__/graphDb.test.js
+++ b/src/datasources/__tests__/graphDb.test.js
@@ -161,7 +161,13 @@ describe('graphDb', () => {
             limit: 1,
             relatedUrlType: ['VIEW RELATED INFORMATION']
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -187,7 +193,13 @@ describe('graphDb', () => {
             limit: 1,
             relatedUrlSubtype: ["USER'S GUIDE"]
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -214,7 +226,13 @@ describe('graphDb', () => {
             relatedUrlType: ['VIEW RELATED INFORMATION'],
             relatedUrlSubtype: ["USER'S GUIDE"]
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -301,7 +319,13 @@ describe('graphDb', () => {
           {
             limit: 1
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -392,7 +416,13 @@ describe('graphDb', () => {
           {
             limit: 1
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -495,7 +525,13 @@ describe('graphDb', () => {
           {
             limit: 1
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -605,7 +641,13 @@ describe('graphDb', () => {
             limit: 1,
             relatedUrlType: ['VIEW RELATED INFORMATION']
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -723,7 +765,13 @@ describe('graphDb', () => {
             limit: 1,
             relatedUrlType: ['VIEW RELATED INFORMATION']
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -840,7 +888,13 @@ describe('graphDb', () => {
             limit: 1,
             relatedUrlType: ['VIEW RELATED INFORMATION']
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -924,7 +978,13 @@ describe('graphDb', () => {
           {
             limit: 1
           },
-          { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+          {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            },
+            edlUsername: 'edlUsername'
+          },
           parsedInfo
         )
 
@@ -988,7 +1048,13 @@ describe('graphDb', () => {
         {
           limit: 1
         },
-        { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'edlUsername' },
+        {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          },
+          edlUsername: 'edlUsername'
+        },
         parsedInfo
       )
 
@@ -1001,10 +1067,12 @@ describe('graphDb', () => {
       nock(/example-graphdb/)
         .post(() => true, (body) => {
           const { gremlin: gremlinQuery } = body
+
           const correctGremlin = gremlinQuery.includes('within(\'groupid1\',\'groupid2\',\'registered\',\'guest\')')
           if (correctGremlin) {
             return true
           }
+
           return false
         })
         .reply(200, relatedCollectionsRelationshipTypeGraphdbResponseMocks)
@@ -1038,7 +1106,13 @@ describe('graphDb', () => {
         {
           limit: 1
         },
-        { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'someEdlUsername' },
+        {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          },
+          edlUsername: 'someEdlUsername'
+        },
         parsedInfo
       )
       expect(response).toEqual(relatedCollectionsRelationshipTypeResponseMocks)
@@ -1067,7 +1141,13 @@ describe('graphDb', () => {
         {
           limit: 1
         },
-        { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'someEdlUsername' },
+        {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          },
+          edlUsername: 'someEdlUsername'
+        },
         parsedInfo
       )
       expect(response).toEqual({ count: 0, items: [] })

--- a/src/datasources/__tests__/graphDbDuplicateCollections.test.js
+++ b/src/datasources/__tests__/graphDbDuplicateCollections.test.js
@@ -66,7 +66,13 @@ describe('graphDb', () => {
             doi: 'mock doi'
           }
         },
-        { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'someEdlUsername' }
+        {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          },
+          edlUsername: 'someEdlUsername'
+        }
       )
 
       expect(response).toEqual(duplicateCollectionsRelatedUrlTypeResponseMocks)
@@ -79,7 +85,13 @@ describe('graphDb', () => {
           shortName: 'mock shortname',
           doi: null
         },
-        { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'someEdlUsername' }
+        {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          },
+          edlUsername: 'someEdlUsername'
+        }
       )
 
       expect(response).toEqual({
@@ -135,7 +147,13 @@ describe('graphDb', () => {
           doi: 'mock doi'
         }
       },
-      { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }, edlUsername: 'someEdlUsername' }
+      {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
+        edlUsername: 'someEdlUsername'
+      }
     )
 
     expect(response).toEqual(duplicateCollectionsRelatedUrlTypeResponseMocks)

--- a/src/datasources/__tests__/grid.test.js
+++ b/src/datasources/__tests__/grid.test.js
@@ -107,7 +107,12 @@ describe('grid', () => {
             }
           }]
         })
-      const response = await gridDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await gridDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -140,7 +145,12 @@ describe('grid', () => {
             }]
           })
 
-        const response = await gridDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await gridDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -169,7 +179,12 @@ describe('grid', () => {
           }]
         })
 
-      const response = await gridDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await gridDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -196,7 +211,16 @@ describe('grid', () => {
           }]
         })
 
-      const response = await gridDatasource({ params: { concept_id: 'GRD100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await gridDatasource({
+        params: {
+          concept_id: 'GRD100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -256,7 +280,16 @@ describe('grid', () => {
           }]
         })
 
-      const response = await gridDatasource({ params: { concept_id: 'GRD1200445311-CMR_ONLY' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await gridDatasource({
+        params: {
+          concept_id: 'GRD1200445311-CMR_ONLY'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -278,7 +311,16 @@ describe('grid', () => {
       })
 
     await expect(
-      gridDatasource({ params: { conceptId: 'GRD100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      gridDatasource({
+        params: {
+          conceptId: 'GRD100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/service.test.js
+++ b/src/datasources/__tests__/service.test.js
@@ -108,7 +108,12 @@ describe('service', () => {
           }]
         })
 
-      const response = await serviceDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await serviceDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -141,7 +146,12 @@ describe('service', () => {
             }]
           })
 
-        const response = await serviceDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await serviceDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -170,7 +180,12 @@ describe('service', () => {
           }]
         })
 
-      const response = await serviceDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await serviceDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -197,7 +212,16 @@ describe('service', () => {
           }]
         })
 
-      const response = await serviceDatasource({ params: { concept_id: 'S100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await serviceDatasource({
+        params: {
+          concept_id: 'S100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -263,7 +287,16 @@ describe('service', () => {
           }]
         })
 
-      const response = await serviceDatasource({ params: { concept_id: 'S100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await serviceDatasource({
+        params: {
+          concept_id: 'S100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -285,7 +318,16 @@ describe('service', () => {
       })
 
     await expect(
-      serviceDatasource({ params: { conceptId: 'S100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      serviceDatasource({
+        params: {
+          conceptId: 'S100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -114,7 +114,12 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await subscriptionSourceFetch({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -147,7 +152,12 @@ describe('subscription#fetch', () => {
             }]
           })
 
-        const response = await subscriptionSourceFetch({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await subscriptionSourceFetch({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -176,7 +186,12 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await subscriptionSourceFetch({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -203,7 +218,16 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await subscriptionSourceFetch({
+        params: {
+          concept_id: 'SUB100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -263,7 +287,16 @@ describe('subscription#fetch', () => {
           }]
         })
 
-      const response = await subscriptionSourceFetch({ params: { concept_id: 'SUB100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await subscriptionSourceFetch({
+        params: {
+          concept_id: 'SUB100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -285,7 +318,16 @@ describe('subscription#fetch', () => {
       })
 
     await expect(
-      subscriptionSourceFetch({ params: { conceptId: 'SUB100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      subscriptionSourceFetch({
+        params: {
+          conceptId: 'SUB100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })
@@ -354,7 +396,12 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -384,7 +431,12 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -411,7 +463,12 @@ describe('subscription#ingest', () => {
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
         }
-      }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })
@@ -476,7 +533,12 @@ describe('subscription#delete', () => {
           conceptId: 'SUB100000-EDSC',
           nativeId: 'test-guid'
         }
-      }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         conceptId: 'SUB100000-EDSC',
@@ -500,7 +562,12 @@ describe('subscription#delete', () => {
           conceptId: 'C100000-EDSC',
           nativeId: 'test-guid'
         }
-      }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/tool.test.js
+++ b/src/datasources/__tests__/tool.test.js
@@ -108,7 +108,12 @@ describe('tool', () => {
           }]
         })
 
-      const response = await toolDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await toolDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -141,7 +146,12 @@ describe('tool', () => {
             }]
           })
 
-        const response = await toolDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await toolDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -170,7 +180,12 @@ describe('tool', () => {
           }]
         })
 
-      const response = await toolDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await toolDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -197,7 +212,16 @@ describe('tool', () => {
           }]
         })
 
-      const response = await toolDatasource({ params: { concept_id: 'T100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await toolDatasource({
+        params: {
+          concept_id: 'T100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -263,7 +287,16 @@ describe('tool', () => {
           }]
         })
 
-      const response = await toolDatasource({ params: { concept_id: 'T100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await toolDatasource({
+        params: {
+          concept_id: 'T100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -285,7 +318,16 @@ describe('tool', () => {
       })
 
     await expect(
-      toolDatasource({ params: { conceptId: 'T100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      toolDatasource({
+        params: {
+          conceptId: 'T100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/datasources/__tests__/variable.test.js
+++ b/src/datasources/__tests__/variable.test.js
@@ -108,7 +108,12 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await variableDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -141,7 +146,12 @@ describe('variable', () => {
             }]
           })
 
-        const response = await variableDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+        const response = await variableDatasource({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
 
         expect(response).toEqual({
           count: 84,
@@ -170,7 +180,12 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({}, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await variableDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -197,7 +212,16 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({ params: { concept_id: 'V100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await variableDatasource({
+        params: {
+          concept_id: 'V100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -263,7 +287,16 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({ params: { conceptId: 'V100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      const response = await variableDatasource({
+        params: {
+          conceptId: 'V100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
 
       expect(response).toEqual({
         count: 84,
@@ -285,7 +318,16 @@ describe('variable', () => {
       })
 
     await expect(
-      variableDatasource({ params: { conceptId: 'V100000-EDSC' } }, { headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' } }, requestInfo)
+      variableDatasource({
+        params: {
+          conceptId: 'V100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
     ).rejects.toThrow(Error)
   })
 })

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -79,8 +79,11 @@ const server = new ApolloServer({
       }
     }
 
-    // If the client has identified themselves using Client-Id supply it to CMR
-    if (clientId) requestHeaders['Client-Id'] = clientId
+    // Concatenate this applications client id with the user provided value, if one was provided
+    requestHeaders['Client-Id'] = [
+      clientId,
+      `eed-${process.env.stage}-graphql`
+    ].filter(Boolean).join('-')
 
     return {
       ...context,

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -28,6 +28,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/__tests__/collectionDraft.test.js
+++ b/src/resolvers/__tests__/collectionDraft.test.js
@@ -23,6 +23,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'X-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/__tests__/collectionDraftProposal.test.js
+++ b/src/resolvers/__tests__/collectionDraftProposal.test.js
@@ -24,6 +24,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'X-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),
@@ -62,6 +63,7 @@ describe('Collection', () => {
         test('returns results', async () => {
           nock(/example/)
             .defaultReplyHeaders({
+              'Client-Id': 'eed-test-graphql',
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
             .get(/collection_draft_proposals/)
@@ -92,6 +94,7 @@ describe('Collection', () => {
         test('returns no results', async () => {
           nock(/example/)
             .defaultReplyHeaders({
+              'Client-Id': 'eed-test-graphql',
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
             .get(/collection_draft_proposals/)

--- a/src/resolvers/__tests__/granule.test.js
+++ b/src/resolvers/__tests__/granule.test.js
@@ -25,6 +25,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     },
     collectionLoader: new DataLoader(getCollectionsById, { cacheKeyFn: (obj) => obj.conceptId })

--- a/src/resolvers/__tests__/grid.test.js
+++ b/src/resolvers/__tests__/grid.test.js
@@ -12,6 +12,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/__tests__/service.test.js
+++ b/src/resolvers/__tests__/service.test.js
@@ -21,6 +21,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/__tests__/subscription.test.js
+++ b/src/resolvers/__tests__/subscription.test.js
@@ -23,6 +23,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),
@@ -355,6 +356,7 @@ describe('Subscription', () => {
       nock(/example/, {
         reqheaders: {
           accept: 'application/json',
+          'client-id': 'eed-test-graphql',
           'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.1',
           'cmr-request-id': 'abcd-1234-efgh-5678'
         }
@@ -413,6 +415,7 @@ describe('Subscription', () => {
       nock(/example/, {
         reqheaders: {
           accept: 'application/json',
+          'client-id': 'eed-test-graphql',
           'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.1',
           'cmr-request-id': 'abcd-1234-efgh-5678'
         }

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -21,6 +21,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -21,6 +21,7 @@ const server = new ApolloServer({
   resolvers,
   context: () => ({
     headers: {
+      'Client-Id': 'eed-test-graphql',
       'CMR-Request-Id': 'abcd-1234-efgh-5678'
     }
   }),

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -22,7 +22,7 @@ export default {
 
   Collection: {
     granules: async (source, args, context, info) => {
-      const { dataSources, headers } = context
+      const { dataSources } = context
 
       // Pull out parent collection id to provide to the granules endpoint because cmr requires it
       const {
@@ -72,7 +72,7 @@ export default {
         ...args
       })
 
-      return dataSources.granuleSource(requestedParams, headers, parseResolveInfo(info))
+      return dataSources.granuleSource(requestedParams, context, parseResolveInfo(info))
     },
     relatedCollections: async (source, args, context, info) => {
       const { dataSources } = context

--- a/src/resolvers/collectionDraft.js
+++ b/src/resolvers/collectionDraft.js
@@ -2,8 +2,10 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 export default {
   Query: {
-    collectionDraft: async (source, args, { dataSources, headers }, info) => {
-      const result = await dataSources.collectionDraftSource(args, headers, parseResolveInfo(info))
+    collectionDraft: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const result = await dataSources.collectionDraftSource(args, context, parseResolveInfo(info))
 
       const [firstResult] = result
 

--- a/src/resolvers/collectionDraftProposal.js
+++ b/src/resolvers/collectionDraftProposal.js
@@ -2,10 +2,12 @@ import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 export default {
   Query: {
-    collectionDraftProposal: async (source, args, { dataSources, headers }, info) => {
+    collectionDraftProposal: async (source, args, context, info) => {
+      const { dataSources } = context
+
       const result = await dataSources.collectionDraftProposalSource(
         args,
-        headers,
+        context,
         parseResolveInfo(info)
       )
 

--- a/src/utils/__tests__/cmrDelete.test.js
+++ b/src/utils/__tests__/cmrDelete.test.js
@@ -22,6 +22,7 @@ describe('cmrDelete', () => {
     nock(/example/, {
       reqheaders: {
         Accept: 'application/json',
+        'Client-Id': 'eed-test-graphql',
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       }
     })
@@ -37,7 +38,10 @@ describe('cmrDelete', () => {
         conceptId: 'SUB100000-EDSC',
         nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
       },
-      { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+      {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      },
       'subscriptions'
     )
 
@@ -53,7 +57,7 @@ describe('cmrDelete', () => {
     })
 
     expect(consoleMock).toBeCalledWith(
-      `Request abcd-1234-efgh-5678 to delete [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
+      `Request abcd-1234-efgh-5678 from eed-test-graphql to delete [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
     )
   })
 
@@ -64,8 +68,9 @@ describe('cmrDelete', () => {
       nock(/example/, {
         reqheaders: {
           Accept: 'application/json',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
         .delete(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
@@ -81,8 +86,9 @@ describe('cmrDelete', () => {
           nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
         },
         {
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
         'subscriptions'
       )
@@ -99,7 +105,7 @@ describe('cmrDelete', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to delete [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to delete [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -108,6 +114,7 @@ describe('cmrDelete', () => {
     test('throws an exception', async () => {
       nock(/example/, {
         reqheaders: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -122,7 +129,10 @@ describe('cmrDelete', () => {
           conceptId: 'SUB100000-EDSC',
           nativeId: '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         'subscriptions'
       )
 

--- a/src/utils/__tests__/cmrGraphDb.test.js
+++ b/src/utils/__tests__/cmrGraphDb.test.js
@@ -37,7 +37,10 @@ describe('cmrGraphDb', () => {
 
       const response = await cmrGraphDb({
         conceptId: 'C100000-EDSC',
-        headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         query: 'mock query'
       })
 
@@ -52,7 +55,7 @@ describe('cmrGraphDb', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to [graphdb conceptId: C100000-EDSC] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to [graphdb conceptId: C100000-EDSC] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -73,7 +76,10 @@ describe('cmrGraphDb', () => {
 
       const response = await cmrGraphDb({
         conceptId: 'C100000-EDSC',
-        headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         query: 'mock query'
       })
 
@@ -88,7 +94,7 @@ describe('cmrGraphDb', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to [graphdb conceptId: C100000-EDSC] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to [graphdb conceptId: C100000-EDSC] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -97,6 +103,7 @@ describe('cmrGraphDb', () => {
     test('throws an exception', async () => {
       nock(/example-graphdb/, {
         reqheaders: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -108,6 +115,7 @@ describe('cmrGraphDb', () => {
       const response = cmrGraphDb({
         conceptId: 'C100000-EDSC',
         headers: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
         query: 'mock query'

--- a/src/utils/__tests__/cmrIngest.test.js
+++ b/src/utils/__tests__/cmrIngest.test.js
@@ -24,8 +24,9 @@ describe('cmrIngest', () => {
     nock(/example/, {
       reqheaders: {
         Accept: 'application/json',
-        'Content-Type': 'application/vnd.nasa.cmr.umm+json; version=1.0',
-        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678',
+        'Content-Type': 'application/vnd.nasa.cmr.umm+json; version=1.0'
       }
     })
       .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
@@ -39,6 +40,7 @@ describe('cmrIngest', () => {
       { collectionConceptId: 'C100000-EDSC' },
       {
         'CMR-Request-Id': 'abcd-1234-efgh-5678',
+        'Client-Id': 'eed-test-graphql',
         'Content-Type': 'application/vnd.nasa.cmr.umm+json; version=1.0'
       },
       'subscriptions'
@@ -56,7 +58,7 @@ describe('cmrIngest', () => {
     })
 
     expect(consoleMock).toBeCalledWith(
-      `Request abcd-1234-efgh-5678 to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
+      `Request abcd-1234-efgh-5678 from eed-test-graphql to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
     )
   })
 
@@ -67,6 +69,7 @@ describe('cmrIngest', () => {
       nock(/example/, {
         reqheaders: {
           Accept: 'application/json',
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -82,50 +85,9 @@ describe('cmrIngest', () => {
           collectionConceptId: 'C100000-EDSC',
           nativeId: 'provided-native-id'
         },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
-        'subscriptions'
-      )
-
-      const { data, headers } = response
-
-      const {
-        'request-duration': requestDuration
-      } = downcaseKeys(headers)
-
-      expect(data).toEqual({
-        'concept-id': 'SUB100000-EDSC',
-        'revision-id': 1
-      })
-
-      expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
-      )
-    })
-  })
-
-  describe('when provided a token via the Authorization header', () => {
-    test('queries cmr using the Authorization header', async () => {
-      const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
-
-      nock(/example/, {
-        reqheaders: {
-          Accept: 'application/json',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
-        }
-      })
-        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
-        .reply(201, {
-          'concept-id': 'SUB100000-EDSC',
-          'revision-id': 1
-        })
-
-      const response = await cmrIngest(
-        'subscriptions',
-        { collectionConceptId: 'C100000-EDSC' },
         {
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
         'subscriptions'
       )
@@ -142,7 +104,53 @@ describe('cmrIngest', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
+      )
+    })
+  })
+
+  describe('when provided a token via the Authorization header', () => {
+    test('queries cmr using the Authorization header', async () => {
+      const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
+
+      nock(/example/, {
+        reqheaders: {
+          Accept: 'application/json',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678',
+          Authorization: 'test-token'
+        }
+      })
+        .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+        .reply(201, {
+          'concept-id': 'SUB100000-EDSC',
+          'revision-id': 1
+        })
+
+      const response = await cmrIngest(
+        'subscriptions',
+        { collectionConceptId: 'C100000-EDSC' },
+        {
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
+        'subscriptions'
+      )
+
+      const { data, headers } = response
+
+      const {
+        'request-duration': requestDuration
+      } = downcaseKeys(headers)
+
+      expect(data).toEqual({
+        'concept-id': 'SUB100000-EDSC',
+        'revision-id': 1
+      })
+
+      expect(consoleMock).toBeCalledWith(
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to ingest [concept: subscriptions] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -151,6 +159,7 @@ describe('cmrIngest', () => {
     test('throws an exception', async () => {
       nock(/example/, {
         reqheaders: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -162,7 +171,10 @@ describe('cmrIngest', () => {
       const response = cmrIngest(
         'subscriptions',
         { collectionConceptId: 'C100000-EDSC' },
-        { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         'subscriptions'
       )
 

--- a/src/utils/__tests__/cmrQuery.test.js
+++ b/src/utils/__tests__/cmrQuery.test.js
@@ -21,6 +21,7 @@ describe('cmrQuery', () => {
 
     nock(/example/, {
       reqheaders: {
+        'Client-Id': 'eed-test-graphql',
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       }
     })
@@ -39,7 +40,10 @@ describe('cmrQuery', () => {
     const response = await cmrQuery({
       conceptType: 'collections',
       params: {},
-      headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' }
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
     })
 
     const { data, headers } = response
@@ -58,7 +62,7 @@ describe('cmrQuery', () => {
     })
 
     expect(consoleMock).toBeCalledWith(
-      `Request abcd-1234-efgh-5678 to [concept: collections, format: json] completed external request in [reported: ${cmrTook} ms, observed: ${requestDuration} ms]`
+      `Request abcd-1234-efgh-5678 from eed-test-graphql to [concept: collections, format: json] completed external request in [reported: ${cmrTook} ms, observed: ${requestDuration} ms]`
     )
   })
 
@@ -66,6 +70,7 @@ describe('cmrQuery', () => {
     test('queries cmr', async () => {
       nock(/example/, {
         reqheaders: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -81,7 +86,10 @@ describe('cmrQuery', () => {
       const response = await cmrQuery({
         conceptType: 'collections',
         params: {},
-        headers: { 'CMR-Request-Id': 'abcd-1234-efgh-5678' },
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        },
         options: { format: 'umm_json' }
       })
 
@@ -100,8 +108,9 @@ describe('cmrQuery', () => {
     test('queries cmr using the Authorization header', async () => {
       nock(/example/, {
         reqheaders: {
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
         .post(/collections\.json/)
@@ -117,8 +126,9 @@ describe('cmrQuery', () => {
         conceptType: 'collections',
         params: {},
         headers: {
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
 
@@ -137,6 +147,7 @@ describe('cmrQuery', () => {
     test('throws an exception', async () => {
       nock(/example/, {
         reqheaders: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
@@ -149,6 +160,7 @@ describe('cmrQuery', () => {
         conceptType: 'collections',
         params: {},
         headers: {
+          'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         }
       })

--- a/src/utils/__tests__/draftMmtQuery.test.js
+++ b/src/utils/__tests__/draftMmtQuery.test.js
@@ -39,7 +39,10 @@ describe('draftMmtQuery', () => {
         params: {
           id: 123
         },
-        headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' }
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
+        }
       })
 
       const { data, headers } = response
@@ -53,7 +56,7 @@ describe('draftMmtQuery', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to [concept: collectionDraftProposal] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to [concept: collectionDraftProposal] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -81,7 +84,10 @@ describe('draftMmtQuery', () => {
         params: {
           id: 123
         },
-        headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' }
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
+        }
       })
 
       const { data, headers } = response
@@ -95,7 +101,7 @@ describe('draftMmtQuery', () => {
       })
 
       expect(consoleMock).toBeCalledWith(
-        `Request abcd-1234-efgh-5678 to [concept: collectionDraftProposal] completed external request in [observed: ${requestDuration} ms]`
+        `Request abcd-1234-efgh-5678 from eed-test-graphql to [concept: collectionDraftProposal] completed external request in [observed: ${requestDuration} ms]`
       )
     })
   })
@@ -104,8 +110,9 @@ describe('draftMmtQuery', () => {
     test('queries draft mmt using the Authorization header', async () => {
       nock(/example/, {
         reqheaders: {
-          'X-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
         .get(/collection_draft_proposals/)
@@ -117,8 +124,9 @@ describe('draftMmtQuery', () => {
         conceptType: 'collectionDraftProposal',
         params: {},
         headers: {
-          'X-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
 
@@ -141,6 +149,7 @@ describe('draftMmtQuery', () => {
         conceptType: 'collectionDraftProposal',
         params: {},
         headers: {
+          'Client-Id': 'eed-test-graphql',
           'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })

--- a/src/utils/__tests__/mmtQuery.test.js
+++ b/src/utils/__tests__/mmtQuery.test.js
@@ -30,7 +30,10 @@ describe('mmtQuery', () => {
       params: {
         id: 123
       },
-      headers: { 'X-Request-Id': 'abcd-1234-efgh-5678' }
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'X-Request-Id': 'abcd-1234-efgh-5678'
+      }
     })
 
     const { data, headers } = response
@@ -44,7 +47,7 @@ describe('mmtQuery', () => {
     })
 
     expect(consoleMock).toBeCalledWith(
-      `Request abcd-1234-efgh-5678 to [concept: collectionDraft] completed external request in [observed: ${requestDuration} ms]`
+      `Request abcd-1234-efgh-5678 from eed-test-graphql to [concept: collectionDraft] completed external request in [observed: ${requestDuration} ms]`
     )
   })
 
@@ -52,8 +55,9 @@ describe('mmtQuery', () => {
     test('queries mmt using the Authorization header', async () => {
       nock(/example/, {
         reqheaders: {
-          'X-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
         .get(/collection_drafts/)
@@ -65,8 +69,9 @@ describe('mmtQuery', () => {
         conceptType: 'collectionDraft',
         params: {},
         headers: {
-          'X-Request-Id': 'abcd-1234-efgh-5678',
-          Authorization: 'test-token'
+          Authorization: 'test-token',
+          'Client-Id': 'eed-test-graphql',
+          'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
 
@@ -89,6 +94,7 @@ describe('mmtQuery', () => {
         conceptType: 'collectionDraft',
         params: {},
         headers: {
+          'Client-Id': 'eed-test-graphql',
           'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })

--- a/src/utils/__tests__/parseCmrError.test.js
+++ b/src/utils/__tests__/parseCmrError.test.js
@@ -22,6 +22,7 @@ describe('parseCmrError', () => {
           errors: ['HTTP Error']
         },
         headers: {
+          'client-id': 'eed-test-graphql',
           'cmr-request-id': 'abcd-1234-efgh-5678'
         }
       }
@@ -30,7 +31,7 @@ describe('parseCmrError', () => {
     expect(() => parseCmrError(error)).toThrow()
 
     expect(consoleMock).toBeCalledTimes(1)
-    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 experienced an error: HTTP Error')
+    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 from eed-test-graphql experienced an error: HTTP Error')
   })
 
   test('logs the error and re throws the exception by default', () => {
@@ -42,6 +43,7 @@ describe('parseCmrError', () => {
           errors: ['Token does not exist']
         },
         headers: {
+          'client-id': 'eed-test-graphql',
           'cmr-request-id': 'abcd-1234-efgh-5678'
         },
         status: 401
@@ -51,7 +53,7 @@ describe('parseCmrError', () => {
     expect(() => parseCmrError(error)).toThrow()
 
     expect(consoleMock).toBeCalledTimes(1)
-    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 experienced an error: Token does not exist')
+    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 from eed-test-graphql experienced an error: Token does not exist')
   })
 
   test('logs the error and returns the response when reThrow is false', () => {
@@ -63,6 +65,7 @@ describe('parseCmrError', () => {
           errors: ['HTTP Error']
         },
         headers: {
+          'client-id': 'eed-test-graphql',
           'cmr-request-id': 'abcd-1234-efgh-5678'
         }
       }
@@ -71,7 +74,7 @@ describe('parseCmrError', () => {
     const response = parseCmrError(error, false)
 
     expect(consoleMock).toBeCalledTimes(1)
-    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 experienced an error: HTTP Error')
+    expect(consoleMock).toBeCalledWith('Request abcd-1234-efgh-5678 from eed-test-graphql experienced an error: HTTP Error')
 
     expect(response).toEqual({
       errors: ['HTTP Error']

--- a/src/utils/cmrDelete.js
+++ b/src/utils/cmrDelete.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import pascalCaseKeys from 'pascalcase-keys'
 
+import { downcaseKeys } from './downcaseKeys'
 import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
@@ -39,7 +40,10 @@ export const cmrDelete = async (conceptType, data, headers, ingestPath) => {
 
   const cmrParameters = pascalCaseKeys(data)
 
-  const { 'CMR-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
     data: cmrParameters,
@@ -72,7 +76,7 @@ export const cmrDelete = async (conceptType, data, headers, ingestPath) => {
 
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to delete [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to delete [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/cmrGraphDb.js
+++ b/src/utils/cmrGraphDb.js
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import { downcaseKeys } from './downcaseKeys'
 import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
@@ -27,7 +28,10 @@ export const cmrGraphDb = ({
     'CMR-Request-Id'
   ])
 
-  const { 'CMR-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
     data: query,
@@ -60,7 +64,7 @@ export const cmrGraphDb = ({
 
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to [graphdb conceptId: ${conceptId}] completed external request in [observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to [graphdb conceptId: ${conceptId}] completed external request in [observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -4,6 +4,7 @@ import pascalCaseKeys from 'pascalcase-keys'
 
 import { v4 as uuidv4 } from 'uuid'
 
+import { downcaseKeys } from './downcaseKeys'
 import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
@@ -40,7 +41,10 @@ export const cmrIngest = async (conceptType, data, headers, ingestPath) => {
 
   const cmrParameters = pascalCaseKeys(data)
 
-  const { 'CMR-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
     data: cmrParameters,
@@ -73,7 +77,7 @@ export const cmrIngest = async (conceptType, data, headers, ingestPath) => {
 
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to ingest [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to ingest [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/cmrQuery.js
+++ b/src/utils/cmrQuery.js
@@ -43,7 +43,10 @@ export const cmrQuery = ({
 
   const cmrParameters = prepKeysForCmr(snakeCaseKeys(params), nonIndexedKeys)
 
-  const { 'CMR-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
     data: cmrParameters,
@@ -79,7 +82,7 @@ export const cmrQuery = ({
     const { 'cmr-took': cmrTook } = downcaseKeys(headers)
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to [concept: ${conceptType}, format: ${format}] completed external request in [reported: ${cmrTook} ms, observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to [concept: ${conceptType}, format: ${format}] completed external request in [reported: ${cmrTook} ms, observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/draftMmtQuery.js
+++ b/src/utils/draftMmtQuery.js
@@ -3,6 +3,7 @@ import axios from 'axios'
 
 import snakeCaseKeys from 'snakecase-keys'
 
+import { downcaseKeys } from './downcaseKeys'
 import { pickIgnoringCase } from './pickIgnoringCase'
 import { prepKeysForCmr } from './prepKeysForCmr'
 
@@ -38,7 +39,10 @@ export const draftMmtQuery = ({
 
   const { id } = params
 
-  const { 'X-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'x-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   let httpsAgent
 
@@ -86,7 +90,7 @@ export const draftMmtQuery = ({
 
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/mmtQuery.js
+++ b/src/utils/mmtQuery.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 import snakeCaseKeys from 'snakecase-keys'
 
+import { downcaseKeys } from './downcaseKeys'
 import { pickIgnoringCase } from './pickIgnoringCase'
 import { prepKeysForCmr } from './prepKeysForCmr'
 
@@ -37,7 +38,10 @@ export const mmtQuery = ({
 
   const { id } = params
 
-  const { 'X-Request-Id': requestId } = permittedHeaders
+  const {
+    'client-id': clientId,
+    'x-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
     data: cmrParameters,
@@ -70,7 +74,7 @@ export const mmtQuery = ({
 
     response.headers['request-duration'] = milliseconds
 
-    console.log(`Request ${requestId} to [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
+    console.log(`Request ${requestId} from ${clientId} to [concept: ${conceptType}] completed external request in [observed: ${milliseconds} ms]`)
 
     return response
   })

--- a/src/utils/parseCmrError.js
+++ b/src/utils/parseCmrError.js
@@ -19,10 +19,13 @@ export const parseCmrError = (error, reThrow = true) => {
 
   const { errors } = data
 
-  const { 'cmr-request-id': requestId } = downcaseKeys(headers)
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(headers)
 
   errors.forEach((error) => {
-    console.log(`Request ${requestId} experienced an error: ${error}`)
+    console.log(`Request ${requestId} from ${clientId} experienced an error: ${error}`)
   })
 
   if (reThrow) {


### PR DESCRIPTION
In an effort to create more visibility into the usage of graphql and its place as a proxy between many applications and CMR, this PR increases the usage, including an always sent default, `Client-Id` header.