### PR TITLE
CMR-9153 CloudCoverage from AdditionalAttributes

### DIFF
--- a/src/cmr/concepts/__tests__/granule.test.js
+++ b/src/cmr/concepts/__tests__/granule.test.js
@@ -1,0 +1,37 @@
+import Granule from '../granule'
+
+describe('granule', () => {
+  describe('normalizeUmmItem', () => {
+    describe('cloud coverage', () => {
+      test('Ensure cloud_cover as an additional attribute is moved to a top level property', () => {
+        const granule = new Granule({}, {}, {})
+        const item = {
+          umm: {
+            AdditionalAttributes: [{ Name: 'CLOUD_COVERAGE', Values: ['50.0'] }]
+          }
+        }
+        expect(granule.normalizeUmmItem(item)).toEqual({ ...item, CloudCover: 50 })
+      })
+
+      test('Ensure invalid cloud_cover is not normalized', () => {
+        const granule = new Granule({}, {}, {})
+        const item = {
+          umm: {
+            AdditionalAttributes: [{ Name: 'CLOUD_COVERAGE', Values: ['NONE'] }]
+          }
+        }
+        expect(granule.normalizeUmmItem(item)).toEqual(item)
+      })
+
+      test('Ensure no cloud_cover does not fail', () => {
+        const granule = new Granule({}, {}, {})
+        const item = {
+          umm: {
+            AdditionalAttributes: []
+          }
+        }
+        expect(granule.normalizeUmmItem(item)).toEqual(item)
+      })
+    })
+  })
+})

--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -1,6 +1,30 @@
 import { uniq } from 'lodash'
 import Concept from './concept'
 
+/**
+ * Return the CloudCover representation of CloudCover listed in `AdditionalAttributes`.
+ * @param {Object} item The item returned from the CMR umm_json endpoint
+ *
+ * @example
+ * { umm:
+ *   { AdditionalAttributes: [
+ *     { Name: "CLOUD_COVERAGE",
+ *       Values: [ "50.0" ]}]}}
+ */
+function legacyUmmCloudCover(item) {
+  const {
+    umm: { AdditionalAttributes: additionalAttributes = [] }
+  } = item
+
+  const cloudCoverAttr = additionalAttributes.find((attr) => attr.Name === 'CLOUD_COVERAGE')
+  if (!cloudCoverAttr) {
+    return {}
+  }
+
+  const cloudCoverValue = Number(cloudCoverAttr.Values[0])
+  return Number.isNaN(cloudCoverValue) ? {} : { CloudCover: cloudCoverValue }
+}
+
 export default class Granule extends Concept {
   /**
    * Instantiates a Granule object
@@ -153,28 +177,4 @@ export default class Granule extends Concept {
 
     return item
   }
-}
-
-/**
- * Return the CloudCover representation of CloudCover listed in `AdditionalAttributes`.
- * @param {Object} item The item returned from the CMR umm_json endpoint
- *
- * @example
- * { umm:
- *   { AdditionalAttributes: [
- *     { Name: "CLOUD_COVERAGE",
- *       Values: [ "50.0" ]}]}}
- */
-function legacyUmmCloudCover(item) {
-  const {
-    umm: { AdditionalAttributes: additionalAttributes = [] }
-  } = item
-
-  const cloudCoverAttr = additionalAttributes.find((attr) => attr.Name === 'CLOUD_COVERAGE')
-  if (!cloudCoverAttr) {
-    return {}
-  }
-
-  const cloudCoverValue = Number(cloudCoverAttr.Values[0])
-  return Number.isNaN(cloudCoverValue) ? {} : { CloudCover: cloudCoverValue }
 }


### PR DESCRIPTION
# Overview

Updates where CloudCover values are pulled from. Adds lookup in the outdated `AdditionalAttributes` field for UMM_JSON.

### What is the Solution?

Updates the granule normalization to include checking for the older location.

### What areas of the application does this impact?

Granule search

# Testing

### Reproduction steps

- SIT

```
query Granules($params: GranulesInput) {
  granules(params: $params) {
    count
    items {
      cloudCover
      conceptId
    }
  }
}

{
  "params": {
    "provider": "CMR_ONLY",
    "cloudCover": {
      "min": 0
    }
  }
}
```

Compare to the equivalent CURL results and verify some values are pulled from top level `umm.CloudCover` and others are pulled from `umm.AdditionalAttributes`

```
curl -XGET "https://cmr.sit.earthdata.nasa.gov/search/granules.umm_json?provider=CMR_ONLY&cloud_cover[min]=0"
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
