### PR TITLE
EDSC-3658: add associations to grid and refactor associations into base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ We use [GraphQL interfaces](https://graphql.org/learn/schema/#interfaces) in ord
 
 #### Local graph database:
 
-Normally running graphQl with `serverless offline` will utilize the `(cmr.earthdata.nasa.gov/graphdb)` endpoint, to query against related collections and duplicate collections in the graph database. To send queries to a locally running graph database, we can use a docker gremlin-server that exposes an HTTP endpoint. This is launched by running
+Normally running GraphQl with `serverless offline` will utilize the `(cmr.earthdata.nasa.gov/graphdb)` endpoint, to query against related collections and duplicate collections in the graph database. To send queries to a locally running graph database, we can use a docker gremlin-server that exposes an HTTP endpoint. This is launched by running
 
 `docker run -it -p 8182:8182 tinkerpop/gremlin-server conf gremlin-server-rest-modern.yaml`
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ CMR-GraphQL uses a few environment variables for configuring runtime options:
 |MMT_ROOT_URL||URL to ping when retrieving metadata from MMT e.g. https://mmt.earthdata.nasa.gov|
 |DRAFT_MMT_ROOT_URL||URL to ping when retrieving draft metadata from Draft MMT e.g. https://draftmmt.earthdata.nasa.gov|
 |LAMBDA_TIMEOUT|30|Number of seconds to set the Lambda timeout to.|
+|EDL_KEY_ID, EDL_JWK, EDL_CLIENT_ID|For facilitating EDL connection -- obtain these from a dev|
 
 ### Serverless Framework
 
@@ -683,10 +684,10 @@ We use [GraphQL interfaces](https://graphql.org/learn/schema/#interfaces) in ord
 
 #### Local graph database:
 
-Normally running graphQl with `serverless offline` will utilize the `(cmr.earthdata.nasa.gov/graphdb)` endpoint, to query against related collections and duplicate collections in the graph database. To send queries to a locally running graph database
+Normally running graphQl with `serverless offline` will utilize the `(cmr.earthdata.nasa.gov/graphdb)` endpoint, to query against related collections and duplicate collections in the graph database. To send queries to a locally running graph database, we can use a docker gremlin-server that exposes an HTTP endpoint. This is launched by running
 
-We can use a docker gremlin-server that exposes an HTTP endpoint. This is launched by running
-docker run -it -p 8182:8182 tinkerpop/gremlin-server conf gremlin-server-rest-modern.yaml
+`docker run -it -p 8182:8182 tinkerpop/gremlin-server conf gremlin-server-rest-modern.yaml`
+
 as well as altering the `gremlinPath` in `(src/utils/cmrGraphDb.js)` to the localhost address the gremlin server is running on.
 
-We may add data to this local graph database with http POST requests to the gremlin-server
+We may add data to this local graph database with http POST requests to the gremlin-server.

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -21,26 +21,6 @@ export default class Collection extends Concept {
    * @param {String} id Concept ID to set a value for within the result set
    * @param {Object} item The item returned from the CMR json endpoint
    */
-  // TODO: Since all concepts now support associations we should refactor this on the parent class
-  setEssentialJsonValues(id, item) {
-    super.setEssentialJsonValues(id, item)
-
-    const { association_details: associationDetails } = item
-
-    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
-
-    // Associations are used by services, tools, and variables, it's required to correctly
-    // retrieve those objects and shouldn't need to be provided by the client
-    if (associationDetails) {
-      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
-    }
-  }
-
-  /**
-   * Set a value in the result set that a query has not requested but is necessary for other functionality
-   * @param {String} id Concept ID to set a value for within the result set
-   * @param {Object} item The item returned from the CMR json endpoint
-   */
   setEssentialUmmValues(id, item) {
     super.setEssentialUmmValues(id, item)
 

--- a/src/cmr/concepts/collectionDraft.js
+++ b/src/cmr/concepts/collectionDraft.js
@@ -20,9 +20,10 @@ export default class CollectionDraft extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('collectionDraft', headers, requestInfo, params)
-    // Collection drafts do not support associations
-    delete this.setEssentialJsonValues
   }
+
+  // Collection drafts do not support associations
+  setEssentialJsonValues() {}
 
   /**
    * Returns an array of keys representing supported search params for the umm endpoint

--- a/src/cmr/concepts/collectionDraft.js
+++ b/src/cmr/concepts/collectionDraft.js
@@ -20,6 +20,8 @@ export default class CollectionDraft extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('collectionDraft', headers, requestInfo, params)
+    // Collection drafts do not support associations
+    delete this.setEssentialJsonValues
   }
 
   /**

--- a/src/cmr/concepts/collectionDraftProposal.js
+++ b/src/cmr/concepts/collectionDraftProposal.js
@@ -20,9 +20,10 @@ export default class CollectionDraftProposal extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('collectionDraftProposal', headers, requestInfo, params)
-    // Collection draft proposals do not support associations
-    delete this.setEssentialJsonValues
   }
+
+  // Collection draft proposals do not support associations
+  setEssentialJsonValues() {}
 
   /**
    * Returns an array of keys representing supported search params for the umm endpoint

--- a/src/cmr/concepts/collectionDraftProposal.js
+++ b/src/cmr/concepts/collectionDraftProposal.js
@@ -20,6 +20,8 @@ export default class CollectionDraftProposal extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('collectionDraftProposal', headers, requestInfo, params)
+    // Collection draft proposals do not support associations
+    delete this.setEssentialJsonValues
   }
 
   /**

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -130,7 +130,15 @@ export default class Concept {
    * @param {String} id Concept ID to set a value for within the result set
    * @param {Object} item The item returned from the CMR json endpoint
    */
-  setEssentialJsonValues() {}
+  setEssentialJsonValues(id, item) {
+    const { association_details: associationDetails } = item
+
+    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
+
+    if (associationDetails) {
+      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
+    }
+  }
 
   /**
    * Set a value in the result set that a query has not requested but is necessary for other functionality

--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -10,6 +10,8 @@ export default class Granule extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('granules', headers, requestInfo, params)
+    // Granules do not support associations
+    delete this.setEssentialJsonValues
   }
 
   /**

--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -10,9 +10,10 @@ export default class Granule extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('granules', headers, requestInfo, params)
-    // Granules do not support associations
-    delete this.setEssentialJsonValues
   }
+
+  // Granules do not support associations
+  setEssentialJsonValues() {}
 
   /**
    * Returns an array of keys representing supported search params for the json endpoint

--- a/src/cmr/concepts/service.js
+++ b/src/cmr/concepts/service.js
@@ -23,14 +23,6 @@ export default class Service extends Concept {
   setEssentialJsonValues(id, item) {
     super.setEssentialJsonValues(id, item)
 
-    const { association_details: associationDetails } = item
-
-    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
-
-    // Associations on services are used to retrieve order-options
-    if (associationDetails) {
-      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
-    }
     // Add the parent collection concept-id and pass it to the child queries from this service
     if (this.parentCollectionConceptId) {
       this.setItemValue(id, 'parentCollectionConceptId', this.parentCollectionConceptId)

--- a/src/resolvers/__tests__/dataQualitySummary.test.js
+++ b/src/resolvers/__tests__/dataQualitySummary.test.js
@@ -18,6 +18,7 @@ describe('DataQualitySummary', () => {
   afterEach(() => {
     process.env = OLD_ENV
   })
+
   describe('Query', () => {
     test('All dataQualitySummary fields', async () => {
       nock(/example/)

--- a/src/resolvers/__tests__/grid.test.js
+++ b/src/resolvers/__tests__/grid.test.js
@@ -32,7 +32,15 @@ describe('Grid', () => {
         .reply(200, {
           items: [{
             meta: {
-              'concept-id': 'GRD100000-EDSC'
+              'concept-id': 'GRD100000-EDSC',
+              'association-details': {
+                tools: [
+                  {
+                    data: '{"key": "value", "bool": true}',
+                    'concept-id': 'T100000-EDSC'
+                  }
+                ]
+              }
             },
             umm: {
               RelatedURLs: {},
@@ -62,6 +70,7 @@ describe('Grid', () => {
           grids {
             count
             items {
+              associationDetails
               conceptId
               relatedUrls
               organization
@@ -91,6 +100,13 @@ describe('Grid', () => {
         grids: {
           count: 1,
           items: [{
+            associationDetails: {
+              tools: [
+                {
+                  data: '{"key": "value", "bool": true}',
+                  conceptId: 'T100000-EDSC'
+                }]
+            },
             conceptId: 'GRD100000-EDSC',
             relatedUrls: {},
             organization: {

--- a/src/types/grid.graphql
+++ b/src/types/grid.graphql
@@ -1,4 +1,6 @@
 type Grid {
+  "The list of concepts and any data on the relationship between this DQS and other permitted concepts."
+  associationDetails: JSON
   "The additional attribute to the grid."
   additionalAttribute: JSON
   "The unique concept id assigned to the grid."

--- a/src/utils/umm/gridKeyMap.json
+++ b/src/utils/umm/gridKeyMap.json
@@ -4,6 +4,7 @@
     "name"
   ],
   "ummKeyMappings": {
+    "associationDetails": "meta.association-details",
     "additionalAttribute": "umm.AdditionalAttribute",
     "conceptId": "meta.concept-id",
     "contactMechanisms": "umm.Organization.ContactMechanisms",


### PR DESCRIPTION
# Overview

### What is the feature?

Since all concepts now support associations we should refactor some of the concept specific logic out to the concept parent (base class), while preserving the search functionality of extended classes that do not support associations such as granules, collection drafts, and collection draft proposals.

### What is the Solution?

- Added association search to grids (was the only concept missing them)
- Refactored the association code (handled by a method "setEssentialJsonValues") out from extended classes into the base class "Concept". Those classes that do not support associations, explicitly delete the "setEssentialJsonValues" method in their constructors. The service class also adds more to that method.

### What areas of the application does this impact?

All

# Testing

### Reproduction steps

- **Environment for testing:** SIT
- **Collection to test with:** C1200442362-CMR_ONLY

1. Search for the collection noted above, which has associations with every other concept type that supports it.
```graphql
# query collection
query Collection($params: CollectionInput) {
  collection(params: $params) {
    associationDetails
  }
}

# collection input
{
  "params": {
    "conceptId": "C1200442362-CMR_ONLY"
  }
} 
```
2. Search for the other concept types, which are associated to the above collection.
```graphql
# query all
query ConceptsAssociations($serviceParams: ServiceInput, $orderOptionParams: OrderOptionInput, $toolParams: ToolInput, $gridParams: GridInput, $dqsParams: DataQualitySummaryInput) {
  service(params: $serviceParams) {
    associationDetails
  }
  tool(params: $toolParams) {
    associationDetails
  }
  orderOption(params: $orderOptionParams) {
    associationDetails
  }
  grid(params: $gridParams) {
    associationDetails
  }
  dataQualitySummary(params: $dqsParams) {
    associationDetails
  }
}

# input
{
  "serviceParams": {
    "conceptId": "S1200442363-CMR_ONLY"
  },
  "orderOptionParams": {
    "conceptId": "OO1200442027-CMR_ONLY"
  },
  "toolParams": {
    "conceptId": "TL1200442955-CMR_ONLY"
  },
  "gridParams": {
    "conceptId": "GRD1200460135-CMR_ONLY"
  },
  "dqsParams": {
    "conceptId": "DQS1200441930-CMR_ONLY"
  }
}
```
3. Search for the 3 concept types which do not support associations, to verify that the base class refactoring did not break them.
```graphql
# query
query NoAssociations($granuleParams: GranulesInput, $collectionDraftParams: CollectionDraftInput, $draftProposalParams: CollectionDraftProposalInput) {
  granules(params: $granuleParams) {
    items {
      conceptId
    }
  }
  collectionDraft(params: $collectionDraftParams) {
    shortName
  }
  collectionDraftProposal(params: $draftProposalParams) {
    shortName
  }
}

# params
{
  "granuleParams": {
    "limit": 10,
    "collectionConceptId": "C1200371800-CMR_ONLY"
  },
  "collectionDraftParams": {
    "id": 2964
  },
  "draftProposalParams": {
    "id": 556
  }
}
```

### Attachments

No relevant attachments

# Checklist

- [x ] I have added automated tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
