### PR TITLE
EDSC-3674: Query collections by multiple shortNames.

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -1,7 +1,5 @@
 import camelcaseKeys from 'camelcase-keys'
 import { uniq } from 'lodash'
-import { mergeParams } from '../../utils/mergeParams'
-import { parseError } from '../../utils/parseError'
 
 import Concept from './concept'
 
@@ -177,6 +175,7 @@ export default class Collection extends Concept {
       'provider',
       'service_concept_id',
       'service_type',
+      'short_name',
       'sort_key',
       'spatial_keyword',
       'tag_key',
@@ -242,89 +241,6 @@ export default class Collection extends Concept {
     }
 
     return super.fetchUmm(searchParams, ummKeys, ummHeaders)
-  }
-
-  /**
-   * Query the CMR API
-   * @param {Object} searchParams Parameters provided by the query
-   */
-  fetch(searchParams) {
-    // eslint-disable-next-line no-param-reassign
-    searchParams = mergeParams(searchParams)
-
-    // Default an array to hold the promises we need to make depending on the requested fields
-    const promises = []
-
-    const {
-      jsonKeys,
-      metaKeys,
-      ummKeys
-    } = this.requestInfo
-
-    this.logKeyRequest(metaKeys, 'meta')
-
-    if (jsonKeys.length > 0) {
-      const { shortNames } = searchParams
-
-      if (shortNames) {
-        // Make CMR requests for each shortName included in the params
-        shortNames.forEach((shortName) => {
-          const newParams = {
-            ...searchParams,
-            shortName
-          }
-          delete newParams.shortNames
-
-          promises.push(
-            this.fetchJson(this.arrayifyParams(newParams), jsonKeys, this.headers)
-          )
-        })
-      } else {
-        promises.push(
-          this.fetchJson(this.arrayifyParams(searchParams), jsonKeys, this.headers)
-        )
-      }
-    }
-
-    // If any requested keys are umm keys, we need to make an additional request to cmr
-    if (ummKeys.length > 0) {
-      // Construct the promise that will request data from the umm endpoint
-      promises.push(
-        this.fetchUmm(this.arrayifyParams(searchParams), ummKeys, this.headers)
-      )
-    }
-
-    this.response = Promise.all(promises)
-  }
-
-  /**
-   * Parses the response from each endpoint after a request is made
-   * @param {Object} requestInfo Parsed data pertaining to the Graph query
-   */
-  async parse(requestInfo) {
-    try {
-      const {
-        jsonKeys,
-        ummKeys
-      } = requestInfo
-
-      const response = await this.getResponse()
-
-      const promises = []
-
-      response.forEach((res) => {
-        const { config } = res
-        const { url } = config
-        if (url.includes('umm')) {
-          promises.push(this.parseUmm(res, ummKeys))
-        } else {
-          promises.push(this.parseJson(res, jsonKeys))
-        }
-      })
-      await Promise.all(promises)
-    } catch (e) {
-      parseError(e, { reThrowError: true })
-    }
   }
 
   /**

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -42,7 +42,8 @@ export default class Concept {
     this.arrayifiableKeys = {
       collectionConceptIds: 'collectionConceptId',
       dataCenters: 'dataCenter',
-      providers: 'provider'
+      providers: 'provider',
+      shortNames: 'shortName'
     }
   }
 

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -505,68 +505,6 @@ describe('Collection', () => {
           }
         })
       })
-
-      test('returns results when multiple shortName values are requested', async () => {
-        nock(/example-cmr/)
-          .defaultReplyHeaders({
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          })
-          .post(/collections\.json/, 'short_name=short-name-1&page_size=20')
-          .reply(200, {
-            feed: {
-              entry: [{
-                id: 'C100000-EDSC',
-                short_name: 'short-name-1'
-              }]
-            }
-          })
-        nock(/example-cmr/)
-          .defaultReplyHeaders({
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          })
-          .post(/collections\.json/, 'short_name=short-name-2&page_size=20')
-          .reply(200, {
-            feed: {
-              entry: [{
-                id: 'C100001-EDSC',
-                short_name: 'short-name-2'
-              }]
-            }
-          })
-
-        const response = await server.executeOperation({
-          variables: {},
-          query: `{
-            collections(params: { shortNames: ["short-name-1", "short-name-2"] }) {
-              items {
-                conceptId
-                shortName
-              }
-            }
-          }`
-        }, {
-          contextValue
-        })
-
-        const { data } = response.body.singleResult
-
-        expect(data).toEqual({
-          collections: {
-            items: [
-              {
-                conceptId: 'C100000-EDSC',
-                shortName: 'short-name-1'
-              },
-              {
-                conceptId: 'C100001-EDSC',
-                shortName: 'short-name-2'
-              }
-            ]
-          }
-        })
-      })
     })
 
     describe('collection', () => {

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -461,6 +461,8 @@ input CollectionsInput {
   serviceType: [String]
   "The short name associated with the collection."
   shortName: String
+  "An array of 'shortName' param values."
+  shortNames: [String]
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]
   "Keywords relating to spatial aspects of the collection."


### PR DESCRIPTION
# Overview

### What is the feature?

Add support for querying cmr-graphql with a list of shortName values.

### What is the Solution?

Send multiple requests to CMR (one for each provided shortName). Since collection inherits from concept, I adapted the fetch and parse methods to handle when an array of shortName values is a query field.

I wonder if there should be a limit on how many shortName values you can request though (I was thinking there might be potential for launching some kind of attack if each shortName is an additional CMR request and many shortName values were included in the query? Maybe this is already handled somewhere though?)

### What areas of the application does this impact?

Collections concept, possibly other concepts as well. Anywhere collection fetching or parsing is used (I had to change some existing code to make things work).

# Testing in SIT
1. Go to [cmr-graphql playground](https://studio.apollographql.com/sandbox/explorer) at https://graphql.sit.earthdata.nasa.gov/api. 
2. Make a collections query and input an array of shortName values.
`query Query($params: CollectionsInput) {
  collections(params: $params) {
    items {
      conceptId
      shortName
    }
  }
}`
variables:
`{
  "params": {
    "shortNames": ["ACOS_L2_Lite_FP", "SNDRSNIML2CCPRET", "USAP-1753101", "latent-reserves-in-the-swiss-nfi"]
  }
}`
3. Verify that the response returns multiple collections.

### Attachments

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/45649183/228855396-41225685-92ff-442c-bfed-56f4257f3b7b.png">

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
