### PR TITLE
EDSC-3805: ran npm audit fix, fixed fast-xml-parser regex vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.4.1.tgz",
-      "integrity": "sha512-KEEM8Q5KvkarPHn6r//nRonVBQ/C69fmkTKHzuL1ZoD7BevdIh7HLeh69wIazC21wrizBHMR+LKIqZuIT9YQVg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.7.4.tgz",
+      "integrity": "sha512-7MwEsBR+4JRfjAzrFIOP0m/NdzNCyVOlRWCO/86zs73CC+trr08FklTD7JD0yx5BJDfyzjdhF2BZ1sEYvp/Waw==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/server-gateway-interface": "^1.1.0",
@@ -112,7 +112,7 @@
         "@apollo/utils.isnodelike": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
-        "@apollo/utils.usagereporting": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
         "@apollo/utils.withrequired": "^2.0.0",
         "@graphql-tools/schema": "^9.0.0",
         "@josephg/resolvable": "^1.0.0",
@@ -180,17 +180,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.dropunuseddefinitions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.0.tgz",
-      "integrity": "sha512-BoPW+Z3kA8kLh0FCWyzOt+R77W5mVZWer5s6UyvVwZ/qROGiEgcHXFcI5TMMndpXoDo0xBSvQV0lIKYHbJQ7+g==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
     "node_modules/@apollo/server/node_modules/@apollo/utils.keyvaluecache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
@@ -209,72 +198,6 @@
       "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.printwithreducedwhitespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.0.tgz",
