### PR TITLE
CMR-9489: Bumping the UMM-S record to add "Aggregation" field

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ provider:
     # Pinned UMM versions
     ummCollectionVersion: '1.17.2'
     ummGranuleVersion: '1.5'
-    ummServiceVersion: '1.3.4'
+    ummServiceVersion: '1.5.2'
     ummSubscriptionVersion: '1.1'
     ummToolVersion: '1.1'
     ummVariableVersion: '1.9.0'


### PR DESCRIPTION
…on field"

# Overview

### What is the feature?

We need to add the "Aggregation" for the service concept into `cmr-graphql` This field is contained on the service v1.5.2 (https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/service/v1.5.2)

"Aggregation is JSON field" which is a child of the `serviceOptions` field.


### What is the Solution?

Update the UMM-S version being queried from CMR to v1.5.2

### What areas of the application does this impact?

UMM-S/service queries

# Testing

### Reproduction steps

Query for a services which contains the aggregation field such as `S1200463978-CMR_ONLY` in the SIT env

### Attachments

N/A

# Checklist

- [n/a] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
