### PR TITLE
EDSC-3895: Include conceptId in subqueries if necessary

### DIFF
--- a/src/utils/__tests__/parseRequestedFields.test.js
+++ b/src/utils/__tests__/parseRequestedFields.test.js
@@ -643,4 +643,58 @@ describe('parseRequestedFields', () => {
       })
     })
   })
+
+  describe('when collections are requested from within a tool without conceptId', () => {
+    test('requestedFields includes conceptId', () => {
+      const requestInfo = {
+        name: 'tools',
+        alias: 'tools',
+        args: {},
+        fieldsByTypeName: {
+          ToolList: {
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Tool: {
+                  type: {
+                    name: 'type',
+                    alias: 'type',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  collections: {
+                    name: 'collections',
+                    alias: 'collections',
+                    args: {},
+                    fieldsByTypeName: {
+                      CollectionList: {
+                        count: {
+                          name: 'count',
+                          alias: 'count',
+                          args: {},
+                          fieldsByTypeName: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const requestedFields = parseRequestedFields(requestInfo, keyMap, 'tool')
+
+      expect(requestedFields).toEqual({
+        jsonKeys: ['type', 'collections', 'conceptId'],
+        metaKeys: [],
+        ummKeys: [],
+        ummKeyMappings,
+        isList: true
+      })
+    })
+  })
 })

--- a/src/utils/__tests__/parseRequestedFields.test.js
+++ b/src/utils/__tests__/parseRequestedFields.test.js
@@ -535,4 +535,112 @@ describe('parseRequestedFields', () => {
       })
     })
   })
+
+  describe('when collections are requested from within a service without conceptId', () => {
+    test('requestedFields includes conceptId', () => {
+      const requestInfo = {
+        name: 'services',
+        alias: 'services',
+        args: {},
+        fieldsByTypeName: {
+          ServiceList: {
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Service: {
+                  type: {
+                    name: 'type',
+                    alias: 'type',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  collections: {
+                    name: 'collections',
+                    alias: 'collections',
+                    args: {},
+                    fieldsByTypeName: {
+                      CollectionList: {
+                        count: {
+                          name: 'count',
+                          alias: 'count',
+                          args: {},
+                          fieldsByTypeName: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const requestedFields = parseRequestedFields(requestInfo, keyMap, 'service')
+
+      expect(requestedFields).toEqual({
+        jsonKeys: ['type', 'collections', 'conceptId'],
+        metaKeys: [],
+        ummKeys: [],
+        ummKeyMappings,
+        isList: true
+      })
+    })
+  })
+
+  describe('when collections are requested from within a variable without conceptId', () => {
+    test('requestedFields includes conceptId', () => {
+      const requestInfo = {
+        name: 'variables',
+        alias: 'variables',
+        args: {},
+        fieldsByTypeName: {
+          VariableList: {
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Variable: {
+                  type: {
+                    name: 'type',
+                    alias: 'type',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  collections: {
+                    name: 'collections',
+                    alias: 'collections',
+                    args: {},
+                    fieldsByTypeName: {
+                      CollectionList: {
+                        count: {
+                          name: 'count',
+                          alias: 'count',
+                          args: {},
+                          fieldsByTypeName: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      const requestedFields = parseRequestedFields(requestInfo, keyMap, 'variable')
+
+      expect(requestedFields).toEqual({
+        jsonKeys: ['type', 'collections', 'conceptId'],
+        metaKeys: [],
+        ummKeys: [],
+        ummKeyMappings,
+        isList: true
+      })
+    })
+  })
 })

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -161,6 +161,32 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
     if (requestedFields.includes('maxItemsPerOrder') && !requestedFields.includes('type')) {
       requestedFields.push('type')
     }
+
+    // If a user has requested collections, from
+    // within a service request the resolver will pull the conceptId and provide
+    // it to the collections request but if a user doesn't explicity ask for the
+    // collection concept id we need to request it
+    if (
+      (
+        requestedFields.includes('collections')
+      )
+       && !requestedFields.includes('conceptId')) {
+      requestedFields.push('conceptId')
+    }
+  }
+
+  if (name === 'variables') {
+    // If a user has requested collections, from
+    // within a variable request the resolver will pull the conceptId and provide
+    // it to the collections request but if a user doesn't explicity ask for the
+    // collection concept id we need to request it
+    if (
+      (
+        requestedFields.includes('collections')
+      )
+       && !requestedFields.includes('conceptId')) {
+      requestedFields.push('conceptId')
+    }
   }
 
   const { sharedKeys = [], ummKeyMappings } = keyMap

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -189,6 +189,20 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
     }
   }
 
+  if (name === 'tools') {
+    // If a user has requested collections, from
+    // within a tool request the resolver will pull the conceptId and provide
+    // it to the collections request but if a user doesn't explicity ask for the
+    // collection concept id we need to request it
+    if (
+      (
+        requestedFields.includes('collections')
+      )
+       && !requestedFields.includes('conceptId')) {
+      requestedFields.push('conceptId')
+    }
+  }
+
   const { sharedKeys = [], ummKeyMappings } = keyMap
 
   // Gather keys that the user requested that only exist in umm


### PR DESCRIPTION
# Overview

### What is the feature?

When requesting collections as a subquery of other concepts, specifically services and variables, we need to include the parent concept's `conceptId` as a requested field, even if the user did not request that field. This ensures the sub query has the required fields to query collections.

### What is the Solution?

Added `conceptId` as a requestedField when it doesn't exist for services and variables that are requesting collections

### What areas of the application does this impact?

Services and Variables queries with a collections sub query

# Testing

Using this query will result in all the collections being returned, because the query does not request the service's conceptId. This PR forces the conceptId to be included, so the correct collections are returned.
```
query Services($serviceParams: ServicesInput) {
  services(params: $serviceParams) {
    items {
      name
      collections {
        count
        items {
          conceptId
          shortName
        }
      }
    }
  }
}
```

Variables:
In PROD
```
{
  "serviceParams": {
    "conceptId": "S1962070864-POCLOUD"
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