-      "integrity": "sha512-S+wyxFyuO0LJ8v+mg8c7rRwyKZ+9xlO5wXD/UgaysH3rcCe9NBHRWx/9cmdZ9nTqgKC5X01uHZ6Gsi6pOrUGgw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.removealiases": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.0.tgz",
-      "integrity": "sha512-PT5ICz2SfrMCRsR3DhW2E1anX6hcqVXE/uHpmRHbhqSoQODZKG34AlFm1tC8u3MC3eK5gcvtpGvPHF/cwVfakg==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.sortast": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.0.tgz",
-      "integrity": "sha512-VKoVOh8xkvh5HabtyGTekIYbwXdyYFPodFuHpWp333Fo2KBmpczLY+RBMHEr3v2MLoXDn/WUMtR3JZmvFJ45zw==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.stripsensitiveliterals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.0.tgz",
-      "integrity": "sha512-pzj1XINetE54uxIjc4bN6gVzDWYP8OZ/yB0xMTgvzttu1VLgXf3BTV76d9hlqLoe8cV0JiD+xLpJktrHOzmBJQ==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.usagereporting": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.0.0.tgz",
-      "integrity": "sha512-9VvVgA/LzKkBEYEGwE9doL1Sl+VRULkbB3D7W+ImJ028jJuTllvlQsh4Xpqz8mJWprfKx4m/i2DwHtElHWU2vg==",
-      "dependencies": {
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
-        "@apollo/utils.dropunuseddefinitions": "^2.0.0",
-        "@apollo/utils.printwithreducedwhitespace": "^2.0.0",
-        "@apollo/utils.removealiases": "2.0.0",
-        "@apollo/utils.sortast": "^2.0.0",
-        "@apollo/utils.stripsensitiveliterals": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/server/node_modules/@graphql-tools/merge": {
@@ -339,6 +262,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
     "node_modules/@apollo/utils.fetcher": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
@@ -353,6 +287,72 @@
       "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/utils.withrequired": {
@@ -503,1159 +503,672 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+      "integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
-      "dependencies": {
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.280.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.280.0.tgz",
-      "integrity": "sha512-gxyU6b+kA8eC25QdIdIQ75gXRypxTV/9u3WUE6Hs1MLz7dHeCKP/sHmKNT6+DmuWA8+Urm+PuUQZFuWTDtiu7A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.354.0.tgz",
+      "integrity": "sha512-7fRXdnBnTSEmvemoA0MfYxa2EaHZXoegt4wZaSxjUTzP9+EQdidESYSgkGB+kDTAg8KDrFCHvtQ2xQBi7dUMhg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.279.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.279.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/eventstream-serde-browser": "3.347.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+        "@aws-sdk/eventstream-serde-node": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.347.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.282.0.tgz",
-      "integrity": "sha512-Pc3GqSvsQhhsMwbbs+iqv/Ju2HK0z0Hwat1k+bIdzXnEBb8L+KQFuvabqlXd3QAkjkGuG+uHYqB6FheUwN3amg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.354.0.tgz",
+      "integrity": "sha512-AEvHJipD/YhHRbS3l6uyLc6yNHF7vtmInwlQC+v4r61DeqnkHetboam2lMx5WsEJLBkKwfdsFkIEGVjI6OrjpQ==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.282.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/eventstream-serde-browser": "3.272.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.272.0",
-        "@aws-sdk/eventstream-serde-node": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-blob-browser": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/hash-stream-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/md5-js": "3.272.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.282.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-expect-continue": "3.282.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-location-constraint": "3.272.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-sdk-s3": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/middleware-ssec": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4-multi-region": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-stream-browser": "3.282.0",
-        "@aws-sdk/util-stream-node": "3.282.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/eventstream-serde-browser": "3.347.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+        "@aws-sdk/eventstream-serde-node": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-blob-browser": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/hash-stream-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/md5-js": "3.347.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.354.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-expect-continue": "3.347.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-location-constraint": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-s3": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-ssec": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/signature-v4-multi-region": "3.354.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-stream-browser": "3.353.0",
+        "@aws-sdk/util-stream-node": "3.350.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.347.0",
+        "@aws-sdk/xml-builder": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.282.0.tgz",
-      "integrity": "sha512-VzdCCaxlDyU+7wvLDWh+uACQ6RPfaKLQ3yJ2UY0B0SkH4R0E4GLDJ2OJzqS5eyyOsnq1rxfY75S4WYzj8E2cvg==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.282.0.tgz",
-      "integrity": "sha512-upC4yBZllAXg5OVIuS8Lu9MI1aqfAObl2BBixj9fIYbDanQ02s0b1IwfZqlOqNNkGzMko1AWyiOSyOdVgyJ+xg==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.282.0.tgz",
-      "integrity": "sha512-JZybEaST0rloS9drlX/0yJAnKHuV7DlS1n1WZxgaM2DY704ydlGiviiPQvC/q/dItsX4017gscC0blGJcUjK1g==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-sdk-sts": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.282.0.tgz",
-      "integrity": "sha512-30qFLh2N4NXQ2EAook7NIFeu1K/nlrRLrdVb2BtGFi/F3cZnz+sy9o0XmL6x+sO9TznWjdNxD1RKQdqoAwGnCQ==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.282.0.tgz",
-      "integrity": "sha512-2GKduXORcUgOigF1jZF7A1Wh4W/aJt3ynh7xb1vfx020nHx6YDljrEGpzgH6pOVzl7ZhgthpojicCuy2UumkMA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.282.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.282.0.tgz",
-      "integrity": "sha512-qyHipZW0ep8STY+SO+Me8ObQ1Ee/aaZTmAK0Os/gB+EsiZhIE+mi6zRcScwdnpgJPLRYMEe4p/Cr6DOrA0G0GQ==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.282.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.282.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.282.0.tgz",
-      "integrity": "sha512-c4nibry7u0hkYRMi7+cWzdwYXfDDG+j3VYFxk2oOvU1VIJRyE6oeJqVaz3jgYLX9brHyrLJjuFCIJCUV/WXgIA==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
-      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
-      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
-      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
-      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
-      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.282.0.tgz",
-      "integrity": "sha512-3+0M1GP9o480IdqHVZbkhTgge63uKhDFlS6cQznpNGj0eIuQPhXRnlEz2/rma0INUqFm6+7qJ5yzHR4WQbfHpw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
-      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
-      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
-      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
-      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
-      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.282.0.tgz",
-      "integrity": "sha512-Qk/D6i+Hpc0fp/2SRHbfJeKPgUIugzsmye3NL0OV1bqd1Y40dW5LT4u67VcZHwqxzYDKe6Eo+7NHJu7qfvwhog==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.282.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.282.0.tgz",
-      "integrity": "sha512-D1BlFoA7ZMeK2diDUWFx1xBFrSaJuBZMRBuWbnbT9AnRYNCsASZ8DRU1KkZ8LuFQIwmZz94P9q683emYnZBhiw==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
-      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.282.0.tgz",
-      "integrity": "sha512-GSOdWNmzEd554wR9HBrgeYptKBOybveVwUkd6ws+YTdCOz4xD5Gga+I5JomKkcMEUVdBrJnYVUtq7ZsJy2f11w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.279.0.tgz",
-      "integrity": "sha512-599Y5wOrkpjD6p0BTs0X4+Ge9O7jlAPJ2ttI9lfhT2/UEZyqoJHajJs1pMJV75oeZklPOBi8G9jnZcMVJgRpvQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
+      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.279.0.tgz",
-      "integrity": "sha512-tC9xKGo3z/HQbJDMvaUrnBSSRX7sOX2YUA2OpJ3T1TTfylLTO70OKjg1G4OMFNiPpJsHonwD7Iud+rnMnUKI0g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
+      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.279.0.tgz",
-      "integrity": "sha512-y/cI5Gg5WWqmSSDQftCT26wOLu0HSuPY1u6Q4Q97FBIfRC3hYztjYdUDHuTu6qPPT+tdsnWOUy2tr3qamVSQ4g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
+      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.279.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sts": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
+      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
+      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
+      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.279.0.tgz",
-      "integrity": "sha512-FCpr3/khMTb2pWLMC138wU7HzcpkrjejrBNfCJSUu7Emxm039UMLjT2JObnRKxidKlz58oYBRayVIbBYRWREcg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
+      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.279.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.279.0.tgz",
-      "integrity": "sha512-7D8ETopCt3H+x2BEPMEhzc4dcNtSK7umnRdgfiTGRjcQSVPh5Whq/tDIAtNj2D+PmLgu3e+Hk7jrXkaMCDlxMw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
+      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.279.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.279.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-ini": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
+      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.279.0.tgz",
-      "integrity": "sha512-u8ZHz9Sv7sAv2vllyzcdgcO1pC5pa2UuoYKfz9J8hqLHc8VJYtYQ6WJvi4GoA55VDPk87pyVYz9t6ATntsukaw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
+      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.279.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/token-providers": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
+      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.272.0.tgz",
-      "integrity": "sha512-HYMzglDnqUhvx3u9MdzZ/OjLuavaaH9zF9XMXRuv7bdsN9AAi3/0he0FEx84ZXNXSAZCebLwXJYf0ZrN6g37QA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.272.0.tgz",
-      "integrity": "sha512-mE1+mevS+KVKpnTLi5FytsBwAK1kWZ92ERtAiElp58SKE1OpfSg8lEY8VI6JKGlueN540Qq3LeIgA2/HJOcK/w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+      "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.272.0.tgz",
-      "integrity": "sha512-e47BhGBvx+me53cvYx+47ml5KNDj7XoTth80krHlyLrimFELE1ij4tHSKR/XzilKKH1uIWmJQdlAi29129ZX5w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+      "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.272.0.tgz",
-      "integrity": "sha512-uto8y4FoZugWnczM1TKwv6oV2Po2Jgrp+W1Ws3baRQ4Lan+QpFx3Tps1N5rNzQ+7Uz0xT1BhbSNPAkKs22/jtg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+      "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.272.0.tgz",
-      "integrity": "sha512-E9jlt8tzDcEMoNlgv3+01jGPJPHmbmw2NsajZhB4axVMpEy247JV6qvCZe+5R+EGy96t0pfsO2naViEB4Va47g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+      "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
       "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
+      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.272.0.tgz",
-      "integrity": "sha512-IRCIMG42fXcdD92C8Sb0CQI8D/msxDwHGAIqP94iGhVEnKX2egyx5J8lmPY4gEky5UzyMMaH7cayBv89ZMEBmQ==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.353.0.tgz",
+      "integrity": "sha512-YO/38oTbTY5URjmYLU5YDh1VmHndWT7h3a0T5vM9K7AAoqdVbGXP1Di9zpEmteH4rurZNEqLGuLw9/p9dTre6Q==",
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.188.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/chunked-blob-reader": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.272.0.tgz",
-      "integrity": "sha512-mWwQWdfVYoR6PXRLkHP6pC1cghZMg0ULuOAm70EtTO2YXiyLlMIDb+VD4RRbjh3hNkzh+y/W47wSUJthGBM1kg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
+      "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.272.0.tgz",
-      "integrity": "sha512-/GK32mgAarhn/F0xCeBKbYfLRof3tOCNrg8mAGNz9Di8E1/qMOnX/OXUGag0lsvNZ6DTjdjln29t4e8iKmOVqA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+      "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.282.0.tgz",
-      "integrity": "sha512-yXsUigRNGFbFVC1h9WIcB9Dc5bDr0hTah3PARXq/Wa+tUwzWFTIawYDEhRF9w7fJyWfJUsVJbfIldlSmJnQM5w==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.354.0.tgz",
+      "integrity": "sha512-CU1RIwY8dqoPm+TixXHu4p0XziT6kXps1ip+hauxUC/BNalu2Cln8QwukDtYhN0IF9s82NhrDlDkI6RIzfGn2Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.282.0.tgz",
-      "integrity": "sha512-BMzziPjQ4SozKgObdt9PJ1Cs7BLOz6RKzj9nSJKuLzxix8TX2XZhLY3Xuxu/fWXvuDYxly/NA6d/rIvqjcPk3A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
+      "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.282.0.tgz",
-      "integrity": "sha512-yru/1bVrT4EV+Mpcr5docVgZ5/ywsy/mRyvZBfHD3qC5Ydd9fakOnFhHzxSCbKSWQN2jlxPNuAzWVznSuBbSqg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
+      "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.272.0.tgz",
-      "integrity": "sha512-tROQ1DM9djxfXmXPTT0XietrUt6y6QEHShPI9rQMstjXYiaHBVXRveuRLcLAKwl4nXIrgmnIU7ygyj2ZyD8gcA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
+      "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
+      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -1671,236 +1184,222 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.282.0.tgz",
-      "integrity": "sha512-AUHHbLG1tAw7kDtKtXCsiBUdENwHyFL/h0GD24gyupGmis3AwtLfxYsjsKjByCzB6xKAi8TuPHvIvelvGdgcuA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
+      "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
+      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
+      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.272.0.tgz",
-      "integrity": "sha512-WDPcNPkscTmJUzdAvfx8p+YuUn2YR9ocmZA7yYUJ5kA94MyGH6Rbjp8tleWwQvah/HweeCQrYUzJk9wsH64LPA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
+      "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
+      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
+      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
+      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
+      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.282.0.tgz",
-      "integrity": "sha512-0+WZqFGL2Qjo9Upvn0clrK8hzjgp8I5EzJ81oGga1IQqgpJItl+nMGqfV8pv9xVw3Je5hk4GWCVjS2arXF9s4g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.354.0.tgz",
+      "integrity": "sha512-/g/3rQH8lomtUEYMuhZi9RER1+dZtl0U8mtdNJKSJtdYT5Ftk3GXS82uDdgpg1jyeP8TCR2Stl2fWZH2Jed1vA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1914,197 +1413,168 @@
         }
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
-      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.279.0.tgz",
-      "integrity": "sha512-bsUlZSizTXZ8Pehdatcioi8VphxYn7fRjo5L083peOvBjoL+9WSGyP74PLrFLNwA35QxddwOqgnpQZoE1heuPQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
+      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.279.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+      "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
+      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
+      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2122,135 +1592,84 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.282.0.tgz",
-      "integrity": "sha512-84yUR9MYykbMeiAPYNSgnkEnQm7WWVXjYGNfCXQ+xL6hiQXG3F0q1NZ45aT1bIlCL8L/yck1bdfIvPHYHTpmsg==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.353.0.tgz",
+      "integrity": "sha512-2EBLrnjdBiMwupdPlztUjTk7T/6LX//8ppudPJvaFDyXuPYV6pDR4L5CDvrPZQTdzfbzAJKb5MVG1OxTn+aF8g==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
-      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.282.0.tgz",
-      "integrity": "sha512-zZLIxDTShpx4+n+2OE/fBIHKsltJYFl53J75pDycMi4LjeD/yZD3Paz68wexTznjwggnaespPsklGEB2Ug2/rQ==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.350.0.tgz",
+      "integrity": "sha512-qhcmYEAVMJPjCepog3WTFBaeP3XCkLBbUrM5/+LaB/FASKk+JeV8qBQyjYUd8EVb6Gsk7+y9SE3Tj+ChyHB4WA==",
       "dependencies": {
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
-      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "dependencies": {
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
+      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2265,12 +1684,12 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2285,24 +1704,24 @@
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
-      "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+      "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5648,6 +5067,29 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -9569,18 +9011,24 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -18155,9 +17603,9 @@
       }
     },
     "@apollo/server": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.4.1.tgz",
-      "integrity": "sha512-KEEM8Q5KvkarPHn6r//nRonVBQ/C69fmkTKHzuL1ZoD7BevdIh7HLeh69wIazC21wrizBHMR+LKIqZuIT9YQVg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.7.4.tgz",
+      "integrity": "sha512-7MwEsBR+4JRfjAzrFIOP0m/NdzNCyVOlRWCO/86zs73CC+trr08FklTD7JD0yx5BJDfyzjdhF2BZ1sEYvp/Waw==",
       "requires": {
         "@apollo/cache-control-types": "^1.0.2",
         "@apollo/server-gateway-interface": "^1.1.0",
@@ -18167,7 +17615,7 @@
         "@apollo/utils.isnodelike": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0",
-        "@apollo/utils.usagereporting": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
         "@apollo/utils.withrequired": "^2.0.0",
         "@graphql-tools/schema": "^9.0.0",
         "@josephg/resolvable": "^1.0.0",
@@ -18187,12 +17635,6 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
-        "@apollo/utils.dropunuseddefinitions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.0.tgz",
-          "integrity": "sha512-BoPW+Z3kA8kLh0FCWyzOt+R77W5mVZWer5s6UyvVwZ/qROGiEgcHXFcI5TMMndpXoDo0xBSvQV0lIKYHbJQ7+g==",
-          "requires": {}
-        },
         "@apollo/utils.keyvaluecache": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.0.tgz",
@@ -18206,45 +17648,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
           "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
-        },
-        "@apollo/utils.printwithreducedwhitespace": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.0.tgz",
-          "integrity": "sha512-S+wyxFyuO0LJ8v+mg8c7rRwyKZ+9xlO5wXD/UgaysH3rcCe9NBHRWx/9cmdZ9nTqgKC5X01uHZ6Gsi6pOrUGgw==",
-          "requires": {}
-        },
-        "@apollo/utils.removealiases": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.0.tgz",
-          "integrity": "sha512-PT5ICz2SfrMCRsR3DhW2E1anX6hcqVXE/uHpmRHbhqSoQODZKG34AlFm1tC8u3MC3eK5gcvtpGvPHF/cwVfakg==",
-          "requires": {}
-        },
-        "@apollo/utils.sortast": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.0.tgz",
-          "integrity": "sha512-VKoVOh8xkvh5HabtyGTekIYbwXdyYFPodFuHpWp333Fo2KBmpczLY+RBMHEr3v2MLoXDn/WUMtR3JZmvFJ45zw==",
-          "requires": {
-            "lodash.sortby": "^4.7.0"
-          }
-        },
-        "@apollo/utils.stripsensitiveliterals": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.0.tgz",
-          "integrity": "sha512-pzj1XINetE54uxIjc4bN6gVzDWYP8OZ/yB0xMTgvzttu1VLgXf3BTV76d9hlqLoe8cV0JiD+xLpJktrHOzmBJQ==",
-          "requires": {}
-        },
-        "@apollo/utils.usagereporting": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.0.0.tgz",
-          "integrity": "sha512-9VvVgA/LzKkBEYEGwE9doL1Sl+VRULkbB3D7W+ImJ028jJuTllvlQsh4Xpqz8mJWprfKx4m/i2DwHtElHWU2vg==",
-          "requires": {
-            "@apollo/usage-reporting-protobuf": "^4.0.0",
-            "@apollo/utils.dropunuseddefinitions": "^2.0.0",
-            "@apollo/utils.printwithreducedwhitespace": "^2.0.0",
-            "@apollo/utils.removealiases": "2.0.0",
-            "@apollo/utils.sortast": "^2.0.0",
-            "@apollo/utils.stripsensitiveliterals": "^2.0.0"
-          }
         },
         "@graphql-tools/merge": {
           "version": "8.4.0",
@@ -18327,6 +17730,12 @@
         "sha.js": "^2.4.11"
       }
     },
