### PR TITLE
EDSC 3648: As a cmr-graphql, I want to retrieve associationDetails for all supported types

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -23,19 +23,17 @@ export default class Collection extends Concept {
    */
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
-
     // Associations are used by services, tools, and variables, it required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     // const { associations } = item
     const { association_details: associationDetails } = item // This is the association_details
-    console.log('The association details on the collections', associationDetails)
+    // console.log('The association details on the collections', associationDetails)
 
     // const { 'concept-id': associatedConceptIds = [] } = associationDetails
 
     // console.log('The concept-id for the particular association', associatedConceptIds)
     // concept_id is to get the concept_id for the particular association
     if (associationDetails) {
-      console.log('Enter teh logic guard')
       this.setItemValue(id, 'association_details', associationDetails)
     }
 
@@ -53,7 +51,9 @@ export default class Collection extends Concept {
     super.setEssentialUmmValues(id, item)
 
     const { meta } = item
-    const { 'association-details': associationDetails = {} } = meta
+    const { 'association-details': associationDetails } = meta
+
+    // const { 'concept-id': associatedConceptIds = [] } = associationDetails
 
     // Associations are used by services and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
@@ -75,7 +75,6 @@ export default class Collection extends Concept {
   getPermittedJsonSearchParams() {
     return [
       ...super.getPermittedJsonSearchParams(),
-      'association_details',
       'bounding_box',
       'circle',
       'cloud_hosted',
@@ -125,7 +124,6 @@ export default class Collection extends Concept {
   getPermittedUmmSearchParams() {
     return [
       ...super.getPermittedUmmSearchParams(),
-      'association_details',
       'bounding_box',
       'circle',
       'cloud_hosted',
@@ -214,7 +212,7 @@ export default class Collection extends Concept {
     } = this.requestInfo
 
     // While technically the facets are available with a single collection because we use the
-    // search endpoint, we dont support it in the response so we'll only return facets when
+    // search endpoint, we don't support it in the response so we'll only return facets when
     // when the user has requested the list response
     if (isList && metaKeys.includes('collectionFacets')) {
       // Included the facets in the metakeys returned

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -17,7 +17,7 @@ export default class Collection extends Concept {
   }
 
   /**
-   * Set a value in the result set that a query has not requested but is neccessary for other functionality
+   * Set a value in the result set that a query has not requested but is necessary for other functionality
    * @param {String} id Concept ID to set a value for within the result set
    * @param {Object} item The item returned from the CMR json endpoint
    */
@@ -27,6 +27,17 @@ export default class Collection extends Concept {
     // Associations are used by services and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     const { associations } = item
+    const { 'association_details': associationDetails } = item // This is the association_details
+    console.log('The association details on the collections', associationDetails)
+    console.log('The regular associations on the collections', associations)
+
+    const { 'concept-id': associatedConceptId } = associationDetails
+
+    console.log('The concept-id for the particular association', associatedConceptId)
+    // concept_id is to get the concept_id for the particular association
+    if (associationDetails) {
+      this.setItemValue(id, 'association_details', associationDetails)
+    }
 
     if (associations) {
       this.setItemValue(id, 'associations', associations)
@@ -34,7 +45,7 @@ export default class Collection extends Concept {
   }
 
   /**
-   * Set a value in the result set that a query has not requested but is neccessary for other functionality
+   * Set a value in the result set that a query has not requested but is necessary for other functionality
    * @param {String} id Concept ID to set a value for within the result set
    * @param {Object} item The item returned from the CMR json endpoint
    */
@@ -204,7 +215,7 @@ export default class Collection extends Concept {
     // search endpoint, we dont support it in the response so we'll only return facets when
     // when the user has requested the list response
     if (isList && metaKeys.includes('collectionFacets')) {
-      // Incuded the facets in the metakeys returned
+      // Included the facets in the metakeys returned
       return {
         facets: this.getFacets(),
         ...super.getFormattedResponse()

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -24,7 +24,7 @@ export default class Collection extends Concept {
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
 
-    // Associations are used by services, tools, and variables, it required to correctly
+    // Associations are used by services, tools, and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     const { association_details: associationDetails } = item
 

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -24,24 +24,24 @@ export default class Collection extends Concept {
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
 
-    // Associations are used by services and variables, its required to correctly
+    // Associations are used by services, tools, and variables, it required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
-    const { associations } = item
-    const { 'association_details': associationDetails } = item // This is the association_details
+    // const { associations } = item
+    const { association_details: associationDetails } = item // This is the association_details
     console.log('The association details on the collections', associationDetails)
-    console.log('The regular associations on the collections', associations)
 
-    const { 'concept-id': associatedConceptId } = associationDetails
+    // const { 'concept-id': associatedConceptIds = [] } = associationDetails
 
-    console.log('The concept-id for the particular association', associatedConceptId)
+    // console.log('The concept-id for the particular association', associatedConceptIds)
     // concept_id is to get the concept_id for the particular association
     if (associationDetails) {
+      console.log('Enter teh logic guard')
       this.setItemValue(id, 'association_details', associationDetails)
     }
 
-    if (associations) {
-      this.setItemValue(id, 'associations', associations)
-    }
+    // if (associations) {
+    //   this.setItemValue(id, 'associations', associationDetails)
+    // }
   }
 
   /**
@@ -53,12 +53,12 @@ export default class Collection extends Concept {
     super.setEssentialUmmValues(id, item)
 
     const { meta } = item
-    const { associations } = meta
+    const { 'association-details': associationDetails = {} } = meta
 
     // Associations are used by services and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
-    if (associations) {
-      this.setItemValue(id, 'associations', associations)
+    if (associationDetails) {
+      this.setItemValue(id, 'association_details', associationDetails)
     }
   }
 
@@ -75,6 +75,7 @@ export default class Collection extends Concept {
   getPermittedJsonSearchParams() {
     return [
       ...super.getPermittedJsonSearchParams(),
+      'association_details',
       'bounding_box',
       'circle',
       'cloud_hosted',
@@ -124,6 +125,7 @@ export default class Collection extends Concept {
   getPermittedUmmSearchParams() {
     return [
       ...super.getPermittedUmmSearchParams(),
+      'association_details',
       'bounding_box',
       'circle',
       'cloud_hosted',

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -24,12 +24,14 @@ export default class Collection extends Concept {
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
 
-    // Associations are used by services, tools, and variables, its required to correctly
-    // retrieve those objects and shouldn't need to be provided by the client
     const { association_details: associationDetails } = item
 
+    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
+
+    // Associations are used by services, tools, and variables, its required to correctly
+    // retrieve those objects and shouldn't need to be provided by the client
     if (associationDetails) {
-      this.setItemValue(id, 'association_details', associationDetails)
+      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
     }
   }
 
@@ -44,10 +46,12 @@ export default class Collection extends Concept {
     const { meta } = item
     const { 'association-details': associationDetails } = meta
 
-    // Associations are used by services and variables, its required to correctly
+    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
+
+    // Associations are used by services, tools, and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     if (associationDetails) {
-      this.setItemValue(id, 'association_details', associationDetails)
+      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
     }
   }
 

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -28,7 +28,7 @@ export default class Collection extends Concept {
 
     const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
 
-    // Associations are used by services, tools, and variables, its required to correctly
+    // Associations are used by services, tools, and variables, it's required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     if (associationDetails) {
       this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
@@ -48,7 +48,7 @@ export default class Collection extends Concept {
 
     const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
 
-    // Associations are used by services, tools, and variables, its required to correctly
+    // Associations are used by services, tools, and variables, it's required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
     if (associationDetails) {
       this.setItemValue(id, 'associationDetails', formattedAssociationDetails)

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -23,23 +23,14 @@ export default class Collection extends Concept {
    */
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
+
     // Associations are used by services, tools, and variables, it required to correctly
     // retrieve those objects and shouldn't need to be provided by the client
-    // const { associations } = item
-    const { association_details: associationDetails } = item // This is the association_details
-    // console.log('The association details on the collections', associationDetails)
+    const { association_details: associationDetails } = item
 
-    // const { 'concept-id': associatedConceptIds = [] } = associationDetails
-
-    // console.log('The concept-id for the particular association', associatedConceptIds)
-    // concept_id is to get the concept_id for the particular association
     if (associationDetails) {
       this.setItemValue(id, 'association_details', associationDetails)
     }
-
-    // if (associations) {
-    //   this.setItemValue(id, 'associations', associationDetails)
-    // }
   }
 
   /**
@@ -52,8 +43,6 @@ export default class Collection extends Concept {
 
     const { meta } = item
     const { 'association-details': associationDetails } = meta
-
-    // const { 'concept-id': associatedConceptIds = [] } = associationDetails
 
     // Associations are used by services and variables, its required to correctly
     // retrieve those objects and shouldn't need to be provided by the client

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -140,7 +140,7 @@ export default class Concept {
   setEssentialUmmValues() {}
 
   /**
-   * Get the total number of records avaiable for a given search across all endpoints. Also
+   * Get the total number of records available for a given search across all endpoints. Also
    * ensure that the value is the same if a given search spans multiple endpoints
    */
   getItemCount() {

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -607,9 +607,9 @@ describe('collection', () => {
         cursor: null,
         items: [{
           abstract: 'Lorem ipsum dolor sit amet, consectetur adipiscing',
-          association_details: {
+          associationDetails: {
             services: [
-              { 'concept-id': 'S100000-EDSC' }
+              { conceptId: 'S100000-EDSC' }
             ]
           },
           spatialExtent: {}

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -607,8 +607,6 @@ describe('collection', () => {
         cursor: null,
         items: [{
           abstract: 'Lorem ipsum dolor sit amet, consectetur adipiscing',
-          // TODO: Why is this returning blank? this needs to be "_" because we make it that way in the resolver
-          // So that we can simplify the reponse consistently between the json and umm formats
           association_details: {
             services: [
               { 'concept-id': 'S100000-EDSC' }

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -578,9 +578,9 @@ describe('collection', () => {
           items: [{
             meta: {
               'concept-id': 'C100000-EDSC',
-              associations: {
+              'association-details': {
                 services: [
-                  'S100000-EDSC'
+                  { 'concept-id': 'S100000-EDSC' }
                 ]
               }
             },
@@ -607,9 +607,11 @@ describe('collection', () => {
         cursor: null,
         items: [{
           abstract: 'Lorem ipsum dolor sit amet, consectetur adipiscing',
-          associations: {
+          // TODO: Why is this returning blank? this needs to be "_" because we make it that way in the resolver
+          // So that we can simplify the reponse consistently between the json and umm formats
+          association_details: {
             services: [
-              'S100000-EDSC'
+              { 'concept-id': 'S100000-EDSC' }
             ]
           },
           spatialExtent: {}

--- a/src/datasources/service.js
+++ b/src/datasources/service.js
@@ -14,8 +14,6 @@ export default async (params, context, parsedInfo) => {
   // Query CMR
   service.fetch(params)
 
-  // console.log('Response from CMR for search', service.fetch(params))
-
   // Parse the response from CMR
   await service.parse(requestInfo)
 

--- a/src/datasources/service.js
+++ b/src/datasources/service.js
@@ -14,6 +14,8 @@ export default async (params, context, parsedInfo) => {
   // Query CMR
   service.fetch(params)
 
+  console.log('Response from CMR for search', service.fetch(params))
+
   // Parse the response from CMR
   await service.parse(requestInfo)
 

--- a/src/datasources/service.js
+++ b/src/datasources/service.js
@@ -14,7 +14,7 @@ export default async (params, context, parsedInfo) => {
   // Query CMR
   service.fetch(params)
 
-  console.log('Response from CMR for search', service.fetch(params))
+  // console.log('Response from CMR for search', service.fetch(params))
 
   // Parse the response from CMR
   await service.parse(requestInfo)

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -891,13 +891,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    services: ['S100000-EDSC', 'S100001-EDSC']
+                  association_details: {
+                    services: [{ concept_id: 'S100000-EDSC' }, { concept_id: 'S100001-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    services: ['S100002-EDSC', 'S100003-EDSC']
+                  association_details: {
+                    services: [{ concept_id: 'S100002-EDSC' }, { concept_id: 'S100003-EDSC' }]
                   }
                 }]
               }
@@ -1121,7 +1121,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not tool assocations', () => {
+      describe('association are present in the metadata but not tool associations', () => {
         test('doesn\'t query for or return tools', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
@@ -1193,13 +1193,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    tools: ['T100000-EDSC', 'T100001-EDSC']
+                  association_details: {
+                    tools: [{ concept_id: 'T100000-EDSC' }, { concept_id: 'T100001-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    tools: ['T100002-EDSC', 'T100003-EDSC']
+                  association_details: {
+                    tools: [{ concept_id: 'T100002-EDSC' }, { concept_id: 'T100003-EDSC' }]
                   }
                 }]
               }
@@ -1333,7 +1333,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not variable assocations', () => {
+      describe('association are present in the metadata but not variable associations', () => {
         test('doesn\'t query for or return variables', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
@@ -1405,13 +1405,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    variables: ['V100000-EDSC', 'V100001-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }, { concept_id: 'V100001-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    variables: ['V100002-EDSC', 'V100003-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100002-EDSC' }, { concept_id: 'V100003-EDSC' }]
                   }
                 }]
               }

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -843,7 +843,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not service associations', () => {
+      describe('associations are present in the metadata but not service associations', () => {
         test('doesn\'t query for or return services', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
@@ -1145,7 +1145,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not tool associations', () => {
+      describe('associations are present in the metadata but not tool associations', () => {
         test('doesn\'t query for or return tools', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
@@ -1357,7 +1357,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not variable associations', () => {
+      describe('associations are present in the metadata but not variable associations', () => {
         test('doesn\'t query for or return variables', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -843,7 +843,7 @@ describe('Collection', () => {
         })
       })
 
-      describe('association are present in the metadata but not service assocations', () => {
+      describe('association are present in the metadata but not service associations', () => {
         test('doesn\'t query for or return services', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
@@ -855,13 +855,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    variables: ['V100000-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    variables: ['V100000-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
                   }
                 }]
               }
@@ -1157,13 +1157,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    variables: ['V100000-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    variables: ['V100000-EDSC']
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
                   }
                 }]
               }
@@ -1369,13 +1369,13 @@ describe('Collection', () => {
               feed: {
                 entry: [{
                   id: 'C100000-EDSC',
-                  associations: {
-                    services: ['S100000-EDSC']
+                  association_details: {
+                    services: [{ concept_id: 'S100000-EDSC' }]
                   }
                 }, {
                   id: 'C100001-EDSC',
-                  associations: {
-                    services: ['S100000-EDSC']
+                  association_details: {
+                    services: [{ concept_id: 'S100000-EDSC' }]
                   }
                 }]
               }

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -258,13 +258,13 @@ describe('Collection', () => {
             count
             facets
             items {
-              associationDetails
               abstract
               accessConstraints
               additionalAttributes
               ancillaryKeywords
               archiveAndDistributionInformation
               archiveCenter
+              associationDetails
               associatedDois
               boxes
               browseFlag

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -76,6 +76,14 @@ describe('Collection', () => {
           feed: {
             entry: [{
               archive_center: 'CONDIMENTUM/TELLUS/PHARETRA',
+              association_details: {
+                variables: [
+                  {
+                    data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                    'concept-id': 'V100000-EDSC'
+                  }
+                ]
+              },
               boxes: [],
               browse_flag: true,
               cloud_hosted: false,
@@ -144,7 +152,15 @@ describe('Collection', () => {
           items: [{
             meta: {
               'concept-id': 'C100000-EDSC',
-              'native-id': 'test-guid'
+              'native-id': 'test-guid',
+              'association-details': {
+                variables: [
+                  {
+                    data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                    'concept-id': 'V100000-EDSC'
+                  }
+                ]
+              }
             },
             umm: {
               Abstract: 'Cras mattis consectetur purus sit amet fermentum.',
@@ -242,6 +258,7 @@ describe('Collection', () => {
             count
             facets
             items {
+              associationDetails
               abstract
               accessConstraints
               additionalAttributes
@@ -348,6 +365,13 @@ describe('Collection', () => {
             type: 'group'
           },
           items: [{
+            associationDetails: {
+              variables: [
+                {
+                  data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                  conceptId: 'V100000-EDSC'
+                }]
+            },
             abstract: 'Cras mattis consectetur purus sit amet fermentum.',
             accessConstraints: [],
             additionalAttributes: [],

--- a/src/resolvers/__tests__/service.test.js
+++ b/src/resolvers/__tests__/service.test.js
@@ -63,7 +63,15 @@ describe('Service', () => {
           items: [{
             meta: {
               'concept-id': 'S100000-EDSC',
-              'native-id': 'test-guid'
+              'native-id': 'test-guid',
+              'association-details': {
+                collections: [
+                  {
+                    data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                    'concept-id': 'C100000-EDSC'
+                  }
+                ]
+              }
             },
             umm: {
               Description: 'Parturient Dolor Cras Aenean Dapibus',
@@ -88,6 +96,7 @@ describe('Service', () => {
           services {
             count
             items {
+              associationDetails
               conceptId
               description
               longName
@@ -109,6 +118,13 @@ describe('Service', () => {
         services: {
           count: 1,
           items: [{
+            associationDetails: {
+              collections: [
+                {
+                  data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                  conceptId: 'C100000-EDSC'
+                }]
+            },
             conceptId: 'S100000-EDSC',
             description: 'Parturient Dolor Cras Aenean Dapibus',
             longName: 'Parturient Egestas Lorem',

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -63,7 +63,15 @@ describe('Tool', () => {
           items: [{
             meta: {
               'concept-id': 'T100000-EDSC',
-              'native-id': 'test-guid'
+              'native-id': 'test-guid',
+              'association-details': {
+                collections: [
+                  {
+                    data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                    'concept-id': 'C100000-EDSC'
+                  }
+                ]
+              }
             },
             umm: {
               AccessConstraints: 'NONE',
@@ -101,6 +109,7 @@ describe('Tool', () => {
           tools {
             count
             items {
+              associationDetails
               accessConstraints
               ancillaryKeywords
               conceptId
@@ -141,6 +150,13 @@ describe('Tool', () => {
           items: [{
             accessConstraints: 'NONE',
             ancillaryKeywords: [],
+            associationDetails: {
+              collections: [
+                {
+                  data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                  conceptId: 'C100000-EDSC'
+                }]
+            },
             conceptId: 'T100000-EDSC',
             contactGroups: [],
             contactPersons: [],

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -63,7 +63,15 @@ describe('Variable', () => {
           items: [{
             meta: {
               'concept-id': 'V100000-EDSC',
-              'native-id': 'test-guid'
+              'native-id': 'test-guid',
+              'association-details': {
+                collections: [
+                  {
+                    data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                    'concept-id': 'C100000-EDSC'
+                  }
+                ]
+              }
             },
             umm: {
               DataType: 'Dolor Nullam Venenatis',
@@ -87,6 +95,7 @@ describe('Variable', () => {
           variables {
             count
             items {
+              associationDetails
               conceptId
               dataType
               definition
@@ -111,6 +120,13 @@ describe('Variable', () => {
         variables: {
           count: 1,
           items: [{
+            associationDetails: {
+              collections: [
+                {
+                  data: '{"XYZ": "XYZ", "allow-regridding": true}',
+                  conceptId: 'C100000-EDSC'
+                }]
+            },
             conceptId: 'V100000-EDSC',
             dataType: 'Dolor Nullam Venenatis',
             definition: 'Cras mattis consectetur purus sit amet fermentum.',

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -85,12 +85,6 @@ export default {
       return dataSources.graphDbDuplicateCollectionsSource(source, context)
     },
     services: async (source, args, context, info) => {
-      // const {
-      //   associations = {}
-      // } = source
-
-      // console.warn('The source for this particular collections', source)
-
       const {
         association_details: associationDetails = {}
       } = source
@@ -100,33 +94,13 @@ export default {
       const { dataSources } = context
 
       const { services = [] } = associationDetails
-      // console.log('This is services from the association details', services2)
-      // Since they are embeded you need to collect al of them
 
       const serviceConceptIds = []
-      // const serviceAssociationData = []
 
-      // For each concept_id in each of the services add it to the array
-      // services2.forEach('concept_id'){
-      //   serviceConceptIds.push()
-      // }
-
-      // const keyToINput = services2[0]
-      // TODO: Put default values for these desttructure
       services.forEach((service) => {
         const { concept_id: serviceConceptId } = service
-        // const { data: associationData } = service
         serviceConceptIds.push(serviceConceptId)
-        // serviceAssociationData.push(associationData)
       })
-
-      console.log('the list of serviceConceptIds', serviceConceptIds)
-
-      // const { 'concept_id': serviceConceptIds} = services2
-
-      // console.log('This is the service concept-ids from services2', serviceConceptIds)
-
-      // const { services = [] } = associations
 
       if (!services.length) {
         return {
@@ -134,7 +108,6 @@ export default {
           items: null
         }
       }
-      // TODO: Do we need to pass the payload here?
       return dataSources.serviceSource({
         conceptId: serviceConceptIds,
         ...handlePagingParams(args, services.length)
@@ -154,10 +127,6 @@ export default {
       }, context, parseResolveInfo(info))
     },
     tools: async (source, args, context, info) => {
-      // const {
-      //   associations = {}
-      // } = source
-
       const {
         association_details: associationDetails = {}
       } = source
@@ -186,9 +155,6 @@ export default {
       }, context, parseResolveInfo(info))
     },
     variables: async (source, args, context, info) => {
-      // const {
-      //   associations = {}
-      // } = source
       const {
         association_details: associationDetails = {}
       } = source

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -86,14 +86,14 @@ export default {
     },
     services: async (source, args, context, info) => {
       const {
-        association_details: associationDetails = {}
+        associationDetails = {}
       } = source
 
       const { dataSources } = context
 
       const { services = [] } = associationDetails
 
-      const serviceConceptIds = services.map((service) => service.concept_id)
+      const serviceConceptIds = services.map(({ conceptId }) => conceptId)
 
       if (!services.length) {
         return {
@@ -122,14 +122,14 @@ export default {
     },
     tools: async (source, args, context, info) => {
       const {
-        association_details: associationDetails = {}
+        associationDetails = {}
       } = source
 
       const { dataSources } = context
 
       const { tools = [] } = associationDetails
 
-      const toolConceptIds = tools.map((tool) => tool.concept_id)
+      const toolConceptIds = tools.map(({ conceptId }) => conceptId)
 
       if (!tools.length) {
         return {
@@ -145,14 +145,14 @@ export default {
     },
     variables: async (source, args, context, info) => {
       const {
-        association_details: associationDetails = {}
+        associationDetails = {}
       } = source
 
       const { dataSources } = context
 
       const { variables = [] } = associationDetails
 
-      const variableConceptIds = variables.map((variable) => variable.concept_id)
+      const variableConceptIds = variables.map(({ conceptId }) => conceptId)
 
       if (!variables.length) {
         return {

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -104,6 +104,7 @@ export default {
       // Since they are embeded you need to collect al of them
 
       const serviceConceptIds = []
+      // const serviceAssociationData = []
 
       // For each concept_id in each of the services add it to the array
       // services2.forEach('concept_id'){
@@ -111,10 +112,12 @@ export default {
       // }
 
       // const keyToINput = services2[0]
-
+      // TODO: Put default values for these desttructure
       services.forEach((service) => {
         const { concept_id: serviceConceptId } = service
+        // const { data: associationData } = service
         serviceConceptIds.push(serviceConceptId)
+        // serviceAssociationData.push(associationData)
       })
 
       console.log('the list of serviceConceptIds', serviceConceptIds)
@@ -131,7 +134,7 @@ export default {
           items: null
         }
       }
-
+      // TODO: Do we need to pass the payload here?
       return dataSources.serviceSource({
         conceptId: serviceConceptIds,
         ...handlePagingParams(args, services.length)

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -89,7 +89,7 @@ export default {
       //   associations = {}
       // } = source
 
-      console.warn('The source for this particular collections', source)
+      // console.warn('The source for this particular collections', source)
 
       const {
         association_details: associationDetails = {}

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -85,37 +85,36 @@ export default {
       return dataSources.graphDbDuplicateCollectionsSource(source, context)
     },
     services: async (source, args, context, info) => {
-      const {
-        associations = {}
-      } = source
+      // const {
+      //   associations = {}
+      // } = source
 
       console.warn('The source for this particular collections', source)
 
       const {
-        association_details = {}
+        association_details: associationDetails = {}
       } = source
 
-      console.log("The association details", association_details)
+      console.log('The association details', associationDetails)
 
       const { dataSources } = context
 
-      const { services: services2 = [] } = association_details
-      console.log('This is services from the association details', services2)
+      const { services = [] } = associationDetails
+      // console.log('This is services from the association details', services2)
       // Since they are embeded you need to collect al of them
 
-      let serviceConceptIds = []
+      const serviceConceptIds = []
 
       // For each concept_id in each of the services add it to the array
       // services2.forEach('concept_id'){
       //   serviceConceptIds.push()
       // }
-      const conceptIdKey = 'concept_id'
 
       // const keyToINput = services2[0]
 
-      services2.forEach((service) => {
-        const { concept_id: conIds } = service
-        serviceConceptIds.push(conIds)
+      services.forEach((service) => {
+        const { concept_id: serviceConceptId } = service
+        serviceConceptIds.push(serviceConceptId)
       })
 
       console.log('the list of serviceConceptIds', serviceConceptIds)
@@ -124,7 +123,7 @@ export default {
 
       // console.log('This is the service concept-ids from services2', serviceConceptIds)
 
-      const { services = [] } = associations
+      // const { services = [] } = associations
 
       if (!services.length) {
         return {
@@ -152,13 +151,24 @@ export default {
       }, context, parseResolveInfo(info))
     },
     tools: async (source, args, context, info) => {
+      // const {
+      //   associations = {}
+      // } = source
+
       const {
-        associations = {}
+        association_details: associationDetails = {}
       } = source
+
+      const toolConceptIds = []
 
       const { dataSources } = context
 
-      const { tools = [] } = associations
+      const { tools = [] } = associationDetails
+
+      tools.forEach((tool) => {
+        const { concept_id: toolConceptId } = tool
+        toolConceptIds.push(toolConceptId)
+      })
 
       if (!tools.length) {
         return {
@@ -168,7 +178,7 @@ export default {
       }
 
       return dataSources.toolSource({
-        conceptId: tools,
+        conceptId: toolConceptIds,
         ...handlePagingParams(args, tools.length)
       }, context, parseResolveInfo(info))
     },

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -89,8 +89,6 @@ export default {
         association_details: associationDetails = {}
       } = source
 
-      console.log('The association details', associationDetails)
-
       const { dataSources } = context
 
       const { services = [] } = associationDetails

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -93,12 +93,7 @@ export default {
 
       const { services = [] } = associationDetails
 
-      const serviceConceptIds = []
-
-      services.forEach((service) => {
-        const { concept_id: serviceConceptId } = service
-        serviceConceptIds.push(serviceConceptId)
-      })
+      const serviceConceptIds = services.map((service) => service.concept_id)
 
       if (!services.length) {
         return {
@@ -106,6 +101,7 @@ export default {
           items: null
         }
       }
+
       return dataSources.serviceSource({
         conceptId: serviceConceptIds,
         ...handlePagingParams(args, services.length)
@@ -129,16 +125,11 @@ export default {
         association_details: associationDetails = {}
       } = source
 
-      const toolConceptIds = []
-
       const { dataSources } = context
 
       const { tools = [] } = associationDetails
 
-      tools.forEach((tool) => {
-        const { concept_id: toolConceptId } = tool
-        toolConceptIds.push(toolConceptId)
-      })
+      const toolConceptIds = tools.map((tool) => tool.concept_id)
 
       if (!tools.length) {
         return {
@@ -157,16 +148,11 @@ export default {
         association_details: associationDetails = {}
       } = source
 
-      const variableConceptIds = []
-
       const { dataSources } = context
 
       const { variables = [] } = associationDetails
 
-      variables.forEach((variable) => {
-        const { concept_id: variableConceptId } = variable
-        variableConceptIds.push(variableConceptId)
-      })
+      const variableConceptIds = variables.map((variable) => variable.concept_id)
 
       if (!variables.length) {
         return {

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -89,7 +89,40 @@ export default {
         associations = {}
       } = source
 
+      console.warn('The source for this particular collections', source)
+
+      const {
+        association_details = {}
+      } = source
+
+      console.log("The association details", association_details)
+
       const { dataSources } = context
+
+      const { services: services2 = [] } = association_details
+      console.log('This is services from the association details', services2)
+      // Since they are embeded you need to collect al of them
+
+      let serviceConceptIds = []
+
+      // For each concept_id in each of the services add it to the array
+      // services2.forEach('concept_id'){
+      //   serviceConceptIds.push()
+      // }
+      const conceptIdKey = 'concept_id'
+
+      // const keyToINput = services2[0]
+
+      services2.forEach((service) => {
+        const { concept_id: conIds } = service
+        serviceConceptIds.push(conIds)
+      })
+
+      console.log('the list of serviceConceptIds', serviceConceptIds)
+
+      // const { 'concept_id': serviceConceptIds} = services2
+
+      // console.log('This is the service concept-ids from services2', serviceConceptIds)
 
       const { services = [] } = associations
 
@@ -101,7 +134,7 @@ export default {
       }
 
       return dataSources.serviceSource({
-        conceptId: services,
+        conceptId: serviceConceptIds,
         ...handlePagingParams(args, services.length)
       }, context, parseResolveInfo(info))
     },

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -183,13 +183,23 @@ export default {
       }, context, parseResolveInfo(info))
     },
     variables: async (source, args, context, info) => {
+      // const {
+      //   associations = {}
+      // } = source
       const {
-        associations = {}
+        association_details: associationDetails = {}
       } = source
+
+      const variableConceptIds = []
 
       const { dataSources } = context
 
-      const { variables = [] } = associations
+      const { variables = [] } = associationDetails
+
+      variables.forEach((variable) => {
+        const { concept_id: variableConceptId } = variable
+        variableConceptIds.push(variableConceptId)
+      })
 
       if (!variables.length) {
         return {
@@ -199,7 +209,7 @@ export default {
       }
 
       return dataSources.variableSource({
-        conceptId: variables,
+        conceptId: variableConceptIds,
         ...handlePagingParams(args, variables.length)
       }, context, parseResolveInfo(info))
     }

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -5,7 +5,7 @@ type Collection {
   accessConstraints: JSON
   "The data’s distinctive attributes of the collection (i.e. attributes used to describe the unique characteristics of the collection which extend beyond those defined)."
   additionalAttributes: JSON
-  "The list of concepts and any data on the relationship on between this collection and other permitted concepts"
+  "The list of concepts and any data on the relationship between this collection and other permitted concepts"
   associationDetails: JSON
   "This element stores DOIs that are associated with the collection such as from campaigns and other related sources."
   associatedDois: JSON

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -143,6 +143,8 @@ type Collection {
   versionId: String @deprecated(reason: "Use `version`")
   "The Version of the collection."
   version: String
+  "The data on the association between this collection"
+  associationDetails: JSON
 
   relatedCollections (
     "Related Collections query parameters"

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -5,6 +5,8 @@ type Collection {
   accessConstraints: JSON
   "The data’s distinctive attributes of the collection (i.e. attributes used to describe the unique characteristics of the collection which extend beyond those defined)."
   additionalAttributes: JSON
+  "The data on the association between this collection"
+  associationDetails: JSON
   "This element stores DOIs that are associated with the collection such as from campaigns and other related sources."
   associatedDois: JSON
   "Find collections matching 'archive_center' param value."
@@ -143,8 +145,6 @@ type Collection {
   versionId: String @deprecated(reason: "Use `version`")
   "The Version of the collection."
   version: String
-  "The data on the association between this collection"
-  associationDetails: JSON
 
   relatedCollections (
     "Related Collections query parameters"
@@ -417,9 +417,9 @@ input CollectionsInput {
   options: JSON
   "Which page to request from the current collection results."
   pageSize: Int
-  "Platform assocaited with the collection."
+  "Platform associated with the collection."
   platform: String
-  "Platform assocaited with the collection, in facet form."
+  "Platform associated with the collection, in facet form."
   platformH: [String]
   "Search using a point involves using a pair of values representing the point coordinates as parameters. The first value is the longitude and second value is the latitude."
   point: [String]
@@ -528,9 +528,9 @@ type Query {
     options: JSON @deprecated(reason: "Use `params.options`")
     "Which page to request from the current collection results."
     pageSize: Int @deprecated(reason: "Use `params.pageSize`")
-    "Platform assocaited with the collection."
+    "Platform associated with the collection."
     platform: String @deprecated(reason: "Use `params.platform`")
-    "Platform assocaited with the collection, in facet form."
+    "Platform associated with the collection, in facet form."
     platformH: [String] @deprecated(reason: "Use `params.platformH`")
     "Search using a point involves using a pair of values representing the point coordinates as parameters. The first value is the longitude and second value is the latitude."
     point: [String] @deprecated(reason: "Use `params.point`")

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -5,7 +5,7 @@ type Collection {
   accessConstraints: JSON
   "The data’s distinctive attributes of the collection (i.e. attributes used to describe the unique characteristics of the collection which extend beyond those defined)."
   additionalAttributes: JSON
-  "The data on the association between this collection"
+  "The list of concepts and any data on the relationship on between this collection and other permitted concepts"
   associationDetails: JSON
   "This element stores DOIs that are associated with the collection such as from campaigns and other related sources."
   associatedDois: JSON

--- a/src/types/grid.graphql
+++ b/src/types/grid.graphql
@@ -47,7 +47,7 @@ input GridsInput {
   conceptId: [String]
   "Cursor that points to the a specific position in a list of requested records."
   cursor: String
-  "The number of variables requested by the user."
+  "The number of grids requested by the user."
   limit: Int
 }
 

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -1,7 +1,7 @@
 type Service {
   "Words or phrases to further describe the service."
   ancillaryKeywords: [String]
-  "The data on the association between this collection"
+  "The list of concepts and any data on the relationship on between this service and other permitted concepts"
   associationDetails: JSON
   "The unique concept id assigned to the service."
   conceptId: String!

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -1,6 +1,8 @@
 type Service {
   "Words or phrases to further describe the service."
   ancillaryKeywords: [String]
+  "The data on the association between this collection"
+  associationDetails: JSON
   "The unique concept id assigned to the service."
   conceptId: String!
   "This is the contact groups of the service."

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -1,7 +1,7 @@
 type Service {
   "Words or phrases to further describe the service."
   ancillaryKeywords: [String]
-  "The list of concepts and any data on the relationship on between this service and other permitted concepts"
+  "The list of concepts and any data on the relationship between this service and other permitted concepts"
   associationDetails: JSON
   "The unique concept id assigned to the service."
   conceptId: String!

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -3,6 +3,8 @@ type Tool {
   accessConstraints: String
   "Words or phrases to further describe the downloadable tool or web user interface."
   ancillaryKeywords: JSON
+  "The data on the association between this collection"
+  associationDetails: JSON
   "The unique concept id assigned to the tool."
   conceptId: String!
   "Group(s) to contact at an organization to get information about the web user interface or downloadable tool, including how the group may be contacted."
@@ -53,6 +55,7 @@ type Tool {
   version: String
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
+  
 
   collections (
     "Collections query parameters"

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -55,7 +55,6 @@ type Tool {
   version: String
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
-  
 
   collections (
     "Collections query parameters"
@@ -83,7 +82,7 @@ input ToolsInput {
   conceptId: [String]
   "Cursor that points to the a specific position in a list of requested records."
   cursor: String
-  "The number of servies requested by the user."
+  "The number of tools requested by the user."
   limit: Int
   "Zero based offset of individual results."
   offset: Int

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -3,7 +3,7 @@ type Tool {
   accessConstraints: String
   "Words or phrases to further describe the downloadable tool or web user interface."
   ancillaryKeywords: JSON
-  "The data on the association between this collection"
+  "The list of concepts and any data on the relationship on between this tool and other permitted concepts"
   associationDetails: JSON
   "The unique concept id assigned to the tool."
   conceptId: String!

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -3,7 +3,7 @@ type Tool {
   accessConstraints: String
   "Words or phrases to further describe the downloadable tool or web user interface."
   ancillaryKeywords: JSON
-  "The list of concepts and any data on the relationship on between this tool and other permitted concepts"
+  "The list of concepts and any data on the relationship between this tool and other permitted concepts"
   associationDetails: JSON
   "The unique concept id assigned to the tool."
   conceptId: String!

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -1,6 +1,8 @@
 type Variable {
   "The alias for the name of a variable."
   alias: String @deprecated(reason: "Removed as of 1.7")
+  "The data on the association between this collection"
+  associationDetails: JSON
   "The characteristics of a variable."
   characteristics: JSON @deprecated(reason: "Removed as of 1.7")
   "The unique concept id assigned to the variable."

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -1,7 +1,7 @@
 type Variable {
   "The alias for the name of a variable."
   alias: String @deprecated(reason: "Removed as of 1.7")
-  "The list of concepts and any data on the relationship on between this variable and other permitted concepts"
+  "The list of concepts and any data on the relationship between this variable and other permitted concepts"
   associationDetails: JSON
   "The characteristics of a variable."
   characteristics: JSON @deprecated(reason: "Removed as of 1.7")

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -1,7 +1,7 @@
 type Variable {
   "The alias for the name of a variable."
   alias: String @deprecated(reason: "Removed as of 1.7")
-  "The data on the association between this collection"
+  "The list of concepts and any data on the relationship on between this variable and other permitted concepts"
   associationDetails: JSON
   "The characteristics of a variable."
   characteristics: JSON @deprecated(reason: "Removed as of 1.7")

--- a/src/utils/umm/collectionKeyMap.json
+++ b/src/utils/umm/collectionKeyMap.json
@@ -15,10 +15,10 @@
   "ummKeyMappings": {
     "abstract": "umm.Abstract",
     "accessConstraints": "umm.AccessConstraints",
-    "associationDetails": "meta.association-details",
     "additionalAttributes": "umm.AdditionalAttributes",
     "ancillaryKeywords": "umm.AncillaryKeywords",
     "archiveAndDistributionInformation": "umm.ArchiveAndDistributionInformation",
+    "associationDetails": "meta.association-details",
     "associatedDois": "umm.AssociatedDOIs",
     "collectionCitations": "umm.CollectionCitations",
     "collectionProgress": "umm.CollectionProgress",

--- a/src/utils/umm/collectionKeyMap.json
+++ b/src/utils/umm/collectionKeyMap.json
@@ -15,6 +15,7 @@
   "ummKeyMappings": {
     "abstract": "umm.Abstract",
     "accessConstraints": "umm.AccessConstraints",
+    "associationDetails": "meta.association-details",
     "additionalAttributes": "umm.AdditionalAttributes",
     "ancillaryKeywords": "umm.AncillaryKeywords",
     "archiveAndDistributionInformation": "umm.ArchiveAndDistributionInformation",

--- a/src/utils/umm/serviceKeyMap.json
+++ b/src/utils/umm/serviceKeyMap.json
@@ -6,6 +6,7 @@
   ],
   "ummKeyMappings": {
     "ancillaryKeywords": "umm.AncillaryKeywords",
+    "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -7,6 +7,7 @@
   "ummKeyMappings": {
     "accessConstraints": "umm.AccessConstraints",
     "ancillaryKeywords": "umm.AncillaryKeywords",
+    "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",

--- a/src/utils/umm/variableKeyMap.json
+++ b/src/utils/umm/variableKeyMap.json
@@ -5,6 +5,7 @@
     "name"
   ],
   "ummKeyMappings": {
+    "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
     "dataType": "umm.DataType",
     "definition": "umm.Definition",


### PR DESCRIPTION
# Overview

### What is the feature?

Adding association_details field for variables, services, tools, and collections

### What is the Solution?

Replaced data retrieved from the associations field to use the association_details field instead, and added association_details as a field for variables, services, tools, and collections types

### What areas of the application does this impact?

Querying for services, variables, tools, and collections are expanded to include the new field. Previous queries that utilized the associations field to retrieve associated concepts i.e. { collections { items { variables {} }} are now using association_details instead. Tests were altered as well of course

# Testing

### Reproduction steps

Test that we can get back: tools, services, variables from the collection and the collections query for associated concepts

Test that we can get back: collections from tool, tools, service, services, variable, and variables for associated collections

Test that we can get back association_details from: collections, collection, services, service, tools, tool, variable, and variables as a top level field

Test in the event of a concept which does NOT have any associations we return an empty list of the association_details

- **Environment for testing:**

Query against SIT so set your `cmrRootUrl` env var to` https://cmr.sit.earthdata.nasa.gov` as use the accompanying token
that you will need form `sit.urs.earthdata.nasa.gov/`

- **Collection to test with:**

I was using the following concepts to perform queries to make sure that they were able to retrieve each other as associated concepts from this change:
C1200457868-CMR_ONLY
V1200457881-CMR_ONLY - associated variable
TL1200457877-CMR_ONLY - associated tool
S1200457852-CMR_ONLY first associated service
second associated service: S1200457874-CMR_ONLY

### Attachments

No attachments were necessary for this PR there will be more attachments on the Test session which will include all of the graphql queries

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
