### PR TITLE
EDSC-3732 fixes possible mismatch of nested collection objects in granule queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ doc
 
 # CI Outputs
 junit.xml
+
+# Emacs
+.dir-locals.el
+\#*\#
+.\#*

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2007-2020 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+Copyright © 2007-2023 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CMR-GraphQL is an API developed by [NASA](http://nasa.gov) [EOSDIS](https://eart
 
 ## License
 
-> Copyright © 2007-2020 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+> Copyright © 2007-2023 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
 >
 > Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 > You may obtain a copy of the License at

--- a/src/dataloaders/__tests__/getCollectionsById.test.js
+++ b/src/dataloaders/__tests__/getCollectionsById.test.js
@@ -107,4 +107,126 @@ describe('getCollectionsById', () => {
       title: 'Maecenas sed diam eget risus varius blandit sit amet non magna.'
     }])
   })
+
+  test('returns the data in the same order as the input', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Hits': 84,
+        'CMR-Took': 7,
+        'CMR-Request-Id': 'abcd-1234-efgh-5678',
+        'CMR-Search-After': '["abc", 123, 444]'
+      })
+      .post(/granules\.json/)
+      .reply(200, {
+        feed: {
+          entry: [{
+            id: 'G100000-EDSC',
+            collection_concept_id: 'C100000-EDSC'
+          }, {
+            id: 'G100001-EDSC',
+            collection_concept_id: 'C100001-EDSC'
+          }, {
+            id: 'G100002-EDSC',
+            collection_concept_id: 'C100000-EDSC'
+          }, {
+            id: 'G100003-EDSC',
+            collection_concept_id: 'C100002-EDSC'
+          }, {
+            id: 'G100004-EDSC',
+            collection_concept_id: 'C100001-EDSC'
+          }]
+        }
+      })
+
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Hits': 84,
+        'CMR-Took': 7,
+        'CMR-Request-Id': 'abcd-1234-efgh-5678',
+        'CMR-Search-After': '["abc", 123, 444]'
+      })
+      .post(/collections\.json/)
+      .reply(200, {
+        feed: {
+          entry: [{
+            id: 'C100002-EDSC',
+            title: 'Etiam laoreet quam sed arcu.'
+          }, {
+            id: 'C100001-EDSC',
+            title: 'Praesent fermentum tempor tellus.'
+          }, {
+            id: 'C100000-EDSC',
+            title: 'In id erat non orci commodo lobortis.'
+          }]
+        }
+      })
+
+    const context = {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': '4a557d1a-d592-48fb-9833-685aecfb2501'
+      }
+    }
+
+    const parsedInfo = {
+      name: 'collection',
+      alias: 'collection',
+      args: {},
+      fieldsByTypeName: {
+        Collection: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          title: {
+            name: 'title',
+            alias: 'title',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+
+    const orderedCollections = await getCollectionsById([{
+      conceptId: 'C100000-EDSC',
+      context,
+      parsedInfo
+    }, {
+      conceptId: 'C100001-EDSC',
+      context,
+      parsedInfo
+    }, {
+      conceptId: 'C100000-EDSC',
+      context,
+      parsedInfo
+    }, {
+      conceptId: 'C100002-EDSC',
+      context,
+      parsedInfo
+    }, {
+      conceptId: 'C100001-EDSC',
+      context,
+      parsedInfo
+    }])
+
+    expect(orderedCollections).toEqual([{
+      conceptId: 'C100000-EDSC',
+      title: 'In id erat non orci commodo lobortis.'
+    }, {
+      conceptId: 'C100001-EDSC',
+      title: 'Praesent fermentum tempor tellus.'
+    }, {
+      conceptId: 'C100000-EDSC',
+      title: 'In id erat non orci commodo lobortis.'
+    }, {
+      conceptId: 'C100002-EDSC',
+      title: 'Etiam laoreet quam sed arcu.'
+    }, {
+      conceptId: 'C100001-EDSC',
+      title: 'Praesent fermentum tempor tellus.'
+    }])
+  })
 })

