### PR TITLE
MMT-3408: Adds mutations and queries for draft concepts

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,11 +33,6 @@ provider:
     ummToolVersion: '1.1'
     ummVariableVersion: '1.9.0'
 
-    ummCollectionDraftVersion: '1.0.0'
-    ummServiceDraftVersion: '1.0.0'
-    ummToolDraftVersion: '1.0.0'
-    ummVariableDraftVersion: '1.0.0'
-
   vpc:
     securityGroupIds:
       - Fn::ImportValue: ${self:provider.stage}-GraphQLLambdaSecurityGroup
@@ -59,7 +54,7 @@ plugins:
   - serverless-offline
   - serverless-plugin-log-subscription
   - serverless-python-requirements
-  
+
 functions:
   graphql:
     handler: src/graphql/handler.default

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,11 @@ provider:
     ummToolVersion: '1.1'
     ummVariableVersion: '1.9.0'
 
+    ummCollectionDraftVersion: '1.0.0'
+    ummServiceDraftVersion: '1.0.0'
+    ummToolDraftVersion: '1.0.0'
+    ummVariableDraftVersion: '1.0.0'
+
   vpc:
     securityGroupIds:
       - Fn::ImportValue: ${self:provider.stage}-GraphQLLambdaSecurityGroup

--- a/src/cmr/concepts/__tests__/concept.test.js
+++ b/src/cmr/concepts/__tests__/concept.test.js
@@ -1,20 +1,10 @@
 import Concept from '../concept'
 
 describe('collection', () => {
-  const OLD_ENV = process.env
-
   beforeEach(() => {
     jest.resetAllMocks()
 
     jest.restoreAllMocks()
-
-    process.env = { ...OLD_ENV }
-
-    process.env.cmrRootUrl = 'http://example.com'
-  })
-
-  afterEach(() => {
-    process.env = OLD_ENV
   })
 
   describe('concept', () => {

--- a/src/cmr/concepts/__tests__/draft.test.js
+++ b/src/cmr/concepts/__tests__/draft.test.js
@@ -1,20 +1,10 @@
 import Draft from '../draft'
 
 describe('Draft concept', () => {
-  const OLD_ENV = process.env
-
   beforeEach(() => {
     jest.resetAllMocks()
 
     jest.restoreAllMocks()
-
-    process.env = { ...OLD_ENV }
-
-    process.env.cmrRootUrl = 'http://example.com'
-  })
-
-  afterEach(() => {
-    process.env = OLD_ENV
   })
 
   describe('Draft concept', () => {

--- a/src/cmr/concepts/__tests__/draft.test.js
+++ b/src/cmr/concepts/__tests__/draft.test.js
@@ -11,10 +11,6 @@ describe('Draft concept', () => {
     process.env = { ...OLD_ENV }
 
     process.env.cmrRootUrl = 'http://example.com'
-    process.env.ummCollectionDraftVersion = '1.0.0'
-    process.env.ummServiceDraftVersion = '1.0.0'
-    process.env.ummToolDraftVersion = '1.0.0'
-    process.env.ummVariableDraftVersion = '1.0.0'
   })
 
   afterEach(() => {
@@ -25,7 +21,10 @@ describe('Draft concept', () => {
     describe('constructor', () => {
       describe('when the conceptType is collection-drafts', () => {
         test('sets the ingestPath and metadataSpecification correctly', () => {
-          const draft = new Draft('collection-drafts', {}, {}, { providerId: 'EDSC' })
+          const draft = new Draft('collection-drafts', {}, {}, {
+            providerId: 'EDSC',
+            ummVersion: '1.0.0'
+          })
 
           expect(draft.ingestPath).toEqual('providers/EDSC/collection-drafts')
           expect(draft.metadataSpecification).toEqual({
@@ -38,7 +37,10 @@ describe('Draft concept', () => {
 
       describe('when the conceptType is service-drafts', () => {
         test('sets the ingestPath and metadataSpecification correctly', () => {
-          const draft = new Draft('service-drafts', {}, {}, { providerId: 'EDSC' })
+          const draft = new Draft('service-drafts', {}, {}, {
+            providerId: 'EDSC',
+            ummVersion: '1.0.0'
+          })
 
           expect(draft.ingestPath).toEqual('providers/EDSC/service-drafts')
           expect(draft.metadataSpecification).toEqual({
@@ -51,7 +53,10 @@ describe('Draft concept', () => {
 
       describe('when the conceptType is tool-drafts', () => {
         test('sets the ingestPath and metadataSpecification correctly', () => {
-          const draft = new Draft('tool-drafts', {}, {}, { providerId: 'EDSC' })
+          const draft = new Draft('tool-drafts', {}, {}, {
+            providerId: 'EDSC',
+            ummVersion: '1.0.0'
+          })
 
           expect(draft.ingestPath).toEqual('providers/EDSC/tool-drafts')
           expect(draft.metadataSpecification).toEqual({
@@ -64,26 +69,16 @@ describe('Draft concept', () => {
 
       describe('when the conceptType is variable-drafts', () => {
         test('sets the ingestPath and metadataSpecification correctly', () => {
-          const draft = new Draft('variable-drafts', {}, {}, { providerId: 'EDSC' })
+          const draft = new Draft('variable-drafts', {}, {}, {
+            providerId: 'EDSC',
+            ummVersion: '1.0.0'
+          })
 
           expect(draft.ingestPath).toEqual('providers/EDSC/variable-drafts')
           expect(draft.metadataSpecification).toEqual({
             Name: 'variable-draft',
             URL: 'https://cdn.earthdata.nasa.gov/umm/variable-draft/v1.0.0',
             Version: '1.0.0'
-          })
-        })
-      })
-
-      describe('when the conceptType is and unknown draft', () => {
-        test('sets the ingestPath and metadataSpecification correctly', () => {
-          const draft = new Draft('bad-drafts', {}, {}, { providerId: 'EDSC' })
-
-          expect(draft.ingestPath).toEqual('providers/EDSC/bad-drafts')
-          expect(draft.metadataSpecification).toEqual({
-            Name: 'bad-draft',
-            URL: 'https://cdn.earthdata.nasa.gov/umm/bad-draft/vundefined',
-            Version: undefined
           })
         })
       })

--- a/src/cmr/concepts/__tests__/draft.test.js
+++ b/src/cmr/concepts/__tests__/draft.test.js
@@ -1,0 +1,92 @@
+import Draft from '../draft'
+
+describe('Draft concept', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example.com'
+    process.env.ummCollectionDraftVersion = '1.0.0'
+    process.env.ummServiceDraftVersion = '1.0.0'
+    process.env.ummToolDraftVersion = '1.0.0'
+    process.env.ummVariableDraftVersion = '1.0.0'
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('Draft concept', () => {
+    describe('constructor', () => {
+      describe('when the conceptType is collection-drafts', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('collection-drafts', {}, {}, { providerId: 'EDSC' })
+
+          expect(draft.ingestPath).toEqual('providers/EDSC/collection-drafts')
+          expect(draft.metadataSpecification).toEqual({
+            Name: 'collection-draft',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/collection-draft/v1.0.0',
+            Version: '1.0.0'
+          })
+        })
+      })
+
+      describe('when the conceptType is service-drafts', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('service-drafts', {}, {}, { providerId: 'EDSC' })
+
+          expect(draft.ingestPath).toEqual('providers/EDSC/service-drafts')
+          expect(draft.metadataSpecification).toEqual({
+            Name: 'service-draft',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/service-draft/v1.0.0',
+            Version: '1.0.0'
+          })
+        })
+      })
+
+      describe('when the conceptType is tool-drafts', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('tool-drafts', {}, {}, { providerId: 'EDSC' })
+
+          expect(draft.ingestPath).toEqual('providers/EDSC/tool-drafts')
+          expect(draft.metadataSpecification).toEqual({
+            Name: 'tool-draft',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/tool-draft/v1.0.0',
+            Version: '1.0.0'
+          })
+        })
+      })
+
+      describe('when the conceptType is variable-drafts', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('variable-drafts', {}, {}, { providerId: 'EDSC' })
+
+          expect(draft.ingestPath).toEqual('providers/EDSC/variable-drafts')
+          expect(draft.metadataSpecification).toEqual({
+            Name: 'variable-draft',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/variable-draft/v1.0.0',
+            Version: '1.0.0'
+          })
+        })
+      })
+
+      describe('when the conceptType is and unknown draft', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('bad-drafts', {}, {}, { providerId: 'EDSC' })
+
+          expect(draft.ingestPath).toEqual('providers/EDSC/bad-drafts')
+          expect(draft.metadataSpecification).toEqual({
+            Name: 'bad-draft',
+            URL: 'https://cdn.earthdata.nasa.gov/umm/bad-draft/vundefined',
+            Version: undefined
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/cmr/concepts/__tests__/service.test.js
+++ b/src/cmr/concepts/__tests__/service.test.js
@@ -1,20 +1,10 @@
 import Service from '../service'
 
 describe('Service concept', () => {
-  const OLD_ENV = process.env
-
   beforeEach(() => {
     jest.resetAllMocks()
 
     jest.restoreAllMocks()
-
-    process.env = { ...OLD_ENV }
-
-    process.env.cmrRootUrl = 'http://example.com'
-  })
-
-  afterEach(() => {
-    process.env = OLD_ENV
   })
 
   describe('Service concept', () => {

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -651,9 +651,20 @@ export default class Concept {
         // path we've defined above
         let keyValue = get(item, ummKeyMappings[ummKey])
 
-        // If the UMM Key is `draftMetadata`, we need to combine the `meta` and `umm` fields
-        // This ensures all the keys are available for the DraftMetadata union type
-        if (ummKey === 'draftMetadata') {
+        // If the raw `ummMetadata` was requested return that value unaltered
+        if (ummKey === 'ummMetadata') {
+          this.setItemValue(
+            conceptId,
+            ummKey,
+            keyValue
+          )
+
+          return
+        }
+
+        // If the UMM Key is `previewMetadata`, we need to combine the `meta` and `umm` fields
+        // This ensures all the keys are available for the PreviewMetadata union type
+        if (ummKey === 'previewMetadata') {
           keyValue = {
             ...item.umm,
             ...item.meta

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -649,7 +649,16 @@ export default class Concept {
       ummKeys.forEach((ummKey) => {
         // Use lodash.get to retrieve a value from the umm response given the
         // path we've defined above
-        const keyValue = get(item, ummKeyMappings[ummKey])
+        let keyValue = get(item, ummKeyMappings[ummKey])
+
+        // If the UMM Key is `draftMetadata`, we need to combine the `meta` and `umm` fields
+        // This ensures all the keys are available for the DraftMetadata union type
+        if (ummKey === 'draftMetadata') {
+          keyValue = {
+            ...item.umm,
+            ...item.meta
+          }
+        }
 
         if (keyValue != null) {
           const camelCasedObject = camelcaseKeys({ [ummKey]: keyValue }, { deep: true })

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -14,32 +14,10 @@ export default class Draft extends Concept {
     super(conceptType, headers, requestInfo, params)
 
     const singularConceptType = conceptType.replace('drafts', 'draft')
-    const { providerId } = params
-
     const {
-      ummCollectionDraftVersion,
-      ummServiceDraftVersion,
-      ummToolDraftVersion,
-      ummVariableDraftVersion
-    } = process.env
-
-    let ummVersion
-    switch (conceptType) {
-      case 'collection-drafts':
-        ummVersion = ummCollectionDraftVersion
-        break
-      case 'service-drafts':
-        ummVersion = ummServiceDraftVersion
-        break
-      case 'tool-drafts':
-        ummVersion = ummToolDraftVersion
-        break
-      case 'variable-drafts':
-        ummVersion = ummVariableDraftVersion
-        break
-      default:
-        break
-    }
+      providerId,
+      ummVersion
+    } = params
 
     this.ingestPath = `providers/${providerId}/${conceptType}`
     this.metadataSpecification = {
@@ -106,9 +84,16 @@ export default class Draft extends Concept {
    * @param {Object} headers Headers requested by the query
    */
   fetchUmm(searchParams, ummKeys, headers) {
+    const { ummVersion } = searchParams
+
+    let acceptVersion
+    if (ummVersion) {
+      acceptVersion = `version=${ummVersion}`
+    }
+
     const ummHeaders = {
       ...headers,
-      Accept: `application/vnd.nasa.cmr.umm_results+json; version=${process.env.ummToolDraftVersion}`
+      Accept: `application/vnd.nasa.cmr.umm_results+json; ${acceptVersion}`
     }
 
     return super.fetchUmm(searchParams, ummKeys, ummHeaders)
@@ -121,10 +106,11 @@ export default class Draft extends Concept {
    * @param {Object} providedHeaders Headers requested by the query
    */
   ingest(data, requestedKeys, providedHeaders) {
+    const { ummVersion } = data
     // Default headers
     const defaultHeaders = {
       Accept: 'application/json',
-      'Content-Type': `application/vnd.nasa.cmr.umm+json; version=${process.env.ummToolDraftVersion}`
+      'Content-Type': `application/vnd.nasa.cmr.umm+json; version=${ummVersion}`
     }
 
     // Merge default headers into the provided headers and then pick out only permitted values

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -107,6 +107,11 @@ export default class Draft extends Concept {
    */
   ingest(data, requestedKeys, providedHeaders) {
     const { ummVersion } = data
+
+    if (!ummVersion) {
+      throw new Error('`ummVersion` is required when ingesting drafts.')
+    }
+
     // Default headers
     const defaultHeaders = {
       Accept: 'application/json',

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -67,9 +67,10 @@ export default class Draft extends Concept {
   getPermittedJsonSearchParams() {
     return [
       ...super.getPermittedJsonSearchParams(),
-      'provider',
-      'type'
-      // TODO update these
+      'name',
+      'native_id',
+      'options',
+      'provider'
     ]
   }
 
@@ -79,9 +80,10 @@ export default class Draft extends Concept {
   getPermittedUmmSearchParams() {
     return [
       ...super.getPermittedUmmSearchParams(),
-      'provider',
-      'type'
-      // TODO update these
+      'name',
+      'native_id',
+      'options',
+      'provider'
     ]
   }
 
@@ -91,7 +93,9 @@ export default class Draft extends Concept {
   getNonIndexedKeys() {
     return uniq([
       ...super.getNonIndexedKeys(),
-      'collection_concept_id'
+      'name',
+      'native_id',
+      'provider'
     ])
   }
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -22,3 +22,13 @@ export const CONCEPT_TYPES = [
 export const PSEUDO_FIELDS = [
   'maxItemsPerOrder'
 ]
+
+/**
+ * Draft concept ID prefixes
+ */
+export const DRAFT_CONCEPT_ID_PREFIXES = {
+  collection: 'CD',
+  service: 'SD',
+  tool: 'TD',
+  variable: 'VD'
+}

--- a/src/datasources/__tests__/collection.test.js
+++ b/src/datasources/__tests__/collection.test.js
@@ -14,7 +14,7 @@ describe('collection', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -101,7 +101,7 @@ describe('collection', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -118,7 +118,7 @@ describe('collection', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -165,7 +165,7 @@ describe('collection', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -182,7 +182,7 @@ describe('collection', () => {
             }
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -227,7 +227,7 @@ describe('collection', () => {
 
   describe('without params', () => {
     test('returns the parsed collection results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -261,7 +261,7 @@ describe('collection', () => {
 
   describe('with params', () => {
     test('returns the parsed collection results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -359,7 +359,7 @@ describe('collection', () => {
     })
 
     test('returns the parsed collection results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -375,7 +375,7 @@ describe('collection', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -468,7 +468,7 @@ describe('collection', () => {
     })
 
     test('returns the parsed collection results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -485,7 +485,7 @@ describe('collection', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -567,7 +567,7 @@ describe('collection', () => {
     })
 
     test('returns the parsed collection results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -619,7 +619,7 @@ describe('collection', () => {
   })
 
   test('catches errors received from queryCmrCollections', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/collections/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/collectionDraft.test.js
+++ b/src/datasources/__tests__/collectionDraft.test.js
@@ -75,8 +75,8 @@ describe('collectionDraft', () => {
   })
 
   test('catches errors received from mmtQuery', async () => {
-    nock(/example-mmt/)
-      .get(/api\/drafts/)
+    nock(/example/)
+      .get(/api\/collection_drafts/)
       .reply(500, {
         errors: ['HTTP Error']
       }, {

--- a/src/datasources/__tests__/collectionDraftProposal.test.js
+++ b/src/datasources/__tests__/collectionDraftProposal.test.js
@@ -14,7 +14,7 @@ describe('collectionDraftProposal', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.draftMmtRootUrl = 'http://example.com'
+    process.env.draftMmtRootUrl = 'http://example-dmmt.com'
     process.env.dmmtSslCert = '-----BEGIN CERTIFICATE-----\nmock-certificate\n-----END CERTIFICATE-----'
 
     // Default requestInfo
@@ -46,7 +46,7 @@ describe('collectionDraftProposal', () => {
   })
 
   test('returns the collection draft proposal results', async () => {
-    nock(/example/)
+    nock(/example-dmmt/)
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -74,7 +74,7 @@ describe('collectionDraftProposal', () => {
   })
 
   test('catches errors received from draftMmtQuery', async () => {
-    nock(/example/)
+    nock(/example-dmmt/)
       .get(/api\/collection_draft_proposals/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/dataQualitySummary.test.js
+++ b/src/datasources/__tests__/dataQualitySummary.test.js
@@ -14,7 +14,7 @@ describe('dataQualitySummary', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('dataQualitySummary', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('dataQualitySummary', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('dataQualitySummary', () => {
 
   describe('without params', () => {
     test('returns the parsed data-quality-summary results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('dataQualitySummary', () => {
 
   describe('with params', () => {
     test('returns the parsed dataQuality summary results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -263,7 +263,7 @@ describe('dataQualitySummary', () => {
     })
 
     test('returns the parsed dataQualitySummary results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -303,7 +303,7 @@ describe('dataQualitySummary', () => {
   })
 
   test('catches errors received from querying CMR for dataQualitySummaries', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/data-quality-summaries/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/draft.test.js
+++ b/src/datasources/__tests__/draft.test.js
@@ -20,7 +20,7 @@ describe('draft#fetch', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -95,7 +95,7 @@ describe('draft#fetch', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -133,7 +133,7 @@ describe('draft#fetch', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -173,7 +173,7 @@ describe('draft#fetch', () => {
 
   describe('without params', () => {
     test('returns the parsed draft results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -209,7 +209,7 @@ describe('draft#fetch', () => {
 
   describe('with params', () => {
     test('returns the parsed draft results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -274,7 +274,7 @@ describe('draft#fetch', () => {
     })
 
     test('returns the parsed draft results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -314,7 +314,7 @@ describe('draft#fetch', () => {
   })
 
   test('catches errors received from queryCmrDrafts', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/drafts/)
       .reply(500, {
         errors: ['HTTP Error']
@@ -347,17 +347,18 @@ describe('draft#ingest', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
       name: 'createDraft',
       alias: 'createDraft',
       args: {
-        collectionConceptId: 'C100000-EDSC',
-        name: 'Test Draft',
-        query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
-        subscriberId: 'testuser'
+        conceptType: 'Tool',
+        metadata: {},
+        nativeId: 'test-guid',
+        providerId: 'EDSC',
+        ummVersion: '1.0.0'
       },
       fieldsByTypeName: {
         DraftMutationResponse: {
@@ -383,7 +384,7 @@ describe('draft#ingest', () => {
   })
 
   test('returns the parsed draft results', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .defaultReplyHeaders({
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -397,7 +398,8 @@ describe('draft#ingest', () => {
       conceptType: 'Tool',
       metadata: {},
       nativeId: 'test-guid',
-      providerId: 'EDSC'
+      providerId: 'EDSC',
+      ummVersion: '1.0.0'
     }, {
       headers: {
         'Client-Id': 'eed-test-graphql',
@@ -411,8 +413,24 @@ describe('draft#ingest', () => {
     })
   })
 
+  test('throws an error if ummVersion is not present', async () => {
+    await expect(
+      draftSourceIngest({
+        conceptType: 'Tool',
+        metadata: {},
+        nativeId: 'test-guid',
+        providerId: 'EDSC'
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(new Error('`ummVersion` is required when ingesting drafts.'))
+  })
+
   test('catches errors received from ingestCmr', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .put(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
       .reply(500, {
         errors: ['HTTP Error']
@@ -425,7 +443,8 @@ describe('draft#ingest', () => {
         conceptType: 'Tool',
         metadata: {},
         nativeId: 'test-guid',
-        providerId: 'EDSC'
+        providerId: 'EDSC',
+        ummVersion: '1.0.0'
       }, {
         headers: {
           'Client-Id': 'eed-test-graphql',
@@ -446,7 +465,7 @@ describe('draft#delete', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -480,7 +499,7 @@ describe('draft#delete', () => {
   })
 
   test('returns the parsed draft results', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .defaultReplyHeaders({
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -508,7 +527,7 @@ describe('draft#delete', () => {
   })
 
   test('catches errors received from cmrDelete', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .delete(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/draft.test.js
+++ b/src/datasources/__tests__/draft.test.js
@@ -1,0 +1,532 @@
+import nock from 'nock'
+
+jest.mock('uuid', () => ({ v4: () => '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' }))
+
+import {
+  deleteDraft as draftSourceDelete,
+  fetchDrafts as draftSourceFetch,
+  ingestDraft as draftSourceIngest
+} from '../draft'
+
+let requestInfo
+
+describe('draft#fetch', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'drafts',
+      alias: 'drafts',
+      args: {},
+      fieldsByTypeName: {
+        DraftList: {
+          items: {
+            name: 'items',
+            alias: 'items',
+            args: {},
+            fieldsByTypeName: {
+              Draft: {
+                conceptId: {
+                  name: 'conceptId',
+                  alias: 'conceptId',
+                  args: {},
+                  fieldsByTypeName: {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('cursor', () => {
+    beforeEach(() => {
+      // Overwrite default requestInfo
+      requestInfo = {
+        name: 'drafts',
+        alias: 'drafts',
+        args: {},
+        fieldsByTypeName: {
+          DraftList: {
+            cursor: {
+              name: 'cursor',
+              alias: 'cursor',
+              args: {},
+              fieldsByTypeName: {}
+            },
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Draft: {
+                  conceptId: {
+                    name: 'conceptId',
+                    alias: 'conceptId',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  name: {
+                    name: 'name',
+                    alias: 'name',
+                    args: {},
+                    fieldsByTypeName: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('returns a cursor', async () => {
+      nock(/example/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678',
+          'CMR-Search-After': '["xyz", 789, 999]'
+        })
+        .post(/tool-drafts\.json/)
+        .reply(200, {
+          items: [{
+            concept_id: 'TD100000-EDSC',
+            name: 'Mock Name'
+          }]
+        })
+
+      const response = await draftSourceFetch({
+        params: {
+          conceptType: 'Tool'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: 'eyJqc29uIjoiW1wieHl6XCIsIDc4OSwgOTk5XSJ9',
+        items: [{
+          conceptId: 'TD100000-EDSC',
+          name: 'Mock Name'
+        }]
+      })
+    })
+
+    describe('when a cursor is requested', () => {
+      test('requests a cursor', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678',
+            'CMR-Search-After': '["xyz", 789, 999]'
+          })
+          .post(/tool-drafts\.json/)
+          .reply(200, {
+            items: [{
+              concept_id: 'TD100000-EDSC',
+              name: 'Mock Name'
+            }]
+          })
+
+        const response = await draftSourceFetch({
+          params: {
+            conceptType: 'Tool'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: 'eyJqc29uIjoiW1wieHl6XCIsIDc4OSwgOTk5XSJ9',
+          items: [{
+            conceptId: 'TD100000-EDSC',
+            name: 'Mock Name'
+          }]
+        })
+      })
+    })
+  })
+
+  describe('without params', () => {
+    test('returns the parsed draft results', async () => {
+      nock(/example/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .post(/tool-drafts\.json/)
+        .reply(200, {
+          items: [{
+            concept_id: 'TD100000-EDSC'
+          }]
+        })
+
+      const response = await draftSourceFetch({
+        params: {
+          conceptType: 'Tool'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          conceptId: 'TD100000-EDSC'
+        }]
+      })
+    })
+  })
+
+  describe('with params', () => {
+    test('returns the parsed draft results', async () => {
+      nock(/example/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .post(/tool-drafts\.json/, 'concept_id=TD100000-EDSC')
+        .reply(200, {
+          items: [{
+            concept_id: 'TD100000-EDSC'
+          }]
+        })
+
+      const response = await draftSourceFetch({
+        params: {
+          conceptType: 'Tool',
+          conceptId: 'TD100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          conceptId: 'TD100000-EDSC'
+        }]
+      })
+    })
+  })
+
+  describe('with only umm keys', () => {
+    beforeEach(() => {
+      // Overwrite default requestInfo
+      requestInfo = {
+        name: 'drafts', // TODO What is this supposed to be?
+        alias: 'drafts',
+        args: {},
+        fieldsByTypeName: {
+          DraftList: {
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Draft: {
+                  deleted: {
+                    name: 'deleted',
+                    alias: 'deleted',
+                    args: {},
+                    fieldsByTypeName: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('returns the parsed draft results', async () => {
+      nock(/example/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .post(/drafts\.umm_json/)
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'TD100000-EDSC',
+              deleted: false
+            },
+            umm: {}
+          }]
+        })
+
+      const response = await draftSourceFetch({
+        params: {
+          conceptId: 'TD100000-EDSC',
+          conceptType: 'Tool'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          deleted: false
+        }]
+      })
+    })
+  })
+
+  test('catches errors received from queryCmrDrafts', async () => {
+    nock(/example/)
+      .post(/drafts/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      draftSourceFetch({
+        params: {
+          conceptId: 'TD100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})
+
+describe('draft#ingest', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'createDraft',
+      alias: 'createDraft',
+      args: {
+        collectionConceptId: 'C100000-EDSC',
+        name: 'Test Draft',
+        query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
+        subscriberId: 'testuser'
+      },
+      fieldsByTypeName: {
+        DraftMutationResponse: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          revisionId: {
+            name: 'revisionId',
+            alias: 'revisionId',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  test('returns the parsed draft results', async () => {
+    nock(/example/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .put(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
+      .reply(201, {
+        'concept-id': 'TD100000-EDSC',
+        'revision-id': '1'
+      })
+
+    const response = await draftSourceIngest({
+      conceptType: 'Tool',
+      metadata: {},
+      nativeId: 'test-guid',
+      providerId: 'EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'TD100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
+  test('catches errors received from ingestCmr', async () => {
+    nock(/example/)
+      .put(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      draftSourceIngest({
+        conceptType: 'Tool',
+        metadata: {},
+        nativeId: 'test-guid',
+        providerId: 'EDSC'
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})
+
+describe('draft#delete', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'deleteDraft',
+      alias: 'deleteDraft',
+      args: {
+        conceptId: 'TD100000-EDSC',
+        nativeId: 'test-guid'
+      },
+      fieldsByTypeName: {
+        DraftMutationResponse: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          revisionId: {
+            name: 'revisionId',
+            alias: 'revisionId',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  test('returns the parsed draft results', async () => {
+    nock(/example/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .delete(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
+      .reply(201, {
+        'concept-id': 'TD100000-EDSC',
+        'revision-id': '1'
+      })
+
+    const response = await draftSourceDelete({
+      conceptType: 'Tool',
+      nativeId: 'test-guid',
+      providerId: 'EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'TD100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
+  test('catches errors received from cmrDelete', async () => {
+    nock(/example/)
+      .delete(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      draftSourceDelete({
+        conceptType: 'Tool',
+        nativeId: 'test-guid',
+        providerId: 'EDSC'
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})

--- a/src/datasources/__tests__/draft.test.js
+++ b/src/datasources/__tests__/draft.test.js
@@ -248,7 +248,7 @@ describe('draft#fetch', () => {
     beforeEach(() => {
       // Overwrite default requestInfo
       requestInfo = {
-        name: 'drafts', // TODO What is this supposed to be?
+        name: 'drafts',
         alias: 'drafts',
         args: {},
         fieldsByTypeName: {

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -14,7 +14,7 @@ describe('granule', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -95,7 +95,7 @@ describe('granule', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -112,7 +112,7 @@ describe('granule', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -153,7 +153,7 @@ describe('granule', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -170,7 +170,7 @@ describe('granule', () => {
             }
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -211,7 +211,7 @@ describe('granule', () => {
 
   describe('without params', () => {
     test('returns the parsed granule results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -245,7 +245,7 @@ describe('granule', () => {
 
   describe('with params', () => {
     test('returns the parsed granule results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -311,7 +311,7 @@ describe('granule', () => {
     })
 
     test('returns filtered links', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -322,19 +322,19 @@ describe('granule', () => {
           feed: {
             entry: [{
               links: [{
-                href: 'https://example.com/data_link',
+                href: 'https://example-cmr.com/data_link',
                 hreflang: 'en-US',
-                rel: 'https://example.com/data#',
+                rel: 'https://example-cmr.com/data#',
                 type: 'application/x-hdf5'
               }, {
-                href: 'https://example.com/metadata_link',
+                href: 'https://example-cmr.com/metadata_link',
                 hreflang: 'en-US',
-                rel: 'https://example.com/metadata#',
+                rel: 'https://example-cmr.com/metadata#',
                 type: 'application/x-hdf5'
               }, {
-                href: 'https://example.com/s3_link',
+                href: 'https://example-cmr.com/s3_link',
                 hreflang: 'en-US',
-                rel: 'https://example.com/s3#',
+                rel: 'https://example-cmr.com/s3#',
                 type: 'application/x-hdf5'
               }]
             }]
@@ -361,14 +361,14 @@ describe('granule', () => {
         cursor: null,
         items: [{
           links: [{
-            href: 'https://example.com/data_link',
+            href: 'https://example-cmr.com/data_link',
             hreflang: 'en-US',
-            rel: 'https://example.com/data#',
+            rel: 'https://example-cmr.com/data#',
             type: 'application/x-hdf5'
           }, {
-            href: 'https://example.com/s3_link',
+            href: 'https://example-cmr.com/s3_link',
             hreflang: 'en-US',
-            rel: 'https://example.com/s3#',
+            rel: 'https://example-cmr.com/s3#',
             type: 'application/x-hdf5'
           }]
         }]
@@ -418,7 +418,7 @@ describe('granule', () => {
     })
 
     test('returns the parsed granule results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -434,7 +434,7 @@ describe('granule', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -511,7 +511,7 @@ describe('granule', () => {
     })
 
     test('returns the parsed granule results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -551,7 +551,7 @@ describe('granule', () => {
   })
 
   test('catches errors received from queryCmrGranules', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/granules/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/grid.test.js
+++ b/src/datasources/__tests__/grid.test.js
@@ -14,7 +14,7 @@ describe('grid', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('grid', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('grid', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('grid', () => {
 
   describe('without params', () => {
     test('returns the parsed grid results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('grid', () => {
 
   describe('with params', () => {
     test('returns the parsed grid results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -263,7 +263,7 @@ describe('grid', () => {
     })
 
     test('returns the parsed grid results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -303,7 +303,7 @@ describe('grid', () => {
   })
 
   test('Catches errors received from queryCmr', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/grids/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/maxItemsPerOrder.test.js
+++ b/src/datasources/__tests__/maxItemsPerOrder.test.js
@@ -12,7 +12,7 @@ describe('maxItemsPerOrder', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -20,7 +20,7 @@ describe('maxItemsPerOrder', () => {
   })
 
   test('returns the maxItemsPerOrder of the service', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -44,7 +44,7 @@ describe('maxItemsPerOrder', () => {
   })
 
   test('returns null if maxItemsPerOrder of the service is null', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -68,7 +68,7 @@ describe('maxItemsPerOrder', () => {
   })
 
   test('Catches errors received from cmrOrdering', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/ordering\/api/)
       .reply(500, {
         errors: ['HTTP Error']
@@ -89,7 +89,7 @@ describe('maxItemsPerOrder', () => {
   })
 
   test('Catches graphql errors received from cmrOrdering', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/ordering\/api/)
       .reply(200, {
         errors: ['graphql error']

--- a/src/datasources/__tests__/orderOption.test.js
+++ b/src/datasources/__tests__/orderOption.test.js
@@ -14,7 +14,7 @@ describe('Order Option', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('Order Option', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('Order Option', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('Order Option', () => {
 
   describe('without params', () => {
     test('returns the parsed orderOption results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('Order Option', () => {
 
   describe('with params', () => {
     test('returns the parsed orderOption results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -263,7 +263,7 @@ describe('Order Option', () => {
     })
 
     test('returns the parsed orderOption results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -303,7 +303,7 @@ describe('Order Option', () => {
   })
 
   test('Catches errors received from queryCmr', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/order-options/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/service.test.js
+++ b/src/datasources/__tests__/service.test.js
@@ -14,7 +14,7 @@ describe('service', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('service', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('service', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('service', () => {
 
   describe('without params', () => {
     test('returns the parsed service results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('service', () => {
 
   describe('with params', () => {
     test('returns the parsed service results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -269,7 +269,7 @@ describe('service', () => {
     })
 
     test('returns the parsed service results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -309,7 +309,7 @@ describe('service', () => {
   })
 
   test('catches errors received from queryCmrServices', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/services/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/serviceDraft.test.js
+++ b/src/datasources/__tests__/serviceDraft.test.js
@@ -14,7 +14,7 @@ describe('serviceDraft', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.mmtRootUrl = 'http://example.com'
+    process.env.mmtRootUrl = 'http://example-mmt.com'
 
     // Default requestInfo
     requestInfo = {
@@ -45,7 +45,7 @@ describe('serviceDraft', () => {
   })
 
   test('return the service draft results', async () => {
-    nock(/example/)
+    nock(/example-mmt/)
       .defaultReplyHeaders({
         'X-Request-Id': 'abcd-1234-efgh-5678'
       })
@@ -75,7 +75,7 @@ describe('serviceDraft', () => {
   })
 
   test('catches errors received from mmtQuery', async () => {
-    nock(/example/)
+    nock(/example-mmt/)
       .get(/api\/service_drafts/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -20,7 +20,7 @@ describe('subscription#fetch', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -95,7 +95,7 @@ describe('subscription#fetch', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -109,7 +109,7 @@ describe('subscription#fetch', () => {
               'concept-id': 'SUB100000-EDSC'
             },
             umm: {
-              EmailAddress: 'test@example.com'
+              EmailAddress: 'test@example-cmr.com'
             }
           }]
         })
@@ -126,14 +126,14 @@ describe('subscription#fetch', () => {
         cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
         items: [{
           conceptId: 'SUB100000-EDSC',
-          emailAddress: 'test@example.com'
+          emailAddress: 'test@example-cmr.com'
         }]
       })
     })
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -147,7 +147,7 @@ describe('subscription#fetch', () => {
                 'concept-id': 'SUB100000-EDSC'
               },
               umm: {
-                EmailAddress: 'test@example.com'
+                EmailAddress: 'test@example-cmr.com'
               }
             }]
           })
@@ -164,7 +164,7 @@ describe('subscription#fetch', () => {
           cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
           items: [{
             conceptId: 'SUB100000-EDSC',
-            emailAddress: 'test@example.com'
+            emailAddress: 'test@example-cmr.com'
           }]
         })
       })
@@ -173,7 +173,7 @@ describe('subscription#fetch', () => {
 
   describe('without params', () => {
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -205,7 +205,7 @@ describe('subscription#fetch', () => {
 
   describe('with params', () => {
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -269,7 +269,7 @@ describe('subscription#fetch', () => {
     })
 
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -282,7 +282,7 @@ describe('subscription#fetch', () => {
               'concept-id': 'SUB100000-EDSC'
             },
             umm: {
-              EmailAddress: 'test@example.com'
+              EmailAddress: 'test@example-cmr.com'
             }
           }]
         })
@@ -302,14 +302,14 @@ describe('subscription#fetch', () => {
         count: 84,
         cursor: null,
         items: [{
-          emailAddress: 'test@example.com'
+          emailAddress: 'test@example-cmr.com'
         }]
       })
     })
   })
 
   test('catches errors received from queryCmrSubscriptions', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/subscriptions/)
       .reply(500, {
         errors: ['HTTP Error']
@@ -342,7 +342,7 @@ describe('subscription#ingest', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -379,7 +379,7 @@ describe('subscription#ingest', () => {
 
   describe('when a native id is not provided', () => {
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
@@ -412,7 +412,7 @@ describe('subscription#ingest', () => {
 
   describe('when a native id is provided', () => {
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
@@ -425,7 +425,7 @@ describe('subscription#ingest', () => {
       const response = await subscriptionSourceIngest({
         params: {
           collectionConceptId: 'C100000-EDSC',
-          emailAddress: 'test@example.com',
+          emailAddress: 'test@example-cmr.com',
           name: 'Test Subscription',
           nativeId: 'test-guid',
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
@@ -446,7 +446,7 @@ describe('subscription#ingest', () => {
   })
 
   test('catches errors received from ingestCmr', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
       .reply(500, {
         errors: ['HTTP Error']
@@ -458,7 +458,7 @@ describe('subscription#ingest', () => {
       subscriptionSourceIngest({
         params: {
           collectionConceptId: 'C100000-EDSC',
-          emailAddress: 'test@example.com',
+          emailAddress: 'test@example-cmr.com',
           name: 'Test Subscription',
           query: 'polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78',
           subscriberId: 'testuser'
@@ -483,7 +483,7 @@ describe('subscription#delete', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -518,7 +518,7 @@ describe('subscription#delete', () => {
 
   describe('when a native id is provided', () => {
     test('returns the parsed subscription results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
@@ -548,7 +548,7 @@ describe('subscription#delete', () => {
   })
 
   test('catches errors received from cmrDelete', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .delete(/ingest\/subscriptions\/test-guid/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/tool.test.js
+++ b/src/datasources/__tests__/tool.test.js
@@ -14,7 +14,7 @@ describe('tool', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('tool', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('tool', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('tool', () => {
 
   describe('without params', () => {
     test('returns the parsed tool results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('tool', () => {
 
   describe('with params', () => {
     test('returns the parsed tool results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -269,7 +269,7 @@ describe('tool', () => {
     })
 
     test('returns the parsed tool results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -309,7 +309,7 @@ describe('tool', () => {
   })
 
   test('catches errors received from queryCmrTools', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/tools/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/__tests__/variable.test.js
+++ b/src/datasources/__tests__/variable.test.js
@@ -14,7 +14,7 @@ describe('variable', () => {
 
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
 
     // Default requestInfo
     requestInfo = {
@@ -89,7 +89,7 @@ describe('variable', () => {
     })
 
     test('returns a cursor', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -127,7 +127,7 @@ describe('variable', () => {
 
     describe('when a cursor is requested', () => {
       test('requests a cursor', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
             'CMR-Took': 7,
@@ -167,7 +167,7 @@ describe('variable', () => {
 
   describe('without params', () => {
     test('returns the parsed variable results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -199,7 +199,7 @@ describe('variable', () => {
 
   describe('with params', () => {
     test('returns the parsed variable results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -269,7 +269,7 @@ describe('variable', () => {
     })
 
     test('returns the parsed variable results', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 84,
           'CMR-Took': 7,
@@ -309,7 +309,7 @@ describe('variable', () => {
   })
 
   test('catches errors received from queryCmrVariables', async () => {
-    nock(/example/)
+    nock(/example-cmr/)
       .post(/variables/)
       .reply(500, {
         errors: ['HTTP Error']

--- a/src/datasources/draft.js
+++ b/src/datasources/draft.js
@@ -14,10 +14,10 @@ export const fetchDrafts = async (args, context, parsedInfo) => {
 
   const requestInfo = parseRequestedFields(parsedInfo, draftKeyMap, 'Draft')
 
-  const draft = new Draft(draftType, headers, requestInfo, params)
+  const draft = new Draft(draftType, headers, requestInfo, args)
 
   // Query CMR
-  draft.fetch(params)
+  draft.fetch(args)
 
   // Parse the response from CMR
   await draft.parse(requestInfo)
@@ -26,10 +26,10 @@ export const fetchDrafts = async (args, context, parsedInfo) => {
   return draft.getFormattedResponse()
 }
 
-export const ingestDraft = async (params, context, parsedInfo) => {
+export const ingestDraft = async (args, context, parsedInfo) => {
   const { headers } = context
 
-  const { conceptType } = params
+  const { conceptType } = args
 
   const draftType = `${conceptType.toLowerCase()}-drafts`
 
@@ -39,10 +39,10 @@ export const ingestDraft = async (params, context, parsedInfo) => {
     ingestKeys
   } = requestInfo
 
-  const draft = new Draft(draftType, headers, requestInfo, params)
+  const draft = new Draft(draftType, headers, requestInfo, args)
 
   // Contact CMR
-  draft.ingest(params, ingestKeys, headers)
+  draft.ingest(args, ingestKeys, headers)
 
   // Parse the response from CMR
   await draft.parseIngest(requestInfo)
@@ -51,10 +51,10 @@ export const ingestDraft = async (params, context, parsedInfo) => {
   return draft.getFormattedIngestResponse()
 }
 
-export const deleteDraft = async (params, context, parsedInfo) => {
+export const deleteDraft = async (args, context, parsedInfo) => {
   const { headers } = context
 
-  const { conceptType } = params
+  const { conceptType } = args
 
   const draftType = `${conceptType.toLowerCase()}-drafts`
 
@@ -64,10 +64,10 @@ export const deleteDraft = async (params, context, parsedInfo) => {
     ingestKeys
   } = requestInfo
 
-  const draft = new Draft(draftType, headers, requestInfo, params)
+  const draft = new Draft(draftType, headers, requestInfo, args)
 
   // Contact CMR
-  draft.delete(params, ingestKeys, headers)
+  draft.delete(args, ingestKeys, headers)
 
   // Parse the response from CMR
   await draft.parseDelete(requestInfo)

--- a/src/datasources/draft.js
+++ b/src/datasources/draft.js
@@ -1,0 +1,77 @@
+import { parseRequestedFields } from '../utils/parseRequestedFields'
+
+import draftKeyMap from '../utils/umm/draftKeyMap.json'
+
+import Draft from '../cmr/concepts/draft'
+
+export const fetchDrafts = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const { params } = args
+  const { conceptType } = params
+
+  const draftType = `${conceptType.toLowerCase()}-drafts`
+
+  const requestInfo = parseRequestedFields(parsedInfo, draftKeyMap, 'Draft')
+
+  const draft = new Draft(draftType, headers, requestInfo, params)
+
+  // Query CMR
+  draft.fetch(params)
+
+  // Parse the response from CMR
+  await draft.parse(requestInfo)
+
+  // Return a formatted JSON response
+  return draft.getFormattedResponse()
+}
+
+export const ingestDraft = async (params, context, parsedInfo) => {
+  const { headers } = context
+
+  const { conceptType } = params
+
+  const draftType = `${conceptType.toLowerCase()}-drafts`
+
+  const requestInfo = parseRequestedFields(parsedInfo, draftKeyMap, 'Draft')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const draft = new Draft(draftType, headers, requestInfo, params)
+
+  // Contact CMR
+  draft.ingest(params, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await draft.parseIngest(requestInfo)
+
+  // Return a formatted JSON response
+  return draft.getFormattedIngestResponse()
+}
+
+export const deleteDraft = async (params, context, parsedInfo) => {
+  const { headers } = context
+
+  const { conceptType } = params
+
+  const draftType = `${conceptType.toLowerCase()}-drafts`
+
+  const requestInfo = parseRequestedFields(parsedInfo, draftKeyMap, 'Draft')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const draft = new Draft(draftType, headers, requestInfo, params)
+
+  // Contact CMR
+  draft.delete(params, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await draft.parseDelete(requestInfo)
+
+  // Return a formatted JSON response
+  return draft.getFormattedDeleteResponse()
+}

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -34,6 +34,12 @@ import {
   ingestSubscription as subscriptionSourceIngest
 } from '../datasources/subscription'
 
+import {
+  deleteDraft as draftSourceDelete,
+  fetchDrafts as draftSourceFetch,
+  ingestDraft as draftSourceIngest
+} from '../datasources/draft'
+
 import { downcaseKeys } from '../utils/downcaseKeys'
 import { verifyEDLJwt } from '../utils/verifyEDLJwt'
 
@@ -111,23 +117,26 @@ export default startServerAndCreateLambdaHandler(
           collectionDraftProposalSource,
           collectionDraftSource,
           collectionSource,
-          dataQualitySummarySource,
           collectionVariableDraftsSource,
+          dataQualitySummarySource,
+          draftSourceDelete,
+          draftSourceFetch,
+          draftSourceIngest,
           granuleSource,
           graphDbDuplicateCollectionsSource,
           graphDbSource,
+          gridSource,
           maxItemsPerOrderSource,
           orderOptionSource,
-          serviceSource,
           serviceDraftSource,
+          serviceSource,
           subscriptionSourceDelete,
           subscriptionSourceFetch,
           subscriptionSourceIngest,
           toolDraftSource,
           toolSource,
-          variableSource,
           variableDraftSource,
-          gridSource
+          variableSource
         },
         headers: requestHeaders,
         collectionLoader: new DataLoader(getCollectionsById, { cacheKeyFn: (obj) => obj.conceptId })

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -25,6 +25,11 @@ import toolSource from '../../../datasources/tool'
 import toolDraftSource from '../../../datasources/toolDraft'
 import variableDraftSource from '../../../datasources/variableDraft'
 import variableSource from '../../../datasources/variable'
+import {
+  deleteDraft as draftSourceDelete,
+  fetchDrafts as draftSourceFetch,
+  ingestDraft as draftSourceIngest
+} from '../../../datasources/draft'
 
 export const server = new ApolloServer({
   typeDefs,
@@ -33,26 +38,29 @@ export const server = new ApolloServer({
 
 export const buildContextValue = (extraContext) => ({
   dataSources: {
-    collectionSource,
-    collectionDraftSource,
     collectionDraftProposalSource,
-    dataQualitySummarySource,
+    collectionDraftSource,
+    collectionSource,
     collectionVariableDraftsSource,
+    dataQualitySummarySource,
+    draftSourceDelete,
+    draftSourceFetch,
+    draftSourceIngest,
     granuleSource,
     graphDbDuplicateCollectionsSource,
     graphDbSource,
     gridSource,
     maxItemsPerOrderSource,
     orderOptionSource,
-    serviceSource,
     serviceDraftSource,
+    serviceSource,
     subscriptionSourceDelete,
     subscriptionSourceFetch,
     subscriptionSourceIngest,
-    toolSource,
     toolDraftSource,
-    variableSource,
-    variableDraftSource
+    toolSource,
+    variableDraftSource,
+    variableSource
   },
   headers: {
     'Client-Id': 'eed-test-graphql',

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -810,7 +810,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     granules {
                       count
@@ -829,11 +829,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 granules: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 granules: null
               }
             }]
@@ -1090,7 +1090,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     services {
                       count
@@ -1109,11 +1109,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 services: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 services: null
               }
             }]
@@ -1244,7 +1244,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     subscriptions {
                       count
@@ -1263,11 +1263,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 subscriptions: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 subscriptions: null
               }
             }]
@@ -1524,7 +1524,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     tools {
                       count
@@ -1543,11 +1543,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 tools: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 tools: null
               }
             }]
@@ -1804,7 +1804,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     variables {
                       count
@@ -1823,11 +1823,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 variables: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 variables: null
               }
             }]
@@ -2074,7 +2074,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     dataQualitySummaries {
                       count
@@ -2093,11 +2093,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 dataQualitySummaries: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 dataQualitySummaries: null
               }
             }]
@@ -2201,7 +2201,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     relatedCollections {
                       count
@@ -2220,11 +2220,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 relatedCollections: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 relatedCollections: null
               }
             }]
@@ -2411,7 +2411,7 @@ describe('Collection', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     duplicateCollections {
                       count
@@ -2430,11 +2430,11 @@ describe('Collection', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 duplicateCollections: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 duplicateCollections: null
               }
             }]

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -587,194 +587,258 @@ describe('Collection', () => {
   })
 
   describe('Collection', () => {
-    test('granules', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/)
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100000-EDSC'
-            }, {
-              id: 'C100001-EDSC'
-            }]
-          }
-        })
+    describe('granules', () => {
+      test('granules', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/)
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100000-EDSC'
+              }, {
+                id: 'C100001-EDSC'
+              }]
+            }
+          })
 
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/granules\.json/, 'page_size=20&collection_concept_id=C100000-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'G100000-EDSC'
-            }, {
-              id: 'G100001-EDSC'
-            }]
-          }
-        })
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/granules\.json/, 'page_size=20&collection_concept_id=C100000-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'G100000-EDSC'
+              }, {
+                id: 'G100001-EDSC'
+              }]
+            }
+          })
 
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/granules\.json/, 'page_size=20&collection_concept_id=C100001-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'G100002-EDSC'
-            }, {
-              id: 'G100003-EDSC'
-            }]
-          }
-        })
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/granules\.json/, 'page_size=20&collection_concept_id=C100001-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'G100002-EDSC'
+              }, {
+                id: 'G100003-EDSC'
+              }]
+            }
+          })
 
-      const response = await server.executeOperation({
-        variables: {},
-        query: `{
-          collections {
-            items {
-              conceptId
-              granules {
-                items {
-                  conceptId
+        const response = await server.executeOperation({
+          variables: {},
+          query: `{
+            collections {
+              items {
+                conceptId
+                granules {
+                  items {
+                    conceptId
+                  }
                 }
               }
             }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          collections: {
+            items: [{
+              conceptId: 'C100000-EDSC',
+              granules: {
+                items: [{
+                  conceptId: 'G100000-EDSC'
+                }, {
+                  conceptId: 'G100001-EDSC'
+                }]
+              }
+            }, {
+              conceptId: 'C100001-EDSC',
+              granules: {
+                items: [{
+                  conceptId: 'G100002-EDSC'
+                }, {
+                  conceptId: 'G100003-EDSC'
+                }]
+              }
+            }]
           }
-        }`
-      }, {
-        contextValue
+        })
       })
 
-      const { data } = response.body.singleResult
-
-      expect(data).toEqual({
-        collections: {
-          items: [{
-            conceptId: 'C100000-EDSC',
-            granules: {
-              items: [{
-                conceptId: 'G100000-EDSC'
+      test('granules with arguments passed from the collection', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/)
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100000-EDSC'
               }, {
-                conceptId: 'G100001-EDSC'
+                id: 'C100001-EDSC'
               }]
             }
-          }, {
-            conceptId: 'C100001-EDSC',
-            granules: {
-              items: [{
-                conceptId: 'G100002-EDSC'
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100000-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'G100000-EDSC'
               }, {
-                conceptId: 'G100003-EDSC'
+                id: 'G100001-EDSC'
               }]
             }
-          }]
-        }
-      })
-    })
+          })
 
-    test('granules with arguments passed from the collection', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/)
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100000-EDSC'
-            }, {
-              id: 'C100001-EDSC'
-            }]
-          }
-        })
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100001-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'G100002-EDSC'
+              }, {
+                id: 'G100003-EDSC'
+              }]
+            }
+          })
 
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100000-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'G100000-EDSC'
-            }, {
-              id: 'G100001-EDSC'
-            }]
-          }
-        })
-
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/granules\.json/, 'page_size=20&bounding_box=-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307&collection_concept_id=C100001-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'G100002-EDSC'
-            }, {
-              id: 'G100003-EDSC'
-            }]
-          }
-        })
-
-      const response = await server.executeOperation({
-        variables: {},
-        query: `{
-          collections(
-            limit:2
-            boundingBox:"-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307"
-          ) {
-            items {
-              conceptId
-              granules {
-                items {
-                  conceptId
+        const response = await server.executeOperation({
+          variables: {},
+          query: `{
+            collections(
+              limit:2
+              boundingBox:"-90.08940124511719,41.746426050239336,-82.33992004394531,47.84755587105307"
+            ) {
+              items {
+                conceptId
+                granules {
+                  items {
+                    conceptId
+                  }
                 }
               }
             }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          collections: {
+            items: [{
+              conceptId: 'C100000-EDSC',
+              granules: {
+                items: [{
+                  conceptId: 'G100000-EDSC'
+                }, {
+                  conceptId: 'G100001-EDSC'
+                }]
+              }
+            }, {
+              conceptId: 'C100001-EDSC',
+              granules: {
+                items: [{
+                  conceptId: 'G100002-EDSC'
+                }, {
+                  conceptId: 'G100003-EDSC'
+                }]
+              }
+            }]
           }
-        }`
-      }, {
-        contextValue
+        })
       })
 
-      const { data } = response.body.singleResult
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
 
-      expect(data).toEqual({
-        collections: {
-          items: [{
-            conceptId: 'C100000-EDSC',
-            granules: {
-              items: [{
-                conceptId: 'G100000-EDSC'
-              }, {
-                conceptId: 'G100001-EDSC'
-              }]
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
             }
-          }, {
-            conceptId: 'C100001-EDSC',
-            granules: {
-              items: [{
-                conceptId: 'G100002-EDSC'
-              }, {
-                conceptId: 'G100003-EDSC'
-              }]
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    granules {
+                      count
+                    }
+                  }
+                }
+              }
             }
-          }]
-        }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                granules: null
+              }
+            }, {
+              draftMetadata: {
+                granules: null
+              }
+            }]
+          }
+        })
       })
     })
 
@@ -994,6 +1058,68 @@ describe('Collection', () => {
           })
         })
       })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    services {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                services: null
+              }
+            }, {
+              draftMetadata: {
+                services: null
+              }
+            }]
+          }
+        })
+      })
     })
 
     describe('subscriptions', () => {
@@ -1081,6 +1207,68 @@ describe('Collection', () => {
                 }, {
                   conceptId: 'SUB100003-EDSC'
                 }]
+              }
+            }]
+          }
+        })
+      })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    subscriptions {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                subscriptions: null
+              }
+            }, {
+              draftMetadata: {
+                subscriptions: null
               }
             }]
           }
@@ -1304,6 +1492,68 @@ describe('Collection', () => {
           })
         })
       })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    tools {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                tools: null
+              }
+            }, {
+              draftMetadata: {
+                tools: null
+              }
+            }]
+          }
+        })
+      })
     })
 
     describe('variables', () => {
@@ -1522,6 +1772,68 @@ describe('Collection', () => {
           })
         })
       })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    variables {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                variables: null
+              }
+            }, {
+              draftMetadata: {
+                variables: null
+              }
+            }]
+          }
+        })
+      })
     })
 
     describe('data-quality-summaries', () => {
@@ -1730,6 +2042,68 @@ describe('Collection', () => {
           })
         })
       })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    dataQualitySummaries {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                dataQualitySummaries: null
+              }
+            }, {
+              draftMetadata: {
+                dataQualitySummaries: null
+              }
+            }]
+          }
+        })
+      })
     })
 
     describe('relatedCollections', () => {
@@ -1794,6 +2168,68 @@ describe('Collection', () => {
         const { data } = response.body.singleResult
 
         expect(data).toEqual(relatedCollectionsResponseMocks.data)
+      })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    relatedCollections {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                relatedCollections: null
+              }
+            }, {
+              draftMetadata: {
+                relatedCollections: null
+              }
+            }]
+          }
+        })
       })
     })
 
@@ -1942,6 +2378,68 @@ describe('Collection', () => {
         const { data } = response.body.singleResult
 
         expect(data).toEqual(duplicateCollectionsResponseMocks.data)
+      })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Collection {
+                    duplicateCollections {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                duplicateCollections: null
+              }
+            }, {
+              draftMetadata: {
+                duplicateCollections: null
+              }
+            }]
+          }
+        })
       })
     })
   })

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -104,7 +104,7 @@ describe('Collection', () => {
                       applied: false,
                       count: 1,
                       links: {
-                        apply: 'http://example.com:443/search/collections.json?include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Aerosols'
+                        apply: 'http://example-cmr.com:443/search/collections.json?include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Aerosols'
                       },
                       has_children: true
                     }
@@ -326,7 +326,7 @@ describe('Collection', () => {
                     count: 1,
                     hasChildren: true,
                     links: {
-                      apply: 'http://example.com:443/search/collections.json?include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Aerosols'
+                      apply: 'http://example-cmr.com:443/search/collections.json?include_facets=v2&science_keywords_h%5B0%5D%5Btopic%5D=Aerosols'
                     },
                     title: 'Aerosols',
                     type: 'filter'

--- a/src/resolvers/__tests__/dataQualitySummary.test.js
+++ b/src/resolvers/__tests__/dataQualitySummary.test.js
@@ -9,7 +9,7 @@ describe('DataQualitySummary', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -18,7 +18,7 @@ describe('DataQualitySummary', () => {
 
   describe('Query', () => {
     test('All dataQualitySummary fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -90,7 +90,7 @@ describe('DataQualitySummary', () => {
     })
 
     test('dataQualitySummaries', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -134,7 +134,7 @@ describe('DataQualitySummary', () => {
     describe('dataQualitySummary', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -172,7 +172,7 @@ describe('DataQualitySummary', () => {
 
       describe('with no results', () => {
         test('returns no results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -13,7 +13,7 @@ describe('Draft', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -23,7 +23,7 @@ describe('Draft', () => {
   describe('Collection drafts', () => {
     describe('Query', () => {
       test('all draft fields', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -103,7 +103,7 @@ describe('Draft', () => {
       })
 
       test('drafts', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -191,7 +191,7 @@ describe('Draft', () => {
       describe('draft', () => {
         describe('with results', () => {
           test('returns results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Hits': 1,
                 'CMR-Took': 7,
@@ -232,7 +232,7 @@ describe('Draft', () => {
 
         describe('with no results', () => {
           test('returns no results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Took': 0,
                 'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -271,7 +271,7 @@ describe('Draft', () => {
     describe('Mutation', () => {
       describe('ingestDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -339,7 +339,7 @@ describe('Draft', () => {
 
       describe('deleteDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -401,7 +401,7 @@ describe('Draft', () => {
   describe('Service drafts', () => {
     describe('Query', () => {
       test('all draft fields', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -480,7 +480,7 @@ describe('Draft', () => {
       })
 
       test('drafts', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -567,7 +567,7 @@ describe('Draft', () => {
       describe('draft', () => {
         describe('with results', () => {
           test('returns results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Hits': 1,
                 'CMR-Took': 7,
@@ -608,7 +608,7 @@ describe('Draft', () => {
 
         describe('with no results', () => {
           test('returns no results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Took': 0,
                 'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -647,7 +647,7 @@ describe('Draft', () => {
     describe('Mutation', () => {
       describe('ingestDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -715,7 +715,7 @@ describe('Draft', () => {
 
       describe('deleteDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -777,7 +777,7 @@ describe('Draft', () => {
   describe('Tool drafts', () => {
     describe('Query', () => {
       test('all draft fields', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -856,7 +856,7 @@ describe('Draft', () => {
       })
 
       test('drafts', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -943,7 +943,7 @@ describe('Draft', () => {
       describe('draft', () => {
         describe('with results', () => {
           test('returns results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Hits': 1,
                 'CMR-Took': 7,
@@ -984,7 +984,7 @@ describe('Draft', () => {
 
         describe('with no results', () => {
           test('returns no results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Took': 0,
                 'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1023,7 +1023,7 @@ describe('Draft', () => {
     describe('Mutation', () => {
       describe('ingestDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -1091,7 +1091,7 @@ describe('Draft', () => {
 
       describe('deleteDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -1153,7 +1153,7 @@ describe('Draft', () => {
   describe('Variable drafts', () => {
     describe('Query', () => {
       test('all draft fields', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -1232,7 +1232,7 @@ describe('Draft', () => {
       })
 
       test('drafts', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -1319,7 +1319,7 @@ describe('Draft', () => {
       describe('draft', () => {
         describe('with results', () => {
           test('returns results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Hits': 1,
                 'CMR-Took': 7,
@@ -1360,7 +1360,7 @@ describe('Draft', () => {
 
         describe('with no results', () => {
           test('returns no results', async () => {
-            nock(/example/)
+            nock(/example-cmr/)
               .defaultReplyHeaders({
                 'CMR-Took': 0,
                 'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1399,7 +1399,7 @@ describe('Draft', () => {
     describe('Mutation', () => {
       describe('ingestDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',
@@ -1467,7 +1467,7 @@ describe('Draft', () => {
 
       describe('deleteDraft', () => {
         test('returns the cmr result', async () => {
-          nock(/example/, {
+          nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
               'client-id': 'eed-test-graphql',

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -14,10 +14,6 @@ describe('Draft', () => {
     process.env = { ...OLD_ENV }
 
     process.env.cmrRootUrl = 'http://example.com'
-    process.env.ummCollectionDraftVersion = '1.0.0'
-    process.env.ummServiceDraftVersion = '1.0.0'
-    process.env.ummToolDraftVersion = '1.0.0'
-    process.env.ummVariableDraftVersion = '1.0.0'
   })
 
   afterEach(() => {
@@ -56,7 +52,8 @@ describe('Draft', () => {
           variables: {
             params: {
               conceptId: 'CD100000-EDSC',
-              conceptType: 'Collection'
+              conceptType: 'Collection',
+              ummVersion: '1.0.0'
             }
           },
           query: `query Draft($params: DraftInput) {
@@ -69,7 +66,8 @@ describe('Draft', () => {
               providerId
               revisionDate
               revisionId
-              draftMetadata {
+              ummMetadata
+              previewMetadata {
                 ... on Collection {
                   conceptId
                   shortName
@@ -88,7 +86,7 @@ describe('Draft', () => {
             conceptId: 'CD100000-EDSC',
             conceptType: 'collection-draft',
             deleted: false,
-            draftMetadata: {
+            previewMetadata: {
               conceptId: 'CD100000-EDSC',
               shortName: 'Test Draft'
             },
@@ -96,7 +94,10 @@ describe('Draft', () => {
             nativeId: 'test-guid',
             providerId: 'EDSC',
             revisionDate: '2022-05-27T15:18:00.920Z',
-            revisionId: '1'
+            revisionId: '1',
+            ummMetadata: {
+              ShortName: 'Test Draft'
+            }
           }
         })
       })
@@ -143,7 +144,8 @@ describe('Draft', () => {
         const response = await server.executeOperation({
           variables: {
             params: {
-              conceptType: 'Collection'
+              conceptType: 'Collection',
+              ummVersion: '1.0.0'
             }
           },
           query: `query Drafts($params: DraftsInput) {
@@ -151,7 +153,7 @@ describe('Draft', () => {
               count
               items {
                 conceptId
-                draftMetadata {
+                previewMetadata {
                   ... on Collection {
                     conceptId
                     shortName
@@ -171,13 +173,13 @@ describe('Draft', () => {
             count: 2,
             items: [{
               conceptId: 'CD100000-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'CD100000-EDSC',
                 shortName: 'Test Draft'
               }
             }, {
               conceptId: 'CD100001-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'CD100001-EDSC',
                 shortName: 'Test Draft 2'
               }
@@ -295,19 +297,22 @@ describe('Draft', () => {
                 LongName: 'Long Collection Name'
               },
               nativeId: 'collection-1',
-              providerId: 'EDSC'
+              providerId: 'EDSC',
+              ummVersion: '1.0.0'
             },
             query: `mutation IngestDraft(
               $conceptType: DraftConceptType!
               $metadata: JSON!
               $nativeId: String!
               $providerId: String!
+              $ummVersion: String!
             ) {
               ingestDraft(
                 conceptType: $conceptType
                 metadata: $metadata
                 nativeId: $nativeId
                 providerId: $providerId
+                ummVersion: $ummVersion
               ) {
                 conceptId
                 revisionId
@@ -438,7 +443,8 @@ describe('Draft', () => {
               providerId
               revisionDate
               revisionId
-              draftMetadata {
+              ummMetadata
+              previewMetadata {
                 ... on Service {
                   conceptId
                   name
@@ -457,7 +463,7 @@ describe('Draft', () => {
             conceptId: 'SD100000-EDSC',
             conceptType: 'service-draft',
             deleted: false,
-            draftMetadata: {
+            previewMetadata: {
               conceptId: 'SD100000-EDSC',
               name: 'Test Draft'
             },
@@ -465,7 +471,10 @@ describe('Draft', () => {
             nativeId: 'test-guid',
             providerId: 'EDSC',
             revisionDate: '2022-05-27T15:18:00.920Z',
-            revisionId: '1'
+            revisionId: '1',
+            ummMetadata: {
+              Name: 'Test Draft'
+            }
           }
         })
       })
@@ -520,7 +529,7 @@ describe('Draft', () => {
               count
               items {
                 conceptId
-                draftMetadata {
+                previewMetadata {
                   ... on Service {
                     conceptId
                     name
@@ -540,13 +549,13 @@ describe('Draft', () => {
             count: 2,
             items: [{
               conceptId: 'SD100000-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'SD100000-EDSC',
                 name: 'Test Draft'
               }
             }, {
               conceptId: 'SD100001-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'SD100001-EDSC',
                 name: 'Test Draft 2'
               }
@@ -664,19 +673,22 @@ describe('Draft', () => {
                 LongName: 'Long Service Name'
               },
               nativeId: 'service-1',
-              providerId: 'EDSC'
+              providerId: 'EDSC',
+              ummVersion: '1.0.0'
             },
             query: `mutation IngestDraft(
               $conceptType: DraftConceptType!
               $metadata: JSON!
               $nativeId: String!
               $providerId: String!
+              $ummVersion: String!
             ) {
               ingestDraft(
                 conceptType: $conceptType
                 metadata: $metadata
                 nativeId: $nativeId
                 providerId: $providerId
+                ummVersion: $ummVersion
               ) {
                 conceptId
                 revisionId
@@ -807,7 +819,8 @@ describe('Draft', () => {
               providerId
               revisionDate
               revisionId
-              draftMetadata {
+              ummMetadata
+              previewMetadata {
                 ... on Tool {
                   conceptId
                   name
@@ -826,7 +839,7 @@ describe('Draft', () => {
             conceptId: 'TD100000-EDSC',
             conceptType: 'tool-draft',
             deleted: false,
-            draftMetadata: {
+            previewMetadata: {
               conceptId: 'TD100000-EDSC',
               name: 'Test Draft'
             },
@@ -834,7 +847,10 @@ describe('Draft', () => {
             nativeId: 'test-guid',
             providerId: 'EDSC',
             revisionDate: '2022-05-27T15:18:00.920Z',
-            revisionId: '1'
+            revisionId: '1',
+            ummMetadata: {
+              Name: 'Test Draft'
+            }
           }
         })
       })
@@ -889,7 +905,7 @@ describe('Draft', () => {
               count
               items {
                 conceptId
-                draftMetadata {
+                previewMetadata {
                   ... on Tool {
                     conceptId
                     name
@@ -909,13 +925,13 @@ describe('Draft', () => {
             count: 2,
             items: [{
               conceptId: 'TD100000-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'TD100000-EDSC',
                 name: 'Test Draft'
               }
             }, {
               conceptId: 'TD100001-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'TD100001-EDSC',
                 name: 'Test Draft 2'
               }
@@ -1033,19 +1049,22 @@ describe('Draft', () => {
                 LongName: 'Long Tool Name'
               },
               nativeId: 'tool-1',
-              providerId: 'EDSC'
+              providerId: 'EDSC',
+              ummVersion: '1.0.0'
             },
             query: `mutation IngestDraft(
               $conceptType: DraftConceptType!
               $metadata: JSON!
               $nativeId: String!
               $providerId: String!
+              $ummVersion: String!
             ) {
               ingestDraft(
                 conceptType: $conceptType
                 metadata: $metadata
                 nativeId: $nativeId
                 providerId: $providerId
+                ummVersion: $ummVersion
               ) {
                 conceptId
                 revisionId
@@ -1176,7 +1195,8 @@ describe('Draft', () => {
               providerId
               revisionDate
               revisionId
-              draftMetadata {
+              ummMetadata
+              previewMetadata {
                 ... on Variable {
                   conceptId
                   name
@@ -1195,7 +1215,7 @@ describe('Draft', () => {
             conceptId: 'VD100000-EDSC',
             conceptType: 'variable-draft',
             deleted: false,
-            draftMetadata: {
+            previewMetadata: {
               conceptId: 'VD100000-EDSC',
               name: 'Test Draft'
             },
@@ -1203,7 +1223,10 @@ describe('Draft', () => {
             nativeId: 'test-guid',
             providerId: 'EDSC',
             revisionDate: '2022-05-27T15:18:00.920Z',
-            revisionId: '1'
+            revisionId: '1',
+            ummMetadata: {
+              Name: 'Test Draft'
+            }
           }
         })
       })
@@ -1258,7 +1281,7 @@ describe('Draft', () => {
               count
               items {
                 conceptId
-                draftMetadata {
+                previewMetadata {
                   ... on Variable {
                     conceptId
                     name
@@ -1278,13 +1301,13 @@ describe('Draft', () => {
             count: 2,
             items: [{
               conceptId: 'VD100000-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'VD100000-EDSC',
                 name: 'Test Draft'
               }
             }, {
               conceptId: 'VD100001-EDSC',
-              draftMetadata: {
+              previewMetadata: {
                 conceptId: 'VD100001-EDSC',
                 name: 'Test Draft 2'
               }
@@ -1402,19 +1425,22 @@ describe('Draft', () => {
                 LongName: 'Long Variable Name'
               },
               nativeId: 'variable-1',
-              providerId: 'EDSC'
+              providerId: 'EDSC',
+              ummVersion: '1.0.0'
             },
             query: `mutation IngestDraft(
               $conceptType: DraftConceptType!
               $metadata: JSON!
               $nativeId: String!
               $providerId: String!
+              $ummVersion: String!
             ) {
               ingestDraft(
                 conceptType: $conceptType
                 metadata: $metadata
                 nativeId: $nativeId
                 providerId: $providerId
+                ummVersion: $ummVersion
               ) {
                 conceptId
                 revisionId
@@ -1500,43 +1526,43 @@ describe('Draft', () => {
     })
   })
 
-  describe('DraftMetadata', () => {
+  describe('PreviewMetadata', () => {
     describe('__resolveType', () => {
       test('returns Collection when the conceptId starts with CD', () => {
-        const { DraftMetadata: draftMetadata } = resolvers
-        const { __resolveType: resolveType } = draftMetadata
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
 
         const result = resolveType({ conceptId: 'CD' })
         expect(result).toEqual('Collection')
       })
 
       test('returns Service when the conceptId starts with SD', () => {
-        const { DraftMetadata: draftMetadata } = resolvers
-        const { __resolveType: resolveType } = draftMetadata
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
 
         const result = resolveType({ conceptId: 'SD' })
         expect(result).toEqual('Service')
       })
 
       test('returns Tool when the conceptId starts with TD', () => {
-        const { DraftMetadata: draftMetadata } = resolvers
-        const { __resolveType: resolveType } = draftMetadata
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
 
         const result = resolveType({ conceptId: 'TD' })
         expect(result).toEqual('Tool')
       })
 
       test('returns Variable when the conceptId starts with VD', () => {
-        const { DraftMetadata: draftMetadata } = resolvers
-        const { __resolveType: resolveType } = draftMetadata
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
 
         const result = resolveType({ conceptId: 'VD' })
         expect(result).toEqual('Variable')
       })
 
       test('returns null when the conceptId is not a draft', () => {
-        const { DraftMetadata: draftMetadata } = resolvers
-        const { __resolveType: resolveType } = draftMetadata
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
 
         const result = resolveType({ conceptId: 'something-bad' })
         expect(result).toEqual(null)

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1,0 +1,1546 @@
+import nock from 'nock'
+
+import resolvers from '..'
+import { buildContextValue, server } from './__mocks__/mockServer'
+
+const contextValue = buildContextValue()
+
+jest.mock('uuid', () => ({ v4: () => '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed' }))
+
+describe('Draft', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example.com'
+    process.env.ummCollectionDraftVersion = '1.0.0'
+    process.env.ummServiceDraftVersion = '1.0.0'
+    process.env.ummToolDraftVersion = '1.0.0'
+    process.env.ummVariableDraftVersion = '1.0.0'
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('Collection drafts', () => {
+    describe('Query', () => {
+      test('all draft fields', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            hits: 1,
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC',
+                'concept-type': 'collection-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                ShortName: 'Test Draft'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptId: 'CD100000-EDSC',
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Draft($params: DraftInput) {
+            draft(params: $params) {
+              conceptId
+              conceptType
+              deleted
+              name
+              nativeId
+              providerId
+              revisionDate
+              revisionId
+              draftMetadata {
+                ... on Collection {
+                  conceptId
+                  shortName
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          draft: {
+            conceptId: 'CD100000-EDSC',
+            conceptType: 'collection-draft',
+            deleted: false,
+            draftMetadata: {
+              conceptId: 'CD100000-EDSC',
+              shortName: 'Test Draft'
+            },
+            name: null,
+            nativeId: 'test-guid',
+            providerId: 'EDSC',
+            revisionDate: '2022-05-27T15:18:00.920Z',
+            revisionId: '1'
+          }
+        })
+      })
+
+      test('drafts', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collection-drafts\.umm_json/)
+          .reply(200, {
+            hits: 2,
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC',
+                'concept-type': 'collection-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                ShortName: 'Test Draft'
+              }
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC',
+                'concept-type': 'collection-draft',
+                deleted: false,
+                'native-id': 'test-guid-1',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-29T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                ShortName: 'Test Draft 2'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              count
+              items {
+                conceptId
+                draftMetadata {
+                  ... on Collection {
+                    conceptId
+                    shortName
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            count: 2,
+            items: [{
+              conceptId: 'CD100000-EDSC',
+              draftMetadata: {
+                conceptId: 'CD100000-EDSC',
+                shortName: 'Test Draft'
+              }
+            }, {
+              conceptId: 'CD100001-EDSC',
+              draftMetadata: {
+                conceptId: 'CD100001-EDSC',
+                shortName: 'Test Draft 2'
+              }
+            }]
+          }
+        })
+      })
+
+      describe('draft', () => {
+        describe('with results', () => {
+          test('returns results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/collection-drafts\.json/, 'concept_id=CD100000-EDSC')
+              .reply(200, {
+                items: [{
+                  concept_id: 'CD100000-EDSC'
+                }]
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'CD100000-EDSC',
+                  conceptType: 'Collection'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: {
+                conceptId: 'CD100000-EDSC'
+              }
+            })
+          })
+        })
+
+        describe('with no results', () => {
+          test('returns no results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Took': 0,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/collection-drafts\.json/, 'concept_id=CD100000-EDSC')
+              .reply(200, {
+                items: []
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'CD100000-EDSC',
+                  conceptType: 'Collection'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: null
+            })
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('ingestDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/providers\/EDSC\/collection-drafts\/collection-1/)
+            .reply(201, {
+              'concept-id': 'CD100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Collection',
+              metadata: {
+                Name: 'Mock Collection',
+                LongName: 'Long Collection Name'
+              },
+              nativeId: 'collection-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation IngestDraft(
+              $conceptType: DraftConceptType!
+              $metadata: JSON!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              ingestDraft(
+                conceptType: $conceptType
+                metadata: $metadata
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            ingestDraft: {
+              conceptId: 'CD100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('deleteDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete(/ingest\/providers\/EDSC\/collection-drafts\/collection-1/)
+            .reply(201, {
+              'concept-id': 'CD100000-EDSC',
+              'revision-id': '2'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Collection',
+              nativeId: 'collection-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation DeleteDraft(
+              $conceptType: DraftConceptType!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              deleteDraft(
+                conceptType: $conceptType
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            deleteDraft: {
+              conceptId: 'CD100000-EDSC',
+              revisionId: '2',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('Service drafts', () => {
+    describe('Query', () => {
+      test('all draft fields', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/service-drafts\.umm_json/)
+          .reply(200, {
+            hits: 1,
+            items: [{
+              meta: {
+                'concept-id': 'SD100000-EDSC',
+                'concept-type': 'service-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptId: 'SD100000-EDSC',
+              conceptType: 'Service'
+            }
+          },
+          query: `query Draft($params: DraftInput) {
+            draft(params: $params) {
+              conceptId
+              conceptType
+              deleted
+              name
+              nativeId
+              providerId
+              revisionDate
+              revisionId
+              draftMetadata {
+                ... on Service {
+                  conceptId
+                  name
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          draft: {
+            conceptId: 'SD100000-EDSC',
+            conceptType: 'service-draft',
+            deleted: false,
+            draftMetadata: {
+              conceptId: 'SD100000-EDSC',
+              name: 'Test Draft'
+            },
+            name: 'Test Draft',
+            nativeId: 'test-guid',
+            providerId: 'EDSC',
+            revisionDate: '2022-05-27T15:18:00.920Z',
+            revisionId: '1'
+          }
+        })
+      })
+
+      test('drafts', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/service-drafts\.umm_json/)
+          .reply(200, {
+            hits: 2,
+            items: [{
+              meta: {
+                'concept-id': 'SD100000-EDSC',
+                'concept-type': 'service-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }, {
+              meta: {
+                'concept-id': 'SD100001-EDSC',
+                'concept-type': 'service-draft',
+                deleted: false,
+                'native-id': 'test-guid-1',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-29T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft 2'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Service'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              count
+              items {
+                conceptId
+                draftMetadata {
+                  ... on Service {
+                    conceptId
+                    name
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            count: 2,
+            items: [{
+              conceptId: 'SD100000-EDSC',
+              draftMetadata: {
+                conceptId: 'SD100000-EDSC',
+                name: 'Test Draft'
+              }
+            }, {
+              conceptId: 'SD100001-EDSC',
+              draftMetadata: {
+                conceptId: 'SD100001-EDSC',
+                name: 'Test Draft 2'
+              }
+            }]
+          }
+        })
+      })
+
+      describe('draft', () => {
+        describe('with results', () => {
+          test('returns results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/service-drafts\.json/, 'concept_id=SD100000-EDSC')
+              .reply(200, {
+                items: [{
+                  concept_id: 'SD100000-EDSC'
+                }]
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'SD100000-EDSC',
+                  conceptType: 'Service'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: {
+                conceptId: 'SD100000-EDSC'
+              }
+            })
+          })
+        })
+
+        describe('with no results', () => {
+          test('returns no results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Took': 0,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/service-drafts\.json/, 'concept_id=SD100000-EDSC')
+              .reply(200, {
+                items: []
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'SD100000-EDSC',
+                  conceptType: 'Service'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: null
+            })
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('ingestDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/providers\/EDSC\/service-drafts\/service-1/)
+            .reply(201, {
+              'concept-id': 'SD100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Service',
+              metadata: {
+                Name: 'Mock Service',
+                LongName: 'Long Service Name'
+              },
+              nativeId: 'service-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation IngestDraft(
+              $conceptType: DraftConceptType!
+              $metadata: JSON!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              ingestDraft(
+                conceptType: $conceptType
+                metadata: $metadata
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            ingestDraft: {
+              conceptId: 'SD100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('deleteDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete(/ingest\/providers\/EDSC\/service-drafts\/service-1/)
+            .reply(201, {
+              'concept-id': 'SD100000-EDSC',
+              'revision-id': '2'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Service',
+              nativeId: 'service-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation DeleteDraft(
+              $conceptType: DraftConceptType!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              deleteDraft(
+                conceptType: $conceptType
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            deleteDraft: {
+              conceptId: 'SD100000-EDSC',
+              revisionId: '2',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('Tool drafts', () => {
+    describe('Query', () => {
+      test('all draft fields', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/tool-drafts\.umm_json/)
+          .reply(200, {
+            hits: 1,
+            items: [{
+              meta: {
+                'concept-id': 'TD100000-EDSC',
+                'concept-type': 'tool-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptId: 'TD100000-EDSC',
+              conceptType: 'Tool'
+            }
+          },
+          query: `query Draft($params: DraftInput) {
+            draft(params: $params) {
+              conceptId
+              conceptType
+              deleted
+              name
+              nativeId
+              providerId
+              revisionDate
+              revisionId
+              draftMetadata {
+                ... on Tool {
+                  conceptId
+                  name
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          draft: {
+            conceptId: 'TD100000-EDSC',
+            conceptType: 'tool-draft',
+            deleted: false,
+            draftMetadata: {
+              conceptId: 'TD100000-EDSC',
+              name: 'Test Draft'
+            },
+            name: 'Test Draft',
+            nativeId: 'test-guid',
+            providerId: 'EDSC',
+            revisionDate: '2022-05-27T15:18:00.920Z',
+            revisionId: '1'
+          }
+        })
+      })
+
+      test('drafts', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/tool-drafts\.umm_json/)
+          .reply(200, {
+            hits: 2,
+            items: [{
+              meta: {
+                'concept-id': 'TD100000-EDSC',
+                'concept-type': 'tool-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }, {
+              meta: {
+                'concept-id': 'TD100001-EDSC',
+                'concept-type': 'tool-draft',
+                deleted: false,
+                'native-id': 'test-guid-1',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-29T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft 2'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Tool'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              count
+              items {
+                conceptId
+                draftMetadata {
+                  ... on Tool {
+                    conceptId
+                    name
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            count: 2,
+            items: [{
+              conceptId: 'TD100000-EDSC',
+              draftMetadata: {
+                conceptId: 'TD100000-EDSC',
+                name: 'Test Draft'
+              }
+            }, {
+              conceptId: 'TD100001-EDSC',
+              draftMetadata: {
+                conceptId: 'TD100001-EDSC',
+                name: 'Test Draft 2'
+              }
+            }]
+          }
+        })
+      })
+
+      describe('draft', () => {
+        describe('with results', () => {
+          test('returns results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/tool-drafts\.json/, 'concept_id=TD100000-EDSC')
+              .reply(200, {
+                items: [{
+                  concept_id: 'TD100000-EDSC'
+                }]
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'TD100000-EDSC',
+                  conceptType: 'Tool'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: {
+                conceptId: 'TD100000-EDSC'
+              }
+            })
+          })
+        })
+
+        describe('with no results', () => {
+          test('returns no results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Took': 0,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/tool-drafts\.json/, 'concept_id=TD100000-EDSC')
+              .reply(200, {
+                items: []
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'TD100000-EDSC',
+                  conceptType: 'Tool'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: null
+            })
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('ingestDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/providers\/EDSC\/tool-drafts\/tool-1/)
+            .reply(201, {
+              'concept-id': 'TD100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Tool',
+              metadata: {
+                Name: 'Mock Tool',
+                LongName: 'Long Tool Name'
+              },
+              nativeId: 'tool-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation IngestDraft(
+              $conceptType: DraftConceptType!
+              $metadata: JSON!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              ingestDraft(
+                conceptType: $conceptType
+                metadata: $metadata
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            ingestDraft: {
+              conceptId: 'TD100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('deleteDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete(/ingest\/providers\/EDSC\/tool-drafts\/tool-1/)
+            .reply(201, {
+              'concept-id': 'TD100000-EDSC',
+              'revision-id': '2'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Tool',
+              nativeId: 'tool-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation DeleteDraft(
+              $conceptType: DraftConceptType!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              deleteDraft(
+                conceptType: $conceptType
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            deleteDraft: {
+              conceptId: 'TD100000-EDSC',
+              revisionId: '2',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('Variable drafts', () => {
+    describe('Query', () => {
+      test('all draft fields', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/variable-drafts\.umm_json/)
+          .reply(200, {
+            hits: 1,
+            items: [{
+              meta: {
+                'concept-id': 'VD100000-EDSC',
+                'concept-type': 'variable-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptId: 'VD100000-EDSC',
+              conceptType: 'Variable'
+            }
+          },
+          query: `query Draft($params: DraftInput) {
+            draft(params: $params) {
+              conceptId
+              conceptType
+              deleted
+              name
+              nativeId
+              providerId
+              revisionDate
+              revisionId
+              draftMetadata {
+                ... on Variable {
+                  conceptId
+                  name
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          draft: {
+            conceptId: 'VD100000-EDSC',
+            conceptType: 'variable-draft',
+            deleted: false,
+            draftMetadata: {
+              conceptId: 'VD100000-EDSC',
+              name: 'Test Draft'
+            },
+            name: 'Test Draft',
+            nativeId: 'test-guid',
+            providerId: 'EDSC',
+            revisionDate: '2022-05-27T15:18:00.920Z',
+            revisionId: '1'
+          }
+        })
+      })
+
+      test('drafts', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/variable-drafts\.umm_json/)
+          .reply(200, {
+            hits: 2,
+            items: [{
+              meta: {
+                'concept-id': 'VD100000-EDSC',
+                'concept-type': 'variable-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }, {
+              meta: {
+                'concept-id': 'VD100001-EDSC',
+                'concept-type': 'variable-draft',
+                deleted: false,
+                'native-id': 'test-guid-1',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-29T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft 2'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Variable'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              count
+              items {
+                conceptId
+                draftMetadata {
+                  ... on Variable {
+                    conceptId
+                    name
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            count: 2,
+            items: [{
+              conceptId: 'VD100000-EDSC',
+              draftMetadata: {
+                conceptId: 'VD100000-EDSC',
+                name: 'Test Draft'
+              }
+            }, {
+              conceptId: 'VD100001-EDSC',
+              draftMetadata: {
+                conceptId: 'VD100001-EDSC',
+                name: 'Test Draft 2'
+              }
+            }]
+          }
+        })
+      })
+
+      describe('draft', () => {
+        describe('with results', () => {
+          test('returns results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/variable-drafts\.json/, 'concept_id=VD100000-EDSC')
+              .reply(200, {
+                items: [{
+                  concept_id: 'VD100000-EDSC'
+                }]
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'VD100000-EDSC',
+                  conceptType: 'Variable'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: {
+                conceptId: 'VD100000-EDSC'
+              }
+            })
+          })
+        })
+
+        describe('with no results', () => {
+          test('returns no results', async () => {
+            nock(/example/)
+              .defaultReplyHeaders({
+                'CMR-Took': 0,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .post(/variable-drafts\.json/, 'concept_id=VD100000-EDSC')
+              .reply(200, {
+                items: []
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'VD100000-EDSC',
+                  conceptType: 'Variable'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: null
+            })
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('ingestDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/providers\/EDSC\/variable-drafts\/variable-1/)
+            .reply(201, {
+              'concept-id': 'VD100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Variable',
+              metadata: {
+                Name: 'Mock Variable',
+                LongName: 'Long Variable Name'
+              },
+              nativeId: 'variable-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation IngestDraft(
+              $conceptType: DraftConceptType!
+              $metadata: JSON!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              ingestDraft(
+                conceptType: $conceptType
+                metadata: $metadata
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            ingestDraft: {
+              conceptId: 'VD100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('deleteDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete(/ingest\/providers\/EDSC\/variable-drafts\/variable-1/)
+            .reply(201, {
+              'concept-id': 'VD100000-EDSC',
+              'revision-id': '2'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Variable',
+              nativeId: 'variable-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation DeleteDraft(
+              $conceptType: DraftConceptType!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              deleteDraft(
+                conceptType: $conceptType
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            deleteDraft: {
+              conceptId: 'VD100000-EDSC',
+              revisionId: '2',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+    })
+  })
+
+  describe('DraftMetadata', () => {
+    describe('__resolveType', () => {
+      test('returns Collection when the conceptId starts with CD', () => {
+        const { DraftMetadata: draftMetadata } = resolvers
+        const { __resolveType: resolveType } = draftMetadata
+
+        const result = resolveType({ conceptId: 'CD' })
+        expect(result).toEqual('Collection')
+      })
+
+      test('returns Service when the conceptId starts with SD', () => {
+        const { DraftMetadata: draftMetadata } = resolvers
+        const { __resolveType: resolveType } = draftMetadata
+
+        const result = resolveType({ conceptId: 'SD' })
+        expect(result).toEqual('Service')
+      })
+
+      test('returns Tool when the conceptId starts with TD', () => {
+        const { DraftMetadata: draftMetadata } = resolvers
+        const { __resolveType: resolveType } = draftMetadata
+
+        const result = resolveType({ conceptId: 'TD' })
+        expect(result).toEqual('Tool')
+      })
+
+      test('returns Variable when the conceptId starts with VD', () => {
+        const { DraftMetadata: draftMetadata } = resolvers
+        const { __resolveType: resolveType } = draftMetadata
+
+        const result = resolveType({ conceptId: 'VD' })
+        expect(result).toEqual('Variable')
+      })
+
+      test('returns null when the conceptId is not a draft', () => {
+        const { DraftMetadata: draftMetadata } = resolvers
+        const { __resolveType: resolveType } = draftMetadata
+
+        const result = resolveType({ conceptId: 'something-bad' })
+        expect(result).toEqual(null)
+      })
+    })
+  })
+})

--- a/src/resolvers/__tests__/grid.test.js
+++ b/src/resolvers/__tests__/grid.test.js
@@ -10,7 +10,7 @@ describe('Grid', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('Grid', () => {
 
   describe('Query', () => {
     test('all grid fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -133,7 +133,7 @@ describe('Grid', () => {
     })
 
     test('grids', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -176,7 +176,7 @@ describe('Grid', () => {
     describe('grid', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -212,7 +212,7 @@ describe('Grid', () => {
 
       describe('with no results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -10,7 +10,7 @@ describe('OrderOption', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('OrderOption', () => {
 
   describe('Query', () => {
     test('all order option fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -100,7 +100,7 @@ describe('OrderOption', () => {
     })
 
     test('order options query', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -143,7 +143,7 @@ describe('OrderOption', () => {
     describe('orderOption', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -179,7 +179,7 @@ describe('OrderOption', () => {
 
       describe('with no results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/resolvers/__tests__/service.test.js
+++ b/src/resolvers/__tests__/service.test.js
@@ -530,7 +530,7 @@ describe('Service', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Service {
                     collections {
                       count
@@ -549,11 +549,11 @@ describe('Service', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }]
@@ -1175,7 +1175,7 @@ describe('Service', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Service {
                     orderOptions {
                       count
@@ -1194,11 +1194,11 @@ describe('Service', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 orderOptions: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 orderOptions: null
               }
             }]
@@ -1449,7 +1449,7 @@ describe('Service', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Service {
                     variables {
                       count
@@ -1468,11 +1468,11 @@ describe('Service', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 variables: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 variables: null
               }
             }]
@@ -1639,7 +1639,7 @@ describe('Service', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Service {
                     maxItemsPerOrder
                   }
@@ -1656,11 +1656,11 @@ describe('Service', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 maxItemsPerOrder: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 maxItemsPerOrder: null
               }
             }]

--- a/src/resolvers/__tests__/service.test.js
+++ b/src/resolvers/__tests__/service.test.js
@@ -10,7 +10,7 @@ describe('Service', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('Service', () => {
 
   describe('Query', () => {
     test('all service fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -118,7 +118,7 @@ describe('Service', () => {
     })
 
     test('services', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -161,7 +161,7 @@ describe('Service', () => {
     describe('service', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -196,7 +196,7 @@ describe('Service', () => {
 
       describe('with no results', () => {
         test('returns no results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -229,7 +229,7 @@ describe('Service', () => {
 
   describe('when there are variable associations in the service metadata', () => {
     test('queries for and returns variables', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -249,7 +249,7 @@ describe('Service', () => {
           }]
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -263,7 +263,7 @@ describe('Service', () => {
           }]
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -325,7 +325,7 @@ describe('Service', () => {
 
   describe('when there are no variable associations in the service metadata', () => {
     test('queries for and does not return any variables', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -339,7 +339,7 @@ describe('Service', () => {
           }]
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -353,7 +353,7 @@ describe('Service', () => {
           }]
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -408,7 +408,7 @@ describe('Service', () => {
   describe('Service', () => {
     describe('collections', () => {
       test('returns collections when querying a published record', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -422,7 +422,7 @@ describe('Service', () => {
             }]
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -438,7 +438,7 @@ describe('Service', () => {
             }
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -500,7 +500,7 @@ describe('Service', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -566,7 +566,7 @@ describe('Service', () => {
       describe('orderOptions query WITH parent collection', () => {
         // Tests for the associated legacy services order-options
         test('only retrieve one OO filtered from assoc details', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -711,7 +711,7 @@ describe('Service', () => {
         })
 
         test('After filter check data payload fields existence', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -822,7 +822,7 @@ describe('Service', () => {
         })
 
         test('No order options in the payload', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -905,7 +905,7 @@ describe('Service', () => {
         })
 
         test('No association back to the collection', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
           // Note I am not sure that this can happen in CMR
             .defaultReplyHeaders({
               'CMR-Took': 7,
@@ -990,7 +990,7 @@ describe('Service', () => {
         })
 
         test('No order_option field in the data payload in the association between the collection and service', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1083,7 +1083,7 @@ describe('Service', () => {
         })
 
         test('legacy services order-option not retrieved because there were NO associations on the collection', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1145,7 +1145,7 @@ describe('Service', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -1209,7 +1209,7 @@ describe('Service', () => {
 
     describe('orderOptions query WITHOUT parent collection', () => {
       test('order options from service no collection parent retrieves all order-options in the collection assoc', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1302,7 +1302,7 @@ describe('Service', () => {
       })
 
       test('Default no association details for orderOption query off of services', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1349,7 +1349,7 @@ describe('Service', () => {
 
     describe('variables', () => {
       test('returns variables when querying a published record', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1368,7 +1368,7 @@ describe('Service', () => {
             }]
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -1419,7 +1419,7 @@ describe('Service', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,
@@ -1483,7 +1483,7 @@ describe('Service', () => {
 
     describe('maxItemsPerOrder', () => {
       test('returns the maxItemsPerOrder for ECHO ORDERS service types', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -1549,7 +1549,7 @@ describe('Service', () => {
       })
 
       test('returns null for maxItemsPerOrder for non ECHO ORDERS service types', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 1,
             'CMR-Took': 7,
@@ -1609,7 +1609,7 @@ describe('Service', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,

--- a/src/resolvers/__tests__/serviceDraft.test.js
+++ b/src/resolvers/__tests__/serviceDraft.test.js
@@ -10,7 +10,7 @@ describe('ServiceDraft', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.mmtRootUrl = 'http://example.com'
+    process.env.mmtRootUrl = 'http://example-mmt.com'
   })
 
   afterEach(() => {
@@ -21,7 +21,7 @@ describe('ServiceDraft', () => {
     describe('serviceDraft', () => {
       describe('with result', () => {
         test('all service draft fields', async () => {
-          nock(/example/)
+          nock(/example-mmt/)
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
@@ -107,7 +107,7 @@ describe('ServiceDraft', () => {
         })
 
         test('return results', async () => {
-          nock(/example/)
+          nock(/example-mmt/)
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })
@@ -141,7 +141,7 @@ describe('ServiceDraft', () => {
 
       describe('with no results', () => {
         test('return no results', async () => {
-          nock(/example/)
+          nock(/example-mmt/)
             .defaultReplyHeaders({
               'X-Request-Id': 'abcd-1234-efgh-5678'
             })

--- a/src/resolvers/__tests__/subscription.test.js
+++ b/src/resolvers/__tests__/subscription.test.js
@@ -12,7 +12,7 @@ describe('Subscription', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
     process.env.ummSubscriptionVersion = '1.1'
   })
 
@@ -22,7 +22,7 @@ describe('Subscription', () => {
 
   describe('Query', () => {
     test('all subscription fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -99,7 +99,7 @@ describe('Subscription', () => {
     })
 
     test('subscriptions', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -142,7 +142,7 @@ describe('Subscription', () => {
     describe('subscription', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -177,7 +177,7 @@ describe('Subscription', () => {
 
       describe('with no results', () => {
         test('returns no results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -210,7 +210,7 @@ describe('Subscription', () => {
 
   describe('Subscription', () => {
     test('collection', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -226,7 +226,7 @@ describe('Subscription', () => {
           }]
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -240,7 +240,7 @@ describe('Subscription', () => {
           }
         })
 
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -290,7 +290,7 @@ describe('Subscription', () => {
     })
 
     test('collection when collectionConceptId does not exist', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -332,7 +332,7 @@ describe('Subscription', () => {
     })
 
     test('createSubscription for a granule subscription', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           accept: 'application/json',
           'client-id': 'eed-test-graphql',
@@ -393,7 +393,7 @@ describe('Subscription', () => {
     })
 
     test('createSubscription for a collection subscription', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           accept: 'application/json',
           'client-id': 'eed-test-graphql',
@@ -451,7 +451,7 @@ describe('Subscription', () => {
     })
 
     test('updateSubscription', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -508,7 +508,7 @@ describe('Subscription', () => {
     })
 
     test('deleteSubscription', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -391,7 +391,7 @@ describe('Tool', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Tool {
                     collections {
                       count
@@ -410,11 +410,11 @@ describe('Tool', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }]

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -267,95 +267,159 @@ describe('Tool', () => {
   })
 
   describe('Tool', () => {
-    test('collections', async () => {
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/tools\.json/)
-        .reply(200, {
-          items: [{
-            concept_id: 'T100000-EDSC'
-          }, {
-            concept_id: 'T100001-EDSC'
-          }]
-        })
-
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/, 'page_size=20&tool_concept_id=T100000-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100000-EDSC'
+    describe('collections', () => {
+      test('returns collections when querying a published record', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/tools\.json/)
+          .reply(200, {
+            items: [{
+              concept_id: 'T100000-EDSC'
             }, {
-              id: 'C100001-EDSC'
+              concept_id: 'T100001-EDSC'
             }]
-          }
-        })
+          })
 
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/, 'page_size=20&tool_concept_id=T100001-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100002-EDSC'
-            }, {
-              id: 'C100003-EDSC'
-            }]
-          }
-        })
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/, 'page_size=20&tool_concept_id=T100000-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100000-EDSC'
+              }, {
+                id: 'C100001-EDSC'
+              }]
+            }
+          })
 
-      const response = await server.executeOperation({
-        variables: {},
-        query: `{
-          tools {
-            items {
-              conceptId
-              collections {
-                items {
-                  conceptId
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/, 'page_size=20&tool_concept_id=T100001-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100002-EDSC'
+              }, {
+                id: 'C100003-EDSC'
+              }]
+            }
+          })
+
+        const response = await server.executeOperation({
+          variables: {},
+          query: `{
+            tools {
+              items {
+                conceptId
+                collections {
+                  items {
+                    conceptId
+                  }
                 }
               }
             }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          tools: {
+            items: [{
+              conceptId: 'T100000-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100000-EDSC'
+                }, {
+                  conceptId: 'C100001-EDSC'
+                }]
+              }
+            }, {
+              conceptId: 'T100001-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100002-EDSC'
+                }, {
+                  conceptId: 'C100003-EDSC'
+                }]
+              }
+            }]
           }
-        }`
-      }, {
-        contextValue
+        })
       })
 
-      const { data } = response.body.singleResult
+      test('returns null when querying a draft', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/tool-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'TD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'TD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
 
-      expect(data).toEqual({
-        tools: {
-          items: [{
-            conceptId: 'T100000-EDSC',
-            collections: {
-              items: [{
-                conceptId: 'C100000-EDSC'
-              }, {
-                conceptId: 'C100001-EDSC'
-              }]
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Tool'
             }
-          }, {
-            conceptId: 'T100001-EDSC',
-            collections: {
-              items: [{
-                conceptId: 'C100002-EDSC'
-              }, {
-                conceptId: 'C100003-EDSC'
-              }]
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Tool {
+                    collections {
+                      count
+                    }
+                  }
+                }
+              }
             }
-          }]
-        }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                collections: null
+              }
+            }, {
+              draftMetadata: {
+                collections: null
+              }
+            }]
+          }
+        })
       })
     })
   })

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -10,7 +10,7 @@ describe('Tool', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('Tool', () => {
 
   describe('Query', () => {
     test('all tool fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -157,7 +157,7 @@ describe('Tool', () => {
     })
 
     test('tools', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -200,7 +200,7 @@ describe('Tool', () => {
     describe('tool', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -235,7 +235,7 @@ describe('Tool', () => {
 
       describe('with no results', () => {
         test('returns no results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -269,7 +269,7 @@ describe('Tool', () => {
   describe('Tool', () => {
     describe('collections', () => {
       test('returns collections when querying a published record', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -283,7 +283,7 @@ describe('Tool', () => {
             }]
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -299,7 +299,7 @@ describe('Tool', () => {
             }
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -361,7 +361,7 @@ describe('Tool', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -384,7 +384,7 @@ describe('Variable', () => {
           query: `query Drafts($params: DraftsInput) {
             drafts(params: $params) {
               items {
-                draftMetadata {
+                previewMetadata {
                   ... on Variable {
                     collections {
                       count
@@ -403,11 +403,11 @@ describe('Variable', () => {
         expect(data).toEqual({
           drafts: {
             items: [{
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }, {
-              draftMetadata: {
+              previewMetadata: {
                 collections: null
               }
             }]

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -260,95 +260,159 @@ describe('Variable', () => {
   })
 
   describe('Variable', () => {
-    test('collections', async () => {
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/variables\.json/)
-        .reply(200, {
-          items: [{
-            concept_id: 'V100000-EDSC'
-          }, {
-            concept_id: 'V100001-EDSC'
-          }]
-        })
-
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/, 'page_size=20&variable_concept_id=V100000-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100000-EDSC'
+    describe('collections', () => {
+      test('returns collections when querying a published record', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/variables\.json/)
+          .reply(200, {
+            items: [{
+              concept_id: 'V100000-EDSC'
             }, {
-              id: 'C100001-EDSC'
+              concept_id: 'V100001-EDSC'
             }]
-          }
-        })
+          })
 
-      nock(/example/)
-        .defaultReplyHeaders({
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/collections\.json/, 'page_size=20&variable_concept_id=V100001-EDSC')
-        .reply(200, {
-          feed: {
-            entry: [{
-              id: 'C100002-EDSC'
-            }, {
-              id: 'C100003-EDSC'
-            }]
-          }
-        })
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/, 'page_size=20&variable_concept_id=V100000-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100000-EDSC'
+              }, {
+                id: 'C100001-EDSC'
+              }]
+            }
+          })
 
-      const response = await server.executeOperation({
-        variables: {},
-        query: `{
-          variables {
-            items {
-              conceptId
-              collections {
-                items {
-                  conceptId
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/collections\.json/, 'page_size=20&variable_concept_id=V100001-EDSC')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100002-EDSC'
+              }, {
+                id: 'C100003-EDSC'
+              }]
+            }
+          })
+
+        const response = await server.executeOperation({
+          variables: {},
+          query: `{
+            variables {
+              items {
+                conceptId
+                collections {
+                  items {
+                    conceptId
+                  }
                 }
               }
             }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          variables: {
+            items: [{
+              conceptId: 'V100000-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100000-EDSC'
+                }, {
+                  conceptId: 'C100001-EDSC'
+                }]
+              }
+            }, {
+              conceptId: 'V100001-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100002-EDSC'
+                }, {
+                  conceptId: 'C100003-EDSC'
+                }]
+              }
+            }]
           }
-        }`
-      }, {
-        contextValue
+        })
       })
 
-      const { data } = response.body.singleResult
+      test('returns null when querying a draft', async () => {
+        nock(/example/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/variable-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'VD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'VD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
 
-      expect(data).toEqual({
-        variables: {
-          items: [{
-            conceptId: 'V100000-EDSC',
-            collections: {
-              items: [{
-                conceptId: 'C100000-EDSC'
-              }, {
-                conceptId: 'C100001-EDSC'
-              }]
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Variable'
             }
-          }, {
-            conceptId: 'V100001-EDSC',
-            collections: {
-              items: [{
-                conceptId: 'C100002-EDSC'
-              }, {
-                conceptId: 'C100003-EDSC'
-              }]
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                draftMetadata {
+                  ... on Variable {
+                    collections {
+                      count
+                    }
+                  }
+                }
+              }
             }
-          }]
-        }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              draftMetadata: {
+                collections: null
+              }
+            }, {
+              draftMetadata: {
+                collections: null
+              }
+            }]
+          }
+        })
       })
     })
   })

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -10,7 +10,7 @@ describe('Variable', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('Variable', () => {
 
   describe('Query', () => {
     test('all variable fields', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Hits': 1,
           'CMR-Took': 7,
@@ -142,7 +142,7 @@ describe('Variable', () => {
     })
 
     test('variables', async () => {
-      nock(/example/)
+      nock(/example-cmr/)
         .defaultReplyHeaders({
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -185,7 +185,7 @@ describe('Variable', () => {
     describe('variable', () => {
       describe('with results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -226,7 +226,7 @@ describe('Variable', () => {
 
       describe('with no results', () => {
         test('returns results', async () => {
-          nock(/example/)
+          nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -262,7 +262,7 @@ describe('Variable', () => {
   describe('Variable', () => {
     describe('collections', () => {
       test('returns collections when querying a published record', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -276,7 +276,7 @@ describe('Variable', () => {
             }]
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -292,7 +292,7 @@ describe('Variable', () => {
             }
           })
 
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Took': 7,
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -354,7 +354,7 @@ describe('Variable', () => {
       })
 
       test('returns null when querying a draft', async () => {
-        nock(/example/)
+        nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 2,
             'CMR-Took': 7,

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -29,6 +29,10 @@ export default {
         conceptId: collectionId
       } = source
 
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (collectionId.startsWith('CD')) return null
+
       // Empty object that will contain the search parameters sent to CMR
       const granuleParams = {}
 
@@ -77,6 +81,12 @@ export default {
     relatedCollections: async (source, args, context, info) => {
       const { dataSources } = context
 
+      const { conceptId } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('CD')) return null
+
       return dataSources.graphDbSource(source, args, context, parseResolveInfo(info))
     },
     generateVariableDrafts: async (source, args, context) => {
@@ -88,14 +98,21 @@ export default {
     },
     dataQualitySummaries: async (source, args, context, info) => {
       const {
-        associationDetails = {}
+        associationDetails = {},
+        conceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('CD')) return null
 
       const { dataSources } = context
 
       const { dataQualitySummaries = [] } = associationDetails
 
-      const dataQualitySummaryConceptIds = dataQualitySummaries.map(({ conceptId }) => conceptId)
+      const dataQualitySummaryConceptIds = dataQualitySummaries.map(
+        ({ conceptId: dqsId }) => dqsId
+      )
 
       if (!dataQualitySummaryConceptIds.length) {
         return {
@@ -112,6 +129,12 @@ export default {
     duplicateCollections: async (source, args, context) => {
       const { dataSources } = context
 
+      const { conceptId } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('CD')) return null
+
       return dataSources.graphDbDuplicateCollectionsSource(source, context)
     },
     services: async (source, args, context, info) => {
@@ -119,6 +142,10 @@ export default {
         associationDetails = {},
         conceptId: collectionConceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (collectionConceptId.startsWith('CD')) return null
 
       const { dataSources } = context
 
@@ -150,6 +177,10 @@ export default {
         conceptId: collectionId
       } = source
 
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (collectionId.startsWith('CD')) return null
+
       const { dataSources } = context
 
       return dataSources.subscriptionSourceFetch({
@@ -159,14 +190,19 @@ export default {
     },
     tools: async (source, args, context, info) => {
       const {
-        associationDetails = {}
+        associationDetails = {},
+        conceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('CD')) return null
 
       const { dataSources } = context
 
       const { tools = [] } = associationDetails
 
-      const toolConceptIds = tools.map(({ conceptId }) => conceptId)
+      const toolConceptIds = tools.map(({ conceptId: toolId }) => toolId)
 
       if (!tools.length) {
         return {
@@ -182,14 +218,19 @@ export default {
     },
     variables: async (source, args, context, info) => {
       const {
-        associationDetails = {}
+        associationDetails = {},
+        conceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('CD')) return null
 
       const { dataSources } = context
 
       const { variables = [] } = associationDetails
 
-      const variableConceptIds = variables.map(({ conceptId }) => conceptId)
+      const variableConceptIds = variables.map(({ conceptId: variableId }) => variableId)
 
       if (!variables.length) {
         return {

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -1,6 +1,7 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
 
 export default {
   Query: {
@@ -31,7 +32,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (collectionId.startsWith('CD')) return null
+      if (isDraftConceptId(collectionId, 'collection')) return null
 
       // Empty object that will contain the search parameters sent to CMR
       const granuleParams = {}
@@ -85,7 +86,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('CD')) return null
+      if (isDraftConceptId(conceptId, 'collection')) return null
 
       return dataSources.graphDbSource(source, args, context, parseResolveInfo(info))
     },
@@ -104,7 +105,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('CD')) return null
+      if (isDraftConceptId(conceptId, 'collection')) return null
 
       const { dataSources } = context
 
@@ -133,7 +134,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('CD')) return null
+      if (isDraftConceptId(conceptId, 'collection')) return null
 
       return dataSources.graphDbDuplicateCollectionsSource(source, context)
     },
@@ -145,7 +146,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (collectionConceptId.startsWith('CD')) return null
+      if (isDraftConceptId(collectionConceptId, 'collection')) return null
 
       const { dataSources } = context
 
@@ -179,7 +180,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (collectionId.startsWith('CD')) return null
+      if (isDraftConceptId(collectionId, 'collection')) return null
 
       const { dataSources } = context
 
@@ -196,7 +197,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('CD')) return null
+      if (isDraftConceptId(conceptId, 'collection')) return null
 
       const { dataSources } = context
 
@@ -224,7 +225,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('CD')) return null
+      if (isDraftConceptId(conceptId, 'collection')) return null
 
       const { dataSources } = context
 

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -1,5 +1,6 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
 
 export default {
   Mutation: {
@@ -30,8 +31,7 @@ export default {
     draft: async (source, args, context, info) => {
       const { dataSources } = context
 
-      const result = await
-      dataSources.draftSourceFetch(args, context, parseResolveInfo(info))
+      const result = await dataSources.draftSourceFetch(args, context, parseResolveInfo(info))
 
       const [firstResult] = result
 
@@ -51,10 +51,12 @@ export default {
     __resolveType: (source) => {
       const { conceptId } = source
 
-      if (conceptId.startsWith('CD')) return 'Collection'
-      if (conceptId.startsWith('SD')) return 'Service'
-      if (conceptId.startsWith('TD')) return 'Tool'
-      if (conceptId.startsWith('VD')) return 'Variable'
+      // PreviewMetadata is a union, __resolveType is necessary to tell GraphQL which type is being returned
+      // Check the source conceptId in order to determine which union type is correct.
+      if (isDraftConceptId(conceptId, 'collection')) return 'Collection'
+      if (isDraftConceptId(conceptId, 'service')) return 'Service'
+      if (isDraftConceptId(conceptId, 'tool')) return 'Tool'
+      if (isDraftConceptId(conceptId, 'variable')) return 'Variable'
 
       return null
     }

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -1,0 +1,62 @@
+import { parseResolveInfo } from 'graphql-parse-resolve-info'
+import { handlePagingParams } from '../utils/handlePagingParams'
+
+export default {
+  Mutation: {
+    ingestDraft: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const result = await dataSources.draftSourceIngest(
+        args,
+        context,
+        parseResolveInfo(info)
+      )
+
+      return result
+    },
+    deleteDraft: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const result = await dataSources.draftSourceDelete(
+        args,
+        context,
+        parseResolveInfo(info)
+      )
+
+      return result
+    }
+  },
+  Query: {
+    draft: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const result = await
+      dataSources.draftSourceFetch(args, context, parseResolveInfo(info))
+
+      const [firstResult] = result
+
+      return firstResult
+    },
+    drafts: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.draftSourceFetch(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    }
+  },
+  DraftMetadata: {
+    __resolveType: (source) => {
+      const { conceptId } = source
+
+      if (conceptId.startsWith('CD')) return 'Collection'
+      if (conceptId.startsWith('SD')) return 'Service'
+      if (conceptId.startsWith('TD')) return 'Tool'
+      if (conceptId.startsWith('VD')) return 'Variable'
+
+      return null
+    }
+  }
+}

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -47,7 +47,7 @@ export default {
       )
     }
   },
-  DraftMetadata: {
+  PreviewMetadata: {
     __resolveType: (source) => {
       const { conceptId } = source
 

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,25 +1,27 @@
 import { mergeResolvers } from '@graphql-tools/merge'
 
-import collectionDraftResolver from './collectionDraft'
 import collectionDraftProposalResolver from './collectionDraftProposal'
+import collectionDraftResolver from './collectionDraft'
 import collectionResolver from './collection'
+import dataQualitySummaryResolver from './dataQualitySummary'
+import draftResolver from './draft'
 import granuleResolver from './granule'
 import gridResolver from './grid'
+import orderOptionResolver from './orderOption'
 import serviceResolver from './service'
 import serviceDraftResolver from './serviceDraft'
 import subscriptionResolver from './subscription'
 import toolDraftResolver from './toolDraft'
 import toolResolver from './tool'
-import variableResolver from './variable'
 import variableDraftResolver from './variableDraft'
-import orderOptionResolver from './orderOption'
-import dataQualitySummaryResolver from './dataQualitySummary'
+import variableResolver from './variable'
 
 const resolvers = [
-  collectionDraftResolver,
   collectionDraftProposalResolver,
+  collectionDraftResolver,
   collectionResolver,
   dataQualitySummaryResolver,
+  draftResolver,
   granuleResolver,
   gridResolver,
   orderOptionResolver,
@@ -28,8 +30,8 @@ const resolvers = [
   subscriptionResolver,
   toolDraftResolver,
   toolResolver,
-  variableResolver,
-  variableDraftResolver
+  variableDraftResolver,
+  variableResolver
 ]
 
 export default mergeResolvers(resolvers)

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -29,6 +29,10 @@ export default {
         conceptId
       } = source
 
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('SD')) return null
+
       const requestedParams = handlePagingParams({
         serviceConceptId: conceptId,
         ...args
@@ -40,11 +44,15 @@ export default {
       const { dataSources } = context
 
       // Pull out the service's parent collection id to filter the associated orderOptions only to those collections
-
       const {
         associationDetails = {},
+        conceptId,
         parentCollectionConceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('SD')) return null
 
       const { collections = [] } = associationDetails
       // If there are no associations to collections for this service
@@ -89,14 +97,21 @@ export default {
     },
     variables: async (source, args, context, info) => {
       const {
-        associationDetails = {}
+        associationDetails = {},
+        conceptId
       } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('SD')) return null
 
       const { dataSources } = context
 
       const { variables = [] } = associationDetails
 
-      const variableConceptIds = variables.map(({ conceptId }) => conceptId)
+      const variableConceptIds = variables.map(
+        ({ conceptId: variableConceptId }) => variableConceptId
+      )
 
       if (!variables.length) {
         return {
@@ -111,7 +126,15 @@ export default {
       }, context, parseResolveInfo(info))
     },
     maxItemsPerOrder: async (source, args, context) => {
-      const { providerId, type } = source
+      const {
+        conceptId,
+        providerId,
+        type
+      } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('SD')) return null
 
       if (type !== 'ECHO ORDERS') return null
 

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -1,6 +1,7 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
 
 export default {
   Query: {
@@ -31,7 +32,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('SD')) return null
+      if (isDraftConceptId(conceptId, 'service')) return null
 
       const requestedParams = handlePagingParams({
         serviceConceptId: conceptId,
@@ -52,7 +53,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('SD')) return null
+      if (isDraftConceptId(conceptId, 'service')) return null
 
       const { collections = [] } = associationDetails
       // If there are no associations to collections for this service
@@ -103,7 +104,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('SD')) return null
+      if (isDraftConceptId(conceptId, 'service')) return null
 
       const { dataSources } = context
 
@@ -134,7 +135,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('SD')) return null
+      if (isDraftConceptId(conceptId, 'service')) return null
 
       if (type !== 'ECHO ORDERS') return null
 

--- a/src/resolvers/tool.js
+++ b/src/resolvers/tool.js
@@ -25,9 +25,11 @@ export default {
       const { dataSources } = context
 
       // Pull out parent collection id to provide to the granules endpoint because cmr requires it
-      const {
-        conceptId
-      } = source
+      const { conceptId } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('TD')) return null
 
       const requestedParams = handlePagingParams({
         toolConceptId: conceptId,

--- a/src/resolvers/tool.js
+++ b/src/resolvers/tool.js
@@ -1,6 +1,7 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
 
 export default {
   Query: {
@@ -29,7 +30,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('TD')) return null
+      if (isDraftConceptId(conceptId, 'tool')) return null
 
       const requestedParams = handlePagingParams({
         toolConceptId: conceptId,

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -29,6 +29,10 @@ export default {
         conceptId
       } = source
 
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (conceptId.startsWith('VD')) return null
+
       const requestedParams = handlePagingParams({
         variableConceptId: conceptId,
         ...args

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -1,6 +1,7 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 
 import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
 
 export default {
   Query: {
@@ -31,7 +32,7 @@ export default {
 
       // If the concept being returned is a draft, there will be no associations,
       // return null to avoid an extra call to CMR
-      if (conceptId.startsWith('VD')) return null
+      if (isDraftConceptId(conceptId, 'variable')) return null
 
       const requestedParams = handlePagingParams({
         variableConceptId: conceptId,

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -1,5 +1,7 @@
+"DraftMetadata can be either a Collection, Service, Tool or Variable."
 union DraftMetadata = Collection | Service | Tool | Variable
 
+"DraftConceptType must be one of the enum values."
 enum DraftConceptType {
   Collection
   Service
@@ -8,66 +10,105 @@ enum DraftConceptType {
 }
 
 type DraftMutationResponse {
+  "The concept id of the draft."
   conceptId: String!
+  "The revision id of the draft."
   revisionId: String!
+  "Warnings returned from ingesting the draft."
   warnings: [JSON]
+  "Existing errors in the draft."
   existingErrors: [JSON]
 }
 
 type Draft {
+  "The concept id of the draft."
   conceptId: String
+  "The concept type of the draft."
   conceptType: String
+  "If the draft has been deleted."
   deleted: Boolean
+  "Name of the draft."
   name: String
+  "The native id of the draft."
   nativeId: String
+  "Provider ID of the draft."
   providerId: String
+  "Date which the draft was last updated."
   revisionDate: String
+  "The revision id of the draft."
   revisionId: String
+  "The metadata content of the draft"
   draftMetadata: DraftMetadata
 }
 
 type DraftList {
+  "The number of hits for a given search."
   count: Int
+  "Cursor that points to the a specific position in a list of requested records."
+  cursor: String
+  "The list of draft search results."
   items: [Draft]
 }
 
 type Mutation {
   ingestDraft (
+    "The concept type of the draft."
     conceptType: DraftConceptType!
     metadata: JSON!
+    "The native id of the draft."
     nativeId: String!
+    "Provider ID of the draft."
     providerId: String!
   ): DraftMutationResponse
 
   deleteDraft (
+    "The concept type of the draft."
     conceptType: DraftConceptType!
+    "The native id of the draft."
     nativeId: String!
+    "Provider ID of the draft."
     providerId: String!
   ): DraftMutationResponse
 }
 
 input DraftInput {
+  "The concept type of the draft."
   conceptType: DraftConceptType!
+  "The concept id of the draft."
   conceptId: String!
 }
 
 input DraftsInput {
+  "The concept type of the draft."
   conceptType: DraftConceptType!
+  "The concept id of the draft."
   conceptId: [String]
+  "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+  "The number of draft requested by the user."
+  limit: Int
+  "The name of the draft."
   name: [String]
+  "The native id of the draft."
   nativeId: [String]
+  "Zero based offset of individual results."
+  offset: Int
+  "Options to provide to CMR pertaining to and, or, and wildcard searching."
   options: JSON
+  "The name of the provider associated with the draft."
   provider: [String]
+  "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]
 }
 
 type Query {
   draft (
+    "Draft query parameters"
     params: DraftInput
   ): Draft
 
   drafts (
+    "Drafts query parameters"
     params: DraftsInput
   ): DraftList
 }

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -1,5 +1,5 @@
-"DraftMetadata can be either a Collection, Service, Tool or Variable."
-union DraftMetadata = Collection | Service | Tool | Variable
+"PreviewMetadata can be either a Collection, Service, Tool or Variable."
+union PreviewMetadata = Collection | Service | Tool | Variable
 
 "DraftConceptType must be one of the enum values."
 enum DraftConceptType {
@@ -37,8 +37,10 @@ type Draft {
   revisionDate: String
   "The revision id of the draft."
   revisionId: String
-  "The metadata content of the draft"
-  draftMetadata: DraftMetadata
+  "The Metadata Preview compatible metadata of the draft."
+  previewMetadata: PreviewMetadata
+  "Raw UMM Metadata of the draft."
+  ummMetadata: JSON
 }
 
 type DraftList {
@@ -54,11 +56,14 @@ type Mutation {
   ingestDraft (
     "The concept type of the draft."
     conceptType: DraftConceptType!
+    "UMM Metadata of the draft to ingest."
     metadata: JSON!
     "The native id of the draft."
     nativeId: String!
     "Provider ID of the draft."
     providerId: String!
+    "UMM Version of the metadata being ingested."
+    ummVersion: String!
   ): DraftMutationResponse
 
   deleteDraft (
@@ -76,6 +81,8 @@ input DraftInput {
   conceptType: DraftConceptType!
   "The concept id of the draft."
   conceptId: String!
+  "UMM Version of the draft."
+  ummVersion: String
 }
 
 input DraftsInput {
@@ -99,6 +106,8 @@ input DraftsInput {
   provider: [String]
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]
+  "UMM Version of the draft."
+  ummVersion: String
 }
 
 type Query {

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -1,0 +1,73 @@
+union DraftMetadata = Collection | Service | Tool | Variable
+
+enum DraftConceptType {
+  Collection
+  Service
+  Tool
+  Variable
+}
+
+type DraftMutationResponse {
+  conceptId: String!
+  revisionId: String!
+  warnings: [JSON]
+  existingErrors: [JSON]
+}
+
+type Draft {
+  conceptId: String
+  conceptType: String
+  deleted: Boolean
+  name: String
+  nativeId: String
+  providerId: String
+  revisionDate: String
+  revisionId: String
+  draftMetadata: DraftMetadata
+}
+
+type DraftList {
+  count: Int
+  items: [Draft]
+}
+
+type Mutation {
+  ingestDraft (
+    conceptType: DraftConceptType!
+    metadata: JSON!
+    nativeId: String!
+    providerId: String!
+  ): DraftMutationResponse
+
+  deleteDraft (
+    conceptType: DraftConceptType!
+    nativeId: String!
+    providerId: String!
+  ): DraftMutationResponse
+}
+
+input DraftInput {
+  conceptType: DraftConceptType!
+  conceptId: String!
+}
+
+input DraftsInput {
+  conceptType: DraftConceptType!
+  conceptId: [String]
+  cursor: String
+  name: [String]
+  nativeId: [String]
+  options: JSON
+  provider: [String]
+  sortKey: [String]
+}
+
+type Query {
+  draft (
+    params: DraftInput
+  ): Draft
+
+  drafts (
+    params: DraftsInput
+  ): DraftList
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -4,6 +4,7 @@ import collection from './collection.graphql'
 import collectionDraft from './collectionDraft.graphql'
 import collectionDraftProposal from './collectionDraftProposal.graphql'
 import dataQualitySummary from './dataQualitySummary.graphql'
+import draft from './draft.graphql'
 import granule from './granule.graphql'
 import grid from './grid.graphql'
 import json from './json.graphql'
@@ -22,6 +23,7 @@ export default mergeTypeDefs(
     collectionDraft,
     collectionDraftProposal,
     dataQualitySummary,
+    draft,
     granule,
     grid,
     json,

--- a/src/utils/__tests__/cmrDelete.test.js
+++ b/src/utils/__tests__/cmrDelete.test.js
@@ -9,7 +9,7 @@ describe('cmrDelete', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('cmrDelete', () => {
   test('deletes a record from cmr', async () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-    nock(/example/, {
+    nock(/example-cmr/, {
       reqheaders: {
         Accept: 'application/json',
         'Client-Id': 'eed-test-graphql',
@@ -65,7 +65,7 @@ describe('cmrDelete', () => {
     test('queries cmr using the Authorization header', async () => {
       const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           Accept: 'application/json',
           Authorization: 'Bearer test-token',
@@ -112,7 +112,7 @@ describe('cmrDelete', () => {
 
   describe('when an error is returned', () => {
     test('throws an exception', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/utils/__tests__/cmrIngest.test.js
+++ b/src/utils/__tests__/cmrIngest.test.js
@@ -11,7 +11,7 @@ describe('cmrIngest', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -21,7 +21,7 @@ describe('cmrIngest', () => {
   test('ingests a record into cmr', async () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-    nock(/example/, {
+    nock(/example-cmr/, {
       reqheaders: {
         Accept: 'application/json',
         'Client-Id': 'eed-test-graphql',
@@ -66,7 +66,7 @@ describe('cmrIngest', () => {
     test('ingests a record into cmr with the provided native id', async () => {
       const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           Accept: 'application/json',
           'Client-Id': 'eed-test-graphql',
@@ -113,7 +113,7 @@ describe('cmrIngest', () => {
     test('queries cmr using the Authorization header', async () => {
       const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           Accept: 'application/json',
           'Client-Id': 'eed-test-graphql',
@@ -157,7 +157,7 @@ describe('cmrIngest', () => {
 
   describe('when an error is returned', () => {
     test('throws an exception', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/utils/__tests__/cmrOrdering.test.js
+++ b/src/utils/__tests__/cmrOrdering.test.js
@@ -9,7 +9,7 @@ describe('cmrOrdering', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('cmrOrdering', () => {
   test('queries cmr-ordering', async () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-    nock(/example/, {
+    nock(/example-cmr/, {
       reqheaders: {
         'Client-Id': 'eed-test-graphql',
         'X-Request-Id': 'abcd-1234-efgh-5678'
@@ -68,7 +68,7 @@ describe('cmrOrdering', () => {
 
   describe('when an error is returned', () => {
     test('throws an exception', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/utils/__tests__/cmrQuery.test.js
+++ b/src/utils/__tests__/cmrQuery.test.js
@@ -9,7 +9,7 @@ describe('cmrQuery', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
 
-    process.env.cmrRootUrl = 'http://example.com'
+    process.env.cmrRootUrl = 'http://example-cmr.com'
   })
 
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('cmrQuery', () => {
   test('queries cmr', async () => {
     const consoleMock = jest.spyOn(console, 'log').mockImplementation(() => jest.fn())
 
-    nock(/example/, {
+    nock(/example-cmr/, {
       reqheaders: {
         'Client-Id': 'eed-test-graphql',
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -68,7 +68,7 @@ describe('cmrQuery', () => {
 
   describe('when provided a format', () => {
     test('queries cmr', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -106,7 +106,7 @@ describe('cmrQuery', () => {
 
   describe('when provided a token via the Authorization header', () => {
     test('queries cmr using the Authorization header', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           Authorization: 'Bearer test-token',
           'Client-Id': 'eed-test-graphql',
@@ -145,7 +145,7 @@ describe('cmrQuery', () => {
 
   describe('when an error is returned', () => {
     test('throws an exception', async () => {
-      nock(/example/, {
+      nock(/example-cmr/, {
         reqheaders: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'

--- a/src/utils/__tests__/getUserPermittedGroups.test.js
+++ b/src/utils/__tests__/getUserPermittedGroups.test.js
@@ -7,7 +7,7 @@ describe('Retrieve data from EDL on the user groups', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV }
     process.env.rsaKey = ''
-    process.env.ursRootUrl = 'http://example.com'
+    process.env.ursRootUrl = 'http://example-urs.com'
     process.env.edlClientId = 'clientIdOfSomeApplication'
   })
 
@@ -16,7 +16,7 @@ describe('Retrieve data from EDL on the user groups', () => {
   })
 
   test('Retrieving correct data from the permitted groups', async () => {
-    nock(/example/)
+    nock(/example-urs/)
       .get(/user_groups/)
       .reply(200, {
         user_groups: [
@@ -49,7 +49,7 @@ describe('Retrieve data from EDL on the user groups', () => {
   })
 
   test('If the user has no groups they would still have guest and registered privillages', async () => {
-    nock(/example/)
+    nock(/example-urs/)
       .get(/user_groups/)
       .reply(200, {
         user_groups: []
@@ -63,7 +63,7 @@ describe('Retrieve data from EDL on the user groups', () => {
   })
 
   test('If the response has an issue and returns null the client should still have guest privillages ', async () => {
-    nock(/example/)
+    nock(/example-urs/)
       .get(/user_groups/)
       .reply(400, null)
 
@@ -75,7 +75,7 @@ describe('Retrieve data from EDL on the user groups', () => {
   })
 
   test('If the response has an issue and returns null the client should still have guest privillages ', async () => {
-    nock(/example/)
+    nock(/example-urs/)
       .get(/user_groups/)
       .reply(400, null)
 

--- a/src/utils/__tests__/isDraftConceptId.test.js
+++ b/src/utils/__tests__/isDraftConceptId.test.js
@@ -1,0 +1,51 @@
+import { isDraftConceptId } from '../isDraftConceptId'
+
+describe('isDraftConceptId', () => {
+  describe('when the concept id is a draft collection', () => {
+    test('returns true', () => {
+      expect(isDraftConceptId('CD100000-EDSC', 'collection')).toEqual(true)
+    })
+  })
+
+  describe('when the concept id is a published collection', () => {
+    test('returns false', () => {
+      expect(isDraftConceptId('C100000-EDSC', 'collection')).toEqual(false)
+    })
+  })
+
+  describe('when the concept id is a draft service', () => {
+    test('returns true', () => {
+      expect(isDraftConceptId('SD100000-EDSC', 'service')).toEqual(true)
+    })
+  })
+
+  describe('when the concept id is a published service', () => {
+    test('returns false', () => {
+      expect(isDraftConceptId('S100000-EDSC', 'service')).toEqual(false)
+    })
+  })
+
+  describe('when the concept id is a draft tool', () => {
+    test('returns true', () => {
+      expect(isDraftConceptId('TD100000-EDSC', 'tool')).toEqual(true)
+    })
+  })
+
+  describe('when the concept id is a published tool', () => {
+    test('returns false', () => {
+      expect(isDraftConceptId('T100000-EDSC', 'tool')).toEqual(false)
+    })
+  })
+
+  describe('when the concept id is a draft variable', () => {
+    test('returns true', () => {
+      expect(isDraftConceptId('VD100000-EDSC', 'variable')).toEqual(true)
+    })
+  })
+
+  describe('when the concept id is a published variable', () => {
+    test('returns false', () => {
+      expect(isDraftConceptId('V100000-EDSC', 'variable')).toEqual(false)
+    })
+  })
+})

--- a/src/utils/isDraftConceptId.js
+++ b/src/utils/isDraftConceptId.js
@@ -1,0 +1,10 @@
+import { DRAFT_CONCEPT_ID_PREFIXES } from '../constants'
+
+/**
+ * Test if the provided concept ID is a draft
+ * @param {String} conceptId Concept ID to test
+ * @param {String} type Type of concept to check
+ */
+export const isDraftConceptId = (conceptId, type) => (
+  conceptId.startsWith(DRAFT_CONCEPT_ID_PREFIXES[type])
+)

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -204,14 +204,6 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
     }
   }
 
-  if (name === 'draft' || name === 'drafts') {
-    // If a user has requested the collection when making a granule query, but has not requested the
-    // collectionConceptId, push the collection conceptId onto the requested fields.
-    if (requestedFields.includes('draftMetadata') && !requestedFields.includes('conceptId')) {
-      requestedFields.push('conceptId')
-    }
-  }
-
   const { sharedKeys = [], ummKeyMappings } = keyMap
 
   // Gather keys that the user requested that only exist in umm

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -204,6 +204,14 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
     }
   }
 
+  if (name === 'draft' || name === 'drafts') {
+    // If a user has requested the collection when making a granule query, but has not requested the
+    // collectionConceptId, push the collection conceptId onto the requested fields.
+    if (requestedFields.includes('draftMetadata') && !requestedFields.includes('conceptId')) {
+      requestedFields.push('conceptId')
+    }
+  }
+
   const { sharedKeys = [], ummKeyMappings } = keyMap
 
   // Gather keys that the user requested that only exist in umm

--- a/src/utils/umm/draftKeyMap.json
+++ b/src/utils/umm/draftKeyMap.json
@@ -12,9 +12,10 @@
     "deleted": "meta.deleted",
     "name": "umm.Name",
     "nativeId": "meta.native-id",
+    "previewMetadata": "",
     "providerId": "meta.provider-id",
     "revisionDate": "meta.revision-date",
     "revisionId": "meta.revision-id",
-    "draftMetadata": ""
+    "ummMetadata": "umm"
   }
 }

--- a/src/utils/umm/draftKeyMap.json
+++ b/src/utils/umm/draftKeyMap.json
@@ -1,0 +1,20 @@
+{
+  "sharedKeys": [
+    "conceptId",
+    "name",
+    "nativeId",
+    "providerId",
+    "revisionId"
+  ],
+  "ummKeyMappings": {
+    "conceptId": "meta.concept-id",
+    "conceptType": "meta.concept-type",
+    "deleted": "meta.deleted",
+    "name": "umm.Name",
+    "nativeId": "meta.native-id",
+    "providerId": "meta.provider-id",
+    "revisionDate": "meta.revision-date",
+    "revisionId": "meta.revision-id",
+    "draftMetadata": ""
+  }
+}

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -9,7 +9,6 @@
     "ancillaryKeywords": "umm.AncillaryKeywords",
     "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
-    "conceptType": "meta.concept-type",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",
     "description": "umm.Description",

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -9,6 +9,7 @@
     "ancillaryKeywords": "umm.AncillaryKeywords",
     "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
+    "conceptType": "meta.concept-type",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",
     "description": "umm.Description",


### PR DESCRIPTION
# Overview

### What is the feature?

Adds mutations and queries for Collection/Service/Tool/Variable draft concepts

### What areas of the application does this impact?

New `Draft` type/resolvers added.

# Testing

### Reproduction steps

`drafts` query (`draft` query is the same, just singular nouns and no count/items fields)
```
query Drafts($params: DraftsInput) {
  drafts(params: $params) {
    count
    items {
      conceptId
      conceptType
      deleted
      name
      nativeId
      providerId
      revisionDate
      revisionId
      draftMetadata {
        ... on Tool { // needs to match the params conceptType
          name
        }
      }
    }
  }
}
```
Variables:
```
{
  "params": {
    "conceptType": "Tool"
  }
}
```

`ingestDraft` mutation (does create and update)
```
mutation IngestDraft(
  $conceptType: DraftConceptType!
  $metadata: JSON!
  $nativeId: String!
  $providerId: String!
) {
  ingestDraft(
    conceptType: $conceptType
    metadata: $metadata
    nativeId: $nativeId
    providerId: $providerId
  ) {
    conceptId
    revisionId
    warnings
    existingErrors
  }
}
```
Variables:
```
{
  "conceptType": "Tool",
  "metadata": {
    "Name": "Tool 2",
    "LongName": "Long Tool Name"
  },
  "nativeId": "tool-2",
  "providerId": "MMT_2"
}
```

`deleteDraft` query
```
mutation DeleteDraft(
  $conceptType: DraftConceptType!
  $nativeId: String!
  $providerId: String!
) {
  deleteDraft(
    conceptType: $conceptType
    nativeId: $nativeId
    providerId: $providerId
  ) {
    conceptId
    revisionId
    warnings
    existingErrors
  }
}
```
Variables:
```
{
  "conceptType": "Tool",
  "nativeId": "tool-2",
  "providerId": "MMT_2"
}
```

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