+    "@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "requires": {}
+    },
     "@apollo/utils.fetcher": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.0.tgz",
@@ -18336,6 +17745,45 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.0.tgz",
       "integrity": "sha512-77CiAM2qDXn0haQYrgX0UgrboQykb+bOHaz5p3KKItMwUZ/EFphzuB2vqHvubneIc9dxJcTx2L7MFDswRw/JAQ=="
+    },
+    "@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "requires": {}
+    },
+    "@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "requires": {}
+    },
+    "@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "requires": {
+        "lodash.sortby": "^4.7.0"
+      }
+    },
+    "@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "requires": {}
+    },
+    "@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "requires": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      }
     },
     "@apollo/utils.withrequired": {
       "version": "2.0.0",
@@ -18492,994 +17940,582 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
-      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/chunked-blob-reader": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
-      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+      "integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
-      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
-      "requires": {
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-lambda": {
-      "version": "3.280.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.280.0.tgz",
-      "integrity": "sha512-gxyU6b+kA8eC25QdIdIQ75gXRypxTV/9u3WUE6Hs1MLz7dHeCKP/sHmKNT6+DmuWA8+Urm+PuUQZFuWTDtiu7A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.354.0.tgz",
+      "integrity": "sha512-7fRXdnBnTSEmvemoA0MfYxa2EaHZXoegt4wZaSxjUTzP9+EQdidESYSgkGB+kDTAg8KDrFCHvtQ2xQBi7dUMhg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.279.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.279.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/eventstream-serde-browser": "3.347.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+        "@aws-sdk/eventstream-serde-node": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.347.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.282.0.tgz",
-      "integrity": "sha512-Pc3GqSvsQhhsMwbbs+iqv/Ju2HK0z0Hwat1k+bIdzXnEBb8L+KQFuvabqlXd3QAkjkGuG+uHYqB6FheUwN3amg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.354.0.tgz",
+      "integrity": "sha512-AEvHJipD/YhHRbS3l6uyLc6yNHF7vtmInwlQC+v4r61DeqnkHetboam2lMx5WsEJLBkKwfdsFkIEGVjI6OrjpQ==",
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.282.0",
-        "@aws-sdk/config-resolver": "3.282.0",
-        "@aws-sdk/credential-provider-node": "3.282.0",
-        "@aws-sdk/eventstream-serde-browser": "3.272.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.272.0",
-        "@aws-sdk/eventstream-serde-node": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/hash-blob-browser": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/hash-stream-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/md5-js": "3.272.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.282.0",
-        "@aws-sdk/middleware-content-length": "3.282.0",
-        "@aws-sdk/middleware-endpoint": "3.282.0",
-        "@aws-sdk/middleware-expect-continue": "3.282.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.282.0",
-        "@aws-sdk/middleware-host-header": "3.282.0",
-        "@aws-sdk/middleware-location-constraint": "3.272.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.282.0",
-        "@aws-sdk/middleware-retry": "3.282.0",
-        "@aws-sdk/middleware-sdk-s3": "3.282.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.282.0",
-        "@aws-sdk/middleware-ssec": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.282.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4-multi-region": "3.282.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.282.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-stream-browser": "3.282.0",
-        "@aws-sdk/util-stream-node": "3.282.0",
-        "@aws-sdk/util-user-agent-browser": "3.282.0",
-        "@aws-sdk/util-user-agent-node": "3.282.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "@aws-sdk/util-waiter": "3.272.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.282.0.tgz",
-          "integrity": "sha512-VzdCCaxlDyU+7wvLDWh+uACQ6RPfaKLQ3yJ2UY0B0SkH4R0E4GLDJ2OJzqS5eyyOsnq1rxfY75S4WYzj8E2cvg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.282.0",
-            "@aws-sdk/fetch-http-handler": "3.282.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.282.0",
-            "@aws-sdk/middleware-endpoint": "3.282.0",
-            "@aws-sdk/middleware-host-header": "3.282.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.282.0",
-            "@aws-sdk/middleware-retry": "3.282.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.282.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.282.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.282.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.282.0",
-            "@aws-sdk/util-user-agent-node": "3.282.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.282.0.tgz",
-          "integrity": "sha512-upC4yBZllAXg5OVIuS8Lu9MI1aqfAObl2BBixj9fIYbDanQ02s0b1IwfZqlOqNNkGzMko1AWyiOSyOdVgyJ+xg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.282.0",
-            "@aws-sdk/fetch-http-handler": "3.282.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.282.0",
-            "@aws-sdk/middleware-endpoint": "3.282.0",
-            "@aws-sdk/middleware-host-header": "3.282.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.282.0",
-            "@aws-sdk/middleware-retry": "3.282.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.282.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.282.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.282.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.282.0",
-            "@aws-sdk/util-user-agent-node": "3.282.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.282.0.tgz",
-          "integrity": "sha512-JZybEaST0rloS9drlX/0yJAnKHuV7DlS1n1WZxgaM2DY704ydlGiviiPQvC/q/dItsX4017gscC0blGJcUjK1g==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/config-resolver": "3.282.0",
-            "@aws-sdk/credential-provider-node": "3.282.0",
-            "@aws-sdk/fetch-http-handler": "3.282.0",
-            "@aws-sdk/hash-node": "3.272.0",
-            "@aws-sdk/invalid-dependency": "3.272.0",
-            "@aws-sdk/middleware-content-length": "3.282.0",
-            "@aws-sdk/middleware-endpoint": "3.282.0",
-            "@aws-sdk/middleware-host-header": "3.282.0",
-            "@aws-sdk/middleware-logger": "3.272.0",
-            "@aws-sdk/middleware-recursion-detection": "3.282.0",
-            "@aws-sdk/middleware-retry": "3.282.0",
-            "@aws-sdk/middleware-sdk-sts": "3.282.0",
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/middleware-signing": "3.282.0",
-            "@aws-sdk/middleware-stack": "3.272.0",
-            "@aws-sdk/middleware-user-agent": "3.282.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/node-http-handler": "3.282.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/smithy-client": "3.279.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-            "@aws-sdk/util-defaults-mode-node": "3.282.0",
-            "@aws-sdk/util-endpoints": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "@aws-sdk/util-user-agent-browser": "3.282.0",
-            "@aws-sdk/util-user-agent-node": "3.282.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "fast-xml-parser": "4.1.2",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.282.0.tgz",
-          "integrity": "sha512-30qFLh2N4NXQ2EAook7NIFeu1K/nlrRLrdVb2BtGFi/F3cZnz+sy9o0XmL6x+sO9TznWjdNxD1RKQdqoAwGnCQ==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.282.0.tgz",
-          "integrity": "sha512-2GKduXORcUgOigF1jZF7A1Wh4W/aJt3ynh7xb1vfx020nHx6YDljrEGpzgH6pOVzl7ZhgthpojicCuy2UumkMA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.282.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.282.0.tgz",
-          "integrity": "sha512-qyHipZW0ep8STY+SO+Me8ObQ1Ee/aaZTmAK0Os/gB+EsiZhIE+mi6zRcScwdnpgJPLRYMEe4p/Cr6DOrA0G0GQ==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.272.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/credential-provider-ini": "3.282.0",
-            "@aws-sdk/credential-provider-process": "3.272.0",
-            "@aws-sdk/credential-provider-sso": "3.282.0",
-            "@aws-sdk/credential-provider-web-identity": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.282.0.tgz",
-          "integrity": "sha512-c4nibry7u0hkYRMi7+cWzdwYXfDDG+j3VYFxk2oOvU1VIJRyE6oeJqVaz3jgYLX9brHyrLJjuFCIJCUV/WXgIA==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.282.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/token-providers": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
-          "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
-          "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
-          "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.272.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/signature-v4": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/url-parser": "3.272.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
-          "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
-          "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.282.0.tgz",
-          "integrity": "sha512-3+0M1GP9o480IdqHVZbkhTgge63uKhDFlS6cQznpNGj0eIuQPhXRnlEz2/rma0INUqFm6+7qJ5yzHR4WQbfHpw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/service-error-classification": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-retry": "3.272.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
-          "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.282.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/signature-v4": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
-          "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/signature-v4": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
-          "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
-          "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
-          "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.282.0.tgz",
-          "integrity": "sha512-Qk/D6i+Hpc0fp/2SRHbfJeKPgUIugzsmye3NL0OV1bqd1Y40dW5LT4u67VcZHwqxzYDKe6Eo+7NHJu7qfvwhog==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.282.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/shared-ini-file-loader": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.282.0.tgz",
-          "integrity": "sha512-D1BlFoA7ZMeK2diDUWFx1xBFrSaJuBZMRBuWbnbT9AnRYNCsASZ8DRU1KkZ8LuFQIwmZz94P9q683emYnZBhiw==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.282.0",
-            "@aws-sdk/credential-provider-imds": "3.272.0",
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/property-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
-          "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.282.0.tgz",
-          "integrity": "sha512-GSOdWNmzEd554wR9HBrgeYptKBOybveVwUkd6ws+YTdCOz4xD5Gga+I5JomKkcMEUVdBrJnYVUtq7ZsJy2f11w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@aws-sdk/client-sts": "3.354.0",
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/eventstream-serde-browser": "3.347.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.347.0",
+        "@aws-sdk/eventstream-serde-node": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-blob-browser": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/hash-stream-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/md5-js": "3.347.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.354.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-expect-continue": "3.347.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-location-constraint": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-s3": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-ssec": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/signature-v4-multi-region": "3.354.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-stream-browser": "3.353.0",
+        "@aws-sdk/util-stream-node": "3.350.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.347.0",
+        "@aws-sdk/xml-builder": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.279.0.tgz",
-      "integrity": "sha512-599Y5wOrkpjD6p0BTs0X4+Ge9O7jlAPJ2ttI9lfhT2/UEZyqoJHajJs1pMJV75oeZklPOBi8G9jnZcMVJgRpvQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.354.0.tgz",
+      "integrity": "sha512-4jmvjJYDaaPmm1n2TG4LYfTEnHLKcJmImgBqhgzhMgaypb4u/k1iw0INV2r/afYPL/FsrLFwc46RM3HYx3nc4A==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.279.0.tgz",
-      "integrity": "sha512-tC9xKGo3z/HQbJDMvaUrnBSSRX7sOX2YUA2OpJ3T1TTfylLTO70OKjg1G4OMFNiPpJsHonwD7Iud+rnMnUKI0g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.354.0.tgz",
+      "integrity": "sha512-XZcg4s2zKb4S8ltluiw5yxpm974uZqzo2HTECt1lbzUJgVgLsMAh/nPJ1fLqg4jadT+rf8Lq2FEFqOM/vxWT8A==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.279.0.tgz",
-      "integrity": "sha512-y/cI5Gg5WWqmSSDQftCT26wOLu0HSuPY1u6Q4Q97FBIfRC3hYztjYdUDHuTu6qPPT+tdsnWOUy2tr3qamVSQ4g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.354.0.tgz",
+      "integrity": "sha512-l9Ar/C/3PNlToM1ukHVfBtp4plbRUxLMYY2DOTMI0nb3jzfcvETBcdEGCP51fX4uAfJ2vc4g5qBF/qXKX0LMWA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-node": "3.279.0",
-        "@aws-sdk/fetch-http-handler": "3.272.0",
-        "@aws-sdk/hash-node": "3.272.0",
-        "@aws-sdk/invalid-dependency": "3.272.0",
-        "@aws-sdk/middleware-content-length": "3.272.0",
-        "@aws-sdk/middleware-endpoint": "3.272.0",
-        "@aws-sdk/middleware-host-header": "3.278.0",
-        "@aws-sdk/middleware-logger": "3.272.0",
-        "@aws-sdk/middleware-recursion-detection": "3.272.0",
-        "@aws-sdk/middleware-retry": "3.272.0",
-        "@aws-sdk/middleware-sdk-sts": "3.272.0",
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/middleware-user-agent": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/node-http-handler": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/smithy-client": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
-        "@aws-sdk/util-defaults-mode-node": "3.279.0",
-        "@aws-sdk/util-endpoints": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "@aws-sdk/util-user-agent-browser": "3.272.0",
-        "@aws-sdk/util-user-agent-node": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "fast-xml-parser": "4.1.2",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-node": "3.354.0",
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.354.0",
+        "@aws-sdk/middleware-sdk-sts": "3.354.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.353.0",
+        "@aws-sdk/util-defaults-mode-node": "3.354.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.354.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.272.0.tgz",
-      "integrity": "sha512-Dr4CffRVNsOp3LRNdpvcH6XuSgXOSLblWliCy/5I86cNl567KVMxujVx6uPrdTXYs2h1rt3MNl6jQGnAiJeTbw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.354.0.tgz",
+      "integrity": "sha512-K4XWie8yJPT8bpYVX54VJMQhiJRTw8PrjEs9QrKqvwoCcZ3G4qEt40tIu33XksuokXxk8rrVH5d7odOPBsAtdg==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
-      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.353.0.tgz",
+      "integrity": "sha512-Y4VsNS8O1FAD5J7S5itOhnOghQ5LIXlZ44t35nF8cbcF+JPvY3ToKzYpjYN1jM7DXKqU4shtqgYpzSqxlvEgKQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.272.0.tgz",
-      "integrity": "sha512-wwAfVY1jTFQEfxVfdYD5r5ieYGl+0g4nhekVxNMqE8E1JeRDd18OqiwAflzpgBIqxfqvCUkf+vl5JYyacMkNAQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.354.0.tgz",
+      "integrity": "sha512-AB+PuDd1jX6qgz+JYvIyOn8Kz9/lQ60KuY1TFb7g3S8zURw+DSeMJNR1jzEsorWICTzhxXmyasHVMa4Eo4Uq+Q==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.279.0.tgz",
-      "integrity": "sha512-FCpr3/khMTb2pWLMC138wU7HzcpkrjejrBNfCJSUu7Emxm039UMLjT2JObnRKxidKlz58oYBRayVIbBYRWREcg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.354.0.tgz",
+      "integrity": "sha512-bn2ifrRsxWpxzwXa25jRdUECQ1dC+NB3YlRYnGdIaIQLF559N2jnfCabYzqyfKI++WU7aQeMofPe2PxVGlbv9Q==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.279.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.279.0.tgz",
-      "integrity": "sha512-7D8ETopCt3H+x2BEPMEhzc4dcNtSK7umnRdgfiTGRjcQSVPh5Whq/tDIAtNj2D+PmLgu3e+Hk7jrXkaMCDlxMw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.354.0.tgz",
+      "integrity": "sha512-ltKiRtHfqDaCcrb44DIoSHQ9MposFl/aDtNdu5OdQv/2Q1r7M/r2fQdq9DHOrxeQQjaUH4C6k6fGTsxALTHyNA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/credential-provider-ini": "3.279.0",
-        "@aws-sdk/credential-provider-process": "3.272.0",
-        "@aws-sdk/credential-provider-sso": "3.279.0",
-        "@aws-sdk/credential-provider-web-identity": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.353.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/credential-provider-ini": "3.354.0",
+        "@aws-sdk/credential-provider-process": "3.354.0",
+        "@aws-sdk/credential-provider-sso": "3.354.0",
+        "@aws-sdk/credential-provider-web-identity": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.272.0.tgz",
-      "integrity": "sha512-hiCAjWWm2PeBFp5cjkxqyam/XADjiS+e7GzwC34TbZn3LisS0uoweLojj9tD11NnnUhyhbLteUvu5+rotOLwrg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.354.0.tgz",
+      "integrity": "sha512-AxpASm+tS8V1PY4PLfG9dtqa96lzBJ3niTQb+RAm4uYCddW7gxNDkGB+jSCzVdUPVa3xA2ITBS/ka3C5yM8YWg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.279.0.tgz",
-      "integrity": "sha512-u8ZHz9Sv7sAv2vllyzcdgcO1pC5pa2UuoYKfz9J8hqLHc8VJYtYQ6WJvi4GoA55VDPk87pyVYz9t6ATntsukaw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.354.0.tgz",
+      "integrity": "sha512-ihiaUxh8V/nQgTOgQZxWQcbckXhM+J6Wdc4F0z9soi48iSOqzRpzPw5E14wSZScEZjNY/gKEDz8gCt8WkT/G0w==",
       "requires": {
-        "@aws-sdk/client-sso": "3.279.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/token-providers": "3.279.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/token-providers": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
-      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.354.0.tgz",
+      "integrity": "sha512-scx9mAf4m3Hc3uMX2Vh8GciEcC/5GqeDI8qc0zBj+UF/5c/GtihZA4WoCV3Sg3jMPDUKY81DiFCtcKHhtUqKfg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/eventstream-codec": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.272.0.tgz",
-      "integrity": "sha512-HYMzglDnqUhvx3u9MdzZ/OjLuavaaH9zF9XMXRuv7bdsN9AAi3/0he0FEx84ZXNXSAZCebLwXJYf0ZrN6g37QA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.272.0.tgz",
-      "integrity": "sha512-mE1+mevS+KVKpnTLi5FytsBwAK1kWZ92ERtAiElp58SKE1OpfSg8lEY8VI6JKGlueN540Qq3LeIgA2/HJOcK/w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.347.0.tgz",
+      "integrity": "sha512-9BLVTHWgpiTo/hl+k7qt7E9iYu43zVwJN+4TEwA9ZZB3p12068t1Hay6HgCcgJC3+LWMtw/OhvypV6vQAG4UBg==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.272.0.tgz",
-      "integrity": "sha512-e47BhGBvx+me53cvYx+47ml5KNDj7XoTth80krHlyLrimFELE1ij4tHSKR/XzilKKH1uIWmJQdlAi29129ZX5w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.347.0.tgz",
+      "integrity": "sha512-RcXQbNVq0PFmDqfn6+MnjCUWbbobcYVxpimaF6pMDav04o6Mcle+G2Hrefp5NlFr/lZbHW2eUKYsp1sXPaxVlQ==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.272.0.tgz",
-      "integrity": "sha512-uto8y4FoZugWnczM1TKwv6oV2Po2Jgrp+W1Ws3baRQ4Lan+QpFx3Tps1N5rNzQ+7Uz0xT1BhbSNPAkKs22/jtg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.347.0.tgz",
+      "integrity": "sha512-pgQCWH0PkHjcHs04JE7FoGAD3Ww45ffV8Op0MSLUhg9OpGa6EDoO3EOpWi9l/TALtH4f0KRV35PVyUyHJ/wEkA==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.272.0.tgz",
-      "integrity": "sha512-E9jlt8tzDcEMoNlgv3+01jGPJPHmbmw2NsajZhB4axVMpEy247JV6qvCZe+5R+EGy96t0pfsO2naViEB4Va47g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.347.0.tgz",
+      "integrity": "sha512-4wWj6bz6lOyDIO/dCCjwaLwRz648xzQQnf89R29sLoEqvAPP5XOB7HL+uFaQ/f5tPNh49gL6huNFSVwDm62n4Q==",
       "requires": {
-        "@aws-sdk/eventstream-codec": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.272.0.tgz",
-      "integrity": "sha512-1Qhm9e0RbS1Xf4CZqUbQyUMkDLd7GrsRXWIvm9b86/vgeV8/WnjO3CMue9D51nYgcyQORhYXv6uVjAYCWbUExA==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.353.0.tgz",
+      "integrity": "sha512-8ic2+4E6jzfDevd++QS1rOR05QFkAhEFbi5Ja3/Zzp7TkWIS8wv5wwMATjNkbbdsXYuB5Lhl/OsjfZmIv5aqRw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.272.0.tgz",
-      "integrity": "sha512-IRCIMG42fXcdD92C8Sb0CQI8D/msxDwHGAIqP94iGhVEnKX2egyx5J8lmPY4gEky5UzyMMaH7cayBv89ZMEBmQ==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.353.0.tgz",
+      "integrity": "sha512-YO/38oTbTY5URjmYLU5YDh1VmHndWT7h3a0T5vM9K7AAoqdVbGXP1Di9zpEmteH4rurZNEqLGuLw9/p9dTre6Q==",
       "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.188.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/chunked-blob-reader": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
-      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.272.0.tgz",
-      "integrity": "sha512-mWwQWdfVYoR6PXRLkHP6pC1cghZMg0ULuOAm70EtTO2YXiyLlMIDb+VD4RRbjh3hNkzh+y/W47wSUJthGBM1kg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.347.0.tgz",
+      "integrity": "sha512-tOBfcvELyt1GVuAlQ4d0mvm3QxoSSmvhH15SWIubM9RP4JWytBVzaFAn/aC02DBAWyvp0acMZ5J+47mxrWJElg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
-      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.272.0.tgz",
-      "integrity": "sha512-/GK32mgAarhn/F0xCeBKbYfLRof3tOCNrg8mAGNz9Di8E1/qMOnX/OXUGag0lsvNZ6DTjdjln29t4e8iKmOVqA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.347.0.tgz",
+      "integrity": "sha512-mChE+7DByTY9H4cQ6fnWp2x5jf8e6OZN+AdLp6WQ+W99z35zBeqBxVmgm8ziJwkMIrkSTv9j3Y7T9Ve3RIcSfg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.282.0.tgz",
-      "integrity": "sha512-yXsUigRNGFbFVC1h9WIcB9Dc5bDr0hTah3PARXq/Wa+tUwzWFTIawYDEhRF9w7fJyWfJUsVJbfIldlSmJnQM5w==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.354.0.tgz",
+      "integrity": "sha512-CU1RIwY8dqoPm+TixXHu4p0XziT6kXps1ip+hauxUC/BNalu2Cln8QwukDtYhN0IF9s82NhrDlDkI6RIzfGn2Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.272.0.tgz",
-      "integrity": "sha512-sAbDZSTNmLX+UTGwlUHJBWy0QGQkiClpHwVFXACon+aG0ySLNeRKEVYs6NCPYldw4cj6hveLUn50cX44ukHErw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.272.0.tgz",
-      "integrity": "sha512-Dk3JVjj7SxxoUKv3xGiOeBksvPtFhTDrVW75XJ98Ymv8gJH5L1sq4hIeJAHRKogGiRFq2J73mnZSlM9FVXEylg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "requires": {
-        "@aws-sdk/middleware-serde": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/url-parser": "3.272.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.282.0.tgz",
-      "integrity": "sha512-BMzziPjQ4SozKgObdt9PJ1Cs7BLOz6RKzj9nSJKuLzxix8TX2XZhLY3Xuxu/fWXvuDYxly/NA6d/rIvqjcPk3A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.347.0.tgz",
+      "integrity": "sha512-95M1unD1ENL0tx35dfyenSfx0QuXBSKtOi/qJja6LfX5771C5fm5ZTOrsrzPFJvRg/wj8pCOVWRZk+d5+jvfOQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.282.0.tgz",
-      "integrity": "sha512-yru/1bVrT4EV+Mpcr5docVgZ5/ywsy/mRyvZBfHD3qC5Ydd9fakOnFhHzxSCbKSWQN2jlxPNuAzWVznSuBbSqg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.347.0.tgz",
+      "integrity": "sha512-Pda7VMAIyeHw9nMp29rxdFft3EF4KP/tz/vLB6bqVoBNbLujo5rxn3SGOgStgIz7fuMLQQfoWIsmvxUm+Fp+Dw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.278.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.278.0.tgz",
-      "integrity": "sha512-oTkF3exy89KE8NgSeXFwD+0H0GRKL2qUw92t3caEj7+4KzU/0m3t7NtKlq2NLRtTJhZ/izYRpV536oogLzGm3g==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.272.0.tgz",
-      "integrity": "sha512-tROQ1DM9djxfXmXPTT0XietrUt6y6QEHShPI9rQMstjXYiaHBVXRveuRLcLAKwl4nXIrgmnIU7ygyj2ZyD8gcA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.347.0.tgz",
+      "integrity": "sha512-x5fcEV7q8fQ0OmUO+cLhN5iPqGoLWtC3+aKHIfRRb2BpOO1khyc1FKzsIAdeQz2hfktq4j+WsrmcPvFKv51pSg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.272.0.tgz",
-      "integrity": "sha512-u2SQ0hWrFwxbxxYMG5uMEgf01pQY5jauK/LYWgGIvuCmFgiyRQQP3oN7kkmsxnS9MWmNmhbyQguX2NY02s5e9w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.272.0.tgz",
-      "integrity": "sha512-Gp/eKWeUWVNiiBdmUM2qLkBv+VLSJKoWAO+aKmyxxwjjmWhE0FrfA1NQ1a3g+NGMhRbAfQdaYswRAKsul70ISg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.272.0.tgz",
-      "integrity": "sha512-pCGvHM7C76VbO/dFerH+Vwf7tGv7j+e+eGrvhQ35mRghCtfIou/WMfTZlD1TNee93crrAQQVZKjtW3dMB3WCzg==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.354.0.tgz",
+      "integrity": "sha512-dnG5Nd/mobbhcWCM71DQWI9+f6b6fDSzALXftFIP/8lsXKRcWDSQuYjrnVST2wZzk/QmdF8TnVD0C1xL14K6CQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-retry": "3.272.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -19491,343 +18527,305 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.282.0.tgz",
-      "integrity": "sha512-AUHHbLG1tAw7kDtKtXCsiBUdENwHyFL/h0GD24gyupGmis3AwtLfxYsjsKjByCzB6xKAi8TuPHvIvelvGdgcuA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.347.0.tgz",
+      "integrity": "sha512-TLr92+HMvamrhJJ0VDhA/PiUh4rTNQz38B9dB9ikohTaRgm+duP+mRiIv16tNPZPGl8v82Thn7Ogk2qPByNDtg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.272.0.tgz",
-      "integrity": "sha512-VvYPg7LrDIjUOWueSzo2wBzcNG7dw+cmzV6zAKaLxf0RC5jeAP4hE0OzDiiZfDrjNghEzgq/V+0NO+LewqYL9Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.354.0.tgz",
+      "integrity": "sha512-L6vyAwYrdcOoB4YgCqNJNr+ZZtLHEF2Ym3CTfmFm2srXHqHuRB+mBu0NLV/grz77znIArK1H1ZL/ZaH2I5hclA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-signing": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
-      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.272.0.tgz",
-      "integrity": "sha512-4LChFK4VAR91X+dupqM8fQqYhFGE0G4Bf9rQlVTgGSbi2KUOmpqXzH0/WKE228nKuEhmH8+Qd2VPSAE2JcyAUA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.354.0.tgz",
+      "integrity": "sha512-Dd+vIhJL0VqqKWqlTKlKC5jkCaEIk73ZEXNfv44XbsI25a0vXbatHp1M8jB/cgkJC/Mri1TX9dmckP/C0FDEwA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/signature-v4": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.272.0.tgz",
-      "integrity": "sha512-WDPcNPkscTmJUzdAvfx8p+YuUn2YR9ocmZA7yYUJ5kA94MyGH6Rbjp8tleWwQvah/HweeCQrYUzJk9wsH64LPA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.347.0.tgz",
+      "integrity": "sha512-467VEi2elPmUGcHAgTmzhguZ3lwTpwK+3s+pk312uZtVsS9rP1MAknYhpS3ZvssiqBUVPx8m29cLcC6Tx5nOJg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
-      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.272.0.tgz",
-      "integrity": "sha512-Qy7/0fsDJxY5l0bEk7WKDfqb4Os/sCAgFR2zEvrhDtbkhYPf72ysvg/nRUTncmCbo8tOok4SJii2myk8KMfjjw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.272.0.tgz",
-      "integrity": "sha512-YYCIBh9g1EQo7hm2l22HX5Yr9RoPQ2RCvhzKvF1n1e8t1QH4iObQrYUtqHG4khcm64Cft8C5MwZmgzHbya5Z6Q==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.354.0.tgz",
+      "integrity": "sha512-pF1ZGWWvmwbrloNHYF3EDqCb9hq5wfZwDqAwAPhWkYnUYKkR7E7MZVuTwUDU48io8k6Z5pM52l/54w8e8aedTw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.272.0.tgz",
-      "integrity": "sha512-VrW9PjhhngeyYp4yGYPe5S0vgZH6NwU3Po9xAgayUeE37Inr7LS1YteFMHdpgsUUeNXnh7d06CXqHo1XjtqOKA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/protocol-http": "3.272.0",
-        "@aws-sdk/querystring-builder": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
-      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.353.0.tgz",
+      "integrity": "sha512-Iu6J59hncaew7eBKroTcLjZ8cgrom0IWyZZ09rsow3rZDHVtw7LQSrUyuqsSbKGY9eRtL7Wa6ZtYHnXFiAE2kg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.272.0.tgz",
-      "integrity": "sha512-4JQ54v5Yn08jspNDeHo45CaSn1CvTJqS1Ywgr79eU6jBExtguOWv6LNtwVSBD9X37v88iqaxt8iu1Z3pZZAJeg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
-      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
-      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
-      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.272.0.tgz",
-      "integrity": "sha512-lzFPohp5sy2XvwFjZIzLVCRpC0i5cwBiaXmFzXYQZJm6FSCszHO4ax+m9yrtlyVFF/2YPWl+/bzNthy4aJtseA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.354.0.tgz",
+      "integrity": "sha512-UL9loGEsdzpHBu/PtlwUvkl/yRdmWXkySp22jUaeeRtBhiGAnyeYhxJLIt+u+UkX7Mwz+810SaZJqA9ptOXNAg==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.272.0.tgz",
-      "integrity": "sha512-pWxnHG1NqJWMwlhJ6NHNiUikOL00DHROmxah6krJPMPq4I3am2KY2Rs/8ouWhnEXKaHAv4EQhSALJ+7Mq5S4/A==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.354.0.tgz",
+      "integrity": "sha512-bDp43P5NkwwznpZqmsr78DuyqNcjtS4mriuajb8XPhFNo8DrMXUrdrKJ+5aNABW7YG8uK8PSKBpq88ado692/w==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.272.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.347.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.282.0.tgz",
-      "integrity": "sha512-0+WZqFGL2Qjo9Upvn0clrK8hzjgp8I5EzJ81oGga1IQqgpJItl+nMGqfV8pv9xVw3Je5hk4GWCVjS2arXF9s4g==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.354.0.tgz",
+      "integrity": "sha512-/g/3rQH8lomtUEYMuhZi9RER1+dZtl0U8mtdNJKSJtdYT5Ftk3GXS82uDdgpg1jyeP8TCR2Stl2fWZH2Jed1vA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.282.0",
-        "@aws-sdk/signature-v4": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-arn-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
-          "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.272.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "@aws-sdk/util-utf8": "3.254.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
-      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.279.0.tgz",
-      "integrity": "sha512-bsUlZSizTXZ8Pehdatcioi8VphxYn7fRjo5L083peOvBjoL+9WSGyP74PLrFLNwA35QxddwOqgnpQZoE1heuPQ==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.354.0.tgz",
+      "integrity": "sha512-KcijiySy0oIyafKQagcwgu0fo35mK+2K8pwxRU1WfXqe80Gn1qGceeWcG4iW+t/rUaxa/LVo857N0LcagxCrZA==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.279.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/shared-ini-file-loader": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso-oidc": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/shared-ini-file-loader": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
-      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
-      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-arn-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
-      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+      "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-base64": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
-      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.353.0.tgz",
+      "integrity": "sha512-ushvOQKJIH7S6E//xMDPyf2/Bbu0K2A0GJRB88qQV6VKRBo4PEbeHTb6BbzPhYVX0IbY3uR/X7+Xwk4FeEkMWg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.279.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.279.0.tgz",
-      "integrity": "sha512-A2NB10xReWC+GSnOivKGZ9rnljIZdEP8WMCQQEnA6DJNI19AUFF/O9QJ9y+cHGLKEms7jH86Y99wShdpzAK+Jw==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.354.0.tgz",
+      "integrity": "sha512-CaaRVBdOYX4wZadj+CDUxpO+4RjyYJcSv71A60jV6CZ/ya1+oYfmPbG5QZ4AlV6crdev2B+aUoR2LPIYqn/GnQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.272.0",
-        "@aws-sdk/credential-provider-imds": "3.272.0",
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/property-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.354.0",
+        "@aws-sdk/credential-provider-imds": "3.354.0",
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/property-provider": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
-      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-locate-window": {
@@ -19839,127 +18837,81 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
-      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-retry": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
-      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "requires": {
-        "@aws-sdk/service-error-classification": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.282.0.tgz",
-      "integrity": "sha512-84yUR9MYykbMeiAPYNSgnkEnQm7WWVXjYGNfCXQ+xL6hiQXG3F0q1NZ45aT1bIlCL8L/yck1bdfIvPHYHTpmsg==",
+      "version": "3.353.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.353.0.tgz",
+      "integrity": "sha512-2EBLrnjdBiMwupdPlztUjTk7T/6LX//8ppudPJvaFDyXuPYV6pDR4L5CDvrPZQTdzfbzAJKb5MVG1OxTn+aF8g==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-utf8": "3.254.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
-          "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/fetch-http-handler": "3.353.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.282.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.282.0.tgz",
-      "integrity": "sha512-zZLIxDTShpx4+n+2OE/fBIHKsltJYFl53J75pDycMi4LjeD/yZD3Paz68wexTznjwggnaespPsklGEB2Ug2/rQ==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.350.0.tgz",
+      "integrity": "sha512-qhcmYEAVMJPjCepog3WTFBaeP3XCkLBbUrM5/+LaB/FASKk+JeV8qBQyjYUd8EVb6Gsk7+y9SE3Tj+ChyHB4WA==",
       "requires": {
-        "@aws-sdk/node-http-handler": "3.282.0",
-        "@aws-sdk/types": "3.272.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/node-http-handler": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
-          "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.272.0",
-            "@aws-sdk/protocol-http": "3.282.0",
-            "@aws-sdk/querystring-builder": "3.272.0",
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.282.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
-          "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
-          "requires": {
-            "@aws-sdk/types": "3.272.0",
-            "tslib": "^2.3.1"
-          }
-        }
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.272.0.tgz",
-      "integrity": "sha512-Lp5QX5bH6uuwBlIdr7w7OAcAI50ttyskb++yUr9i+SPvj6RI2dsfIBaK4mDg1qUdM5LeUdvIyqwj3XHjFKAAvA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "requires": {
-        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.272.0.tgz",
-      "integrity": "sha512-ljK+R3l+Q1LIHrcR+Knhk0rmcSkfFadZ8V+crEGpABf/QUQRg7NkZMsoe814tfBO5F7tMxo8wwwSdaVNNHtoRA==",
+      "version": "3.354.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.354.0.tgz",
+      "integrity": "sha512-2xkblZS3PGxxh//0lgCwJw2gvh9ZBcI9H9xv05YP7hcwlz9BmkAlbei2i6Uew6agJMLO4unfgWoBTpzp3WLaKg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.354.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-utf8": {
-      "version": "3.254.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
-      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -19971,21 +18923,21 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.272.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.272.0.tgz",
-      "integrity": "sha512-N25/XsJ2wkPh1EgkFyb/GRgfHDityScfD49Hk1AwJWpfetzgkcEtWdeW4IuPymXlSKhrm5L+SBw49USxo9kBag==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.347.0.tgz",
+      "integrity": "sha512-3ze/0PkwkzUzLncukx93tZgGL0JX9NaP8DxTi6WzflnL/TEul5Z63PCruRNK0om17iZYAWKrf8q2mFoHYb4grA==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.272.0",
-        "@aws-sdk/types": "3.272.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/xml-builder": {
-      "version": "3.201.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
-      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
       "requires": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "@babel/code-frame": {
@@ -22483,6 +21435,23 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "@smithy/protocol-http": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.1.0.tgz",
+      "integrity": "sha512-H5y/kZOqfJSqRkwtcAoVbqONmhdXwSgYNJ1Glk5Ry8qlhVVy5qUzD9EklaCH8/XLnoCsLO/F/Giee8MIvaBRkg==",
+      "requires": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-KzmvisMmuwD2jZXuC9e65JrgsZM97y5NpDU7g347oB+Q+xQLU6hQZ5zFNNbEfwwOJHoOvEVTna+dk1h/lW7alw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -25577,9 +24546,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
       "requires": {
         "strnum": "^1.0.5"
       }


### PR DESCRIPTION
# Overview

### What is the feature?

updates sub-dependencies to address ReDos reported for fast-xml-parser

### What is the Solution?

ran npm audit fix

### What areas of the application does this impact?

cmr-graphql

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1.  npm audit

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
