### PR TITLE
CMR-9191: Update the draft retrieval endpoint in CMR-GraphQL

### DIFF
--- a/src/cmr/concepts/draftConcept.js
+++ b/src/cmr/concepts/draftConcept.js
@@ -82,12 +82,29 @@ export default class DraftConcept extends Concept {
     }
   }
 
+  parseConceptType() {
+    let draftType
+    switch (this.getConceptType()) {
+      case 'toolDraft':
+        draftType = 'tool_drafts'
+        break
+      case 'variableDraft':
+        draftType = 'variable_drafts'
+        break
+      case 'collectionDraft':
+        draftType = 'collection_drafts'
+        break
+      default:
+        break
+    }
+    return draftType
+  }
+
   fetchUmm(searchParams, requestedKeys, providedHeaders) {
     this.logKeyRequest(requestedKeys, 'umm')
-
     // Construct the promise that will request data from the umm endpoint
     return mmtQuery({
-      draftType: this.getConceptType(),
+      draftType: this.parseConceptType(),
       params: pick(snakecaseKeys(searchParams), this.getPermittedUmmSearchParams()),
       nonIndexedKeys: this.getNonIndexedKeys(),
       headers: providedHeaders

--- a/src/cmr/concepts/draftConcept.js
+++ b/src/cmr/concepts/draftConcept.js
@@ -91,10 +91,8 @@ export default class DraftConcept extends Concept {
       case 'variableDraft':
         draftType = 'variable_drafts'
         break
-      case 'collectionDraft':
-        draftType = 'collection_drafts'
-        break
       default:
+        draftType = 'collection_drafts'
         break
     }
     return draftType

--- a/src/cmr/concepts/draftConcept.js
+++ b/src/cmr/concepts/draftConcept.js
@@ -82,27 +82,11 @@ export default class DraftConcept extends Concept {
     }
   }
 
-  parseConceptType() {
-    let draftType
-    switch (this.getConceptType()) {
-      case 'toolDraft':
-        draftType = 'tool_drafts'
-        break
-      case 'variableDraft':
-        draftType = 'variable_drafts'
-        break
-      default:
-        draftType = 'collection_drafts'
-        break
-    }
-    return draftType
-  }
-
   fetchUmm(searchParams, requestedKeys, providedHeaders) {
     this.logKeyRequest(requestedKeys, 'umm')
     // Construct the promise that will request data from the umm endpoint
     return mmtQuery({
-      draftType: this.parseConceptType(),
+      draftType: this.getConceptType(),
       params: pick(snakecaseKeys(searchParams), this.getPermittedUmmSearchParams()),
       nonIndexedKeys: this.getNonIndexedKeys(),
       headers: providedHeaders

--- a/src/datasources/__tests__/collectionDraft.test.js
+++ b/src/datasources/__tests__/collectionDraft.test.js
@@ -49,7 +49,7 @@ describe('collectionDraft', () => {
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
-      .get(/api\/drafts/)
+      .get(/api\/collection_drafts/)
       .reply(200, {
         draft: {
           Abstract: 'Mock Abstract',

--- a/src/datasources/__tests__/toolDraft.test.js
+++ b/src/datasources/__tests__/toolDraft.test.js
@@ -49,7 +49,7 @@ describe('toolDraft', () => {
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
-      .get(/api\/drafts/)
+      .get(/api\/tool_drafts/)
       .reply(200, {
         draft: {
           LongName: 'Mock Long Name',
@@ -76,7 +76,7 @@ describe('toolDraft', () => {
 
   test('catches errors received from mmtQuery', async () => {
     nock(/example/)
-      .get(/api\/drafts/)
+      .get(/api\/tool_drafts/)
       .reply(500, {
         errors: ['HTTP Error']
       }, {

--- a/src/datasources/__tests__/variableDraft.test.js
+++ b/src/datasources/__tests__/variableDraft.test.js
@@ -42,7 +42,7 @@ describe('variableDraft', () => {
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
-      .get(/api\/drafts/)
+      .get(/api\/variable_drafts/)
       .reply(200, {
         draft: {
           LongName: 'Mock Long Name'

--- a/src/resolvers/__tests__/collectionDraft.test.js
+++ b/src/resolvers/__tests__/collectionDraft.test.js
@@ -28,7 +28,7 @@ describe('Collection', () => {
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get(/api\/drafts/)
+            .get(/api\/collection_drafts/)
             .reply(200, {
               draft: {
                 ShortName: 'Mock ShortName'
@@ -62,7 +62,7 @@ describe('Collection', () => {
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get(/api\/drafts/)
+            .get(/api\/collection_drafts/)
             .reply(200, {})
 
           const response = await server.executeOperation({

--- a/src/resolvers/__tests__/toolDraft.test.js
+++ b/src/resolvers/__tests__/toolDraft.test.js
@@ -28,7 +28,7 @@ describe('Collection', () => {
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get(/api\/drafts/)
+            .get(/api\/tool_drafts/)
             .reply(200, {
               draft: {
                 DOI: 'Mock doi'
@@ -62,7 +62,7 @@ describe('Collection', () => {
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get(/api\/drafts/)
+            .get(/api\/tool_drafts/)
             .reply(200, {})
 
           const response = await server.executeOperation({

--- a/src/resolvers/__tests__/variableDraft.test.js
+++ b/src/resolvers/__tests__/variableDraft.test.js
@@ -28,7 +28,7 @@ describe('Variable Draft', () => {
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get(/api\/drafts/)
+            .get(/api\/variable_drafts/)
             .reply(200, {
               draft: {
                 StandardName: 'Mock Standard Name'

--- a/src/utils/__tests__/mmtQuery.test.js
+++ b/src/utils/__tests__/mmtQuery.test.js
@@ -20,13 +20,13 @@ describe('mmtQuery', () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
     nock(/example/)
-      .get(/api\/drafts/)
+      .get(/api\/collection_drafts/)
       .reply(200, {
         ShortName: 'Mock ShortName'
       })
 
     const response = await mmtQuery({
-      draftType: 'collectionDraft',
+      draftType: 'collection_drafts',
       params: {
         id: 123
       },
@@ -47,7 +47,7 @@ describe('mmtQuery', () => {
     })
 
     expect(consoleMock).toBeCalledWith(
-      `Request abcd-1234-efgh-5678 from eed-test-graphql to MMT [Draft Type: collectionDraft] completed external request in [observed: ${requestDuration} ms]`
+      `Request abcd-1234-efgh-5678 from eed-test-graphql to MMT [Draft Type: collection_drafts] completed external request in [observed: ${requestDuration} ms]`
     )
   })
 
@@ -60,13 +60,13 @@ describe('mmtQuery', () => {
           'X-Request-Id': 'abcd-1234-efgh-5678'
         }
       })
-        .get(/api\/drafts/)
+        .get(/api\/collection_drafts/)
         .reply(200, {
           ShortName: 'Mock ShortName'
         })
 
       const response = await mmtQuery({
-        draftType: 'collectionDraft',
+        draftType: 'collection_drafts',
         params: {},
         headers: {
           Authorization: 'test-token',
@@ -85,13 +85,13 @@ describe('mmtQuery', () => {
   describe('when an error is returned', () => {
     test('throws an exception', async () => {
       nock(/example/)
-        .get(/api\/drafts/)
+        .get(/api\/collection_drafts/)
         .reply(500, {
           errors: ['HTTP Error']
         })
 
       const response = mmtQuery({
-        draftType: 'collectionDraft',
+        draftType: 'collection_drafts',
         params: {},
         headers: {
           'Client-Id': 'eed-test-graphql',

--- a/src/utils/mmtQuery.js
+++ b/src/utils/mmtQuery.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { snakeCase } from 'lodash'
 
 import snakeCaseKeys from 'snakecase-keys'
 
@@ -47,7 +48,7 @@ export const mmtQuery = ({
     data: cmrParameters,
     headers: permittedHeaders,
     method: 'GET',
-    url: `${process.env.mmtRootUrl}/api/${draftType}/${id}`
+    url: `${process.env.mmtRootUrl}/api/${snakeCase(draftType)}s/${id}`
   }
 
   // Interceptors require an instance of axios

--- a/src/utils/mmtQuery.js
+++ b/src/utils/mmtQuery.js
@@ -47,7 +47,7 @@ export const mmtQuery = ({
     data: cmrParameters,
     headers: permittedHeaders,
     method: 'GET',
-    url: `${process.env.mmtRootUrl}/api/drafts/${id}?draft_type=${draftType}`
+    url: `${process.env.mmtRootUrl}/api/${draftType}/${id}`
   }
 
   // Interceptors require an instance of axios


### PR DESCRIPTION
# Overview
Updated the draft retrieval endpoint as MMT updated the endpoint.

### What is the Solution?

- Updated draftConcept.js with the new endpoint: /api/drafts/:id?draft_type=:draftType -> /api/draftType/id
- Parsing the conceptType in draftConcept.js, MMT requires the to be tool_drafts, variable_drafts or collection_drafts