--- a/src/dataloaders/getCollectionsById.js
+++ b/src/dataloaders/getCollectionsById.js
@@ -28,12 +28,14 @@ export const getCollectionsById = async (collections) => {
   // Parse the client query for information that will help make decisions about what to request
   const requestInfo = parseRequestedFields(parsedInfo, collectionKeyMap, 'collection')
 
+  const conceptIds = collections.map((collection) => collection.conceptId)
+
   // Instantiate a Collection concept to perform our request
   const collection = new Collection(
     headers,
     requestInfo,
     handlePagingParams({
-      conceptId: collections.map((collection) => collection.conceptId),
+      conceptId: conceptIds,
       limit: collections.length
     })
   )
@@ -41,7 +43,7 @@ export const getCollectionsById = async (collections) => {
   // Query CMR
   collection.fetch(
     handlePagingParams({
-      conceptId: collections.map((collection) => collection.conceptId),
+      conceptId: conceptIds,
       limit: collections.length
     }),
     context
@@ -51,5 +53,19 @@ export const getCollectionsById = async (collections) => {
   await collection.parse(requestInfo)
 
   // Return a formatted JSON response
-  return collection.getFormattedResponse()
+  const returnedCollections = collection.getFormattedResponse()
+
+  // Fix the resulting collections return order to match incoming list
+  console.debug("Sorting returned to match requested", collections, conceptIds, returnedCollections)
+  return conceptIds.reduce((orderedCollections, conceptId) => {
+    const sortedCollection = returnedCollections.find(
+      (returnedCollection) => returnedCollection.conceptId === conceptId
+    )
+
+    if (!sortedCollection) {
+      throw new Error(`No collection returned with conceptId [${conceptId}]`)
+    }
+
+    return  [...orderedCollections, sortedCollection];
+  }, [])
 }

--- a/src/resolvers/__tests__/granule.test.js
+++ b/src/resolvers/__tests__/granule.test.js
@@ -295,10 +295,10 @@ describe('Granule', () => {
           feed: {
             entry: [{
               id: 'G1000-TEST',
-              collectionConceptId: 'C1000-TEST'
+              collection_concept_id: 'C1000-TEST'
             }, {
               id: 'G1001-TEST',
-              collectionConceptId: 'C1000-TEST'
+              collection_concept_id: 'C1000-TEST'
             }]
           }
         })

--- a/src/utils/verifyEDLJwt.js
+++ b/src/utils/verifyEDLJwt.js
@@ -6,7 +6,7 @@ import { parseError } from './parseError'
 /**
  * Verify and decode a JWT token
  * @param {String} header - The JWT token in the form "Bearer <TOKEN>"
- * @return {String} The User Id of the edl user if it has been verified, otherwise an empty string if verification fails
+ * @return {Promise<string>} The User Id of the edl user if it has been verified, otherwise an empty string if verification fails
  * @see https://urs.earthdata.nasa.gov/documentation/for_integrators/verify_edl_jwt_token
  * @see https://github.com/auth0/node-jwks-rsa
  */


### PR DESCRIPTION
# Overview

Fixes an issue with the collection DataLoader where returned results did not match the incoming request object indices, allowing collections to be associated with the incorrect granule.

### What is the Solution?

Sorting the returned DataLoader collections to map to the corresponding input list of collectionIds.

### What areas of the application does this impact?

Granules query

# Testing

### Reproduction steps

- SIT
Compare the results of the matched granule collectionConceptId and nested collection values using the query listed below, with the two different parameters. The collectionConceptId and nested collection should be in agreement.

```gql
query Granules($params: GranulesInput) {
  granules(params: $params) {
    count
    cursor 
    items {
      conceptId
      title
      collectionConceptId
      collection {
        shortName
        version
        conceptId
      }
    }
  }
}
```

```json
{ 
  "params": {
  "provider": "LEO_PROV"
}
```

```json
{ 
  "params": {
  "provider": "LEO_PROV",
  "readableGranuleName": ["GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480110.020.nc4"]
  }
}
```

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
