### PR TITLE
CMR-9254: Unable to retrieve drafts in SIT for MMT Preview

### DIFF
--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -98,6 +98,8 @@ export default startServerAndCreateLambdaHandler(
         `eed-${process.env.stage}-graphql`
       ].filter(Boolean).join('-')
 
+      requestHeaders.User = context.edlUsername
+
       return {
         ...context,
         dataSources: {

--- a/src/utils/mmtQuery.js
+++ b/src/utils/mmtQuery.js
@@ -32,7 +32,8 @@ export const mmtQuery = ({
     'Accept',
     'Authorization',
     'Client-Id',
-    'X-Request-Id'
+    'X-Request-Id',
+    'User'
   ])
 
   const cmrParameters = prepKeysForCmr(snakeCaseKeys(params), nonIndexedKeys)


### PR DESCRIPTION
# Overview
After deploying MMT-3263 to SIT, noticed I was getting an unauthorized error in GraphQL. 

### What is the Solution?
After debugging, noticed that the new MMT Draft API requires username as a required param.
Summarize what you changed.
In mmtQuery.js I needed to add User which was already being declared in handler.js as edlUsername. So in handler.js I assigned edlUsername to the requestHeader as User. 
