### PR TITLE
MMT-3417: As a MMT dev, I want to be able to CRUD UMM-V records in CMR GraphQL

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -367,12 +367,13 @@ export default class Concept {
     this.logKeyRequest(requestedKeys, 'ingest')
 
     // Construct the promise that will ingest data into CMR
-    this.response = cmrIngest(
-      this.getConceptType(),
-      params,
-      providedHeaders,
-      this.ingestPath
-    )
+    this.response = cmrIngest({
+      camelCaseKeys: false,
+      conceptType: this.getConceptType(),
+      data: params,
+      headers: providedHeaders,
+      ingestPath: this.ingestPath
+    })
   }
 
   /**

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -368,7 +368,6 @@ export default class Concept {
 
     // Construct the promise that will ingest data into CMR
     this.response = cmrIngest({
-      camelCaseKeys: false,
       conceptType: this.getConceptType(),
       data: params,
       headers: providedHeaders,

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -227,7 +227,7 @@ export default class Draft extends Concept {
       ...pick(params, this.getPermittedPublishKeys()),
       'collection-concept-id': collectionConceptId
     }
-
+    // Calling cmrIngest directly because the ingest path is different for publish is different.
     this.response = cmrIngest({
       conceptType: this.getConceptType(),
       data: prepDataForCmr,

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -227,7 +227,8 @@ export default class Draft extends Concept {
       ...pick(params, this.getPermittedPublishKeys()),
       'collection-concept-id': collectionConceptId
     }
-    // Calling cmrIngest directly because the ingest path is different for publish is different.
+
+    // Calling cmrIngest directly because the ingest path is different for publish.
     this.response = cmrIngest({
       conceptType: this.getConceptType(),
       data: prepDataForCmr,

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -220,18 +220,17 @@ export default class Draft extends Concept {
 
     this.logKeyRequest(requestedKeys, 'ingest')
 
-    // Construct the promise that will ingest data into CMR
-    // return cmrIngest({
-    //   camelCaseKeys: false,
-    //   conceptType: this.getConceptType(),
-    //   data: pick(params, this.getPermittedPublishKeys()),
-    //   headers: permittedHeaders,
-    //   ingestPath: this.publish
-    // })
+    const { collectionConceptId } = params
+    delete params.collectionConceptId
+
+    const prepDataForCmr = {
+      ...pick(params, this.getPermittedPublishKeys()),
+      'collection-concept-id': collectionConceptId
+    }
+
     this.response = cmrIngest({
-      camelCaseKeys: false,
       conceptType: this.getConceptType(),
-      data: pick(params, this.getPermittedPublishKeys()),
+      data: prepDataForCmr,
       headers: permittedHeaders,
       ingestPath: this.publishPath
     })

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -124,7 +124,8 @@ export default class Draft extends Concept {
 
   getPermittedPublishKeys() {
     return [
-      'nativeId'
+      'nativeId',
+      'collectionConceptId'
     ]
   }
 
@@ -220,11 +221,19 @@ export default class Draft extends Concept {
     this.logKeyRequest(requestedKeys, 'ingest')
 
     // Construct the promise that will ingest data into CMR
-    this.response = cmrIngest(
-      this.getConceptType(),
-      pick(params, this.getPermittedPublishKeys()),
-      permittedHeaders,
-      this.publishPath
-    )
+    // return cmrIngest({
+    //   camelCaseKeys: false,
+    //   conceptType: this.getConceptType(),
+    //   data: pick(params, this.getPermittedPublishKeys()),
+    //   headers: permittedHeaders,
+    //   ingestPath: this.publish
+    // })
+    this.response = cmrIngest({
+      camelCaseKeys: false,
+      conceptType: this.getConceptType(),
+      data: pick(params, this.getPermittedPublishKeys()),
+      headers: permittedHeaders,
+      ingestPath: this.publishPath
+    })
   }
 }

--- a/src/cmr/concepts/subscription.js
+++ b/src/cmr/concepts/subscription.js
@@ -1,4 +1,6 @@
+import camelcaseKeys from 'camelcase-keys'
 import { uniq } from 'lodash'
+import { mergeParams } from '../../utils/mergeParams'
 
 import { pickIgnoringCase } from '../../utils/pickIgnoringCase'
 import Concept from './concept'
@@ -113,6 +115,11 @@ export default class Subscription extends Concept {
     // eslint-disable-next-line no-param-reassign
     data.metadataSpecification = this.metadataSpecification
 
-    super.ingest(data, requestedKeys, permittedHeaders)
+    const prepDataForCmr = camelcaseKeys(mergeParams(data), {
+      pascalCase: true,
+      exclude: ['nativeId']
+    })
+
+    super.ingest(prepDataForCmr, requestedKeys, permittedHeaders)
   }
 }

--- a/src/cmr/concepts/variable.js
+++ b/src/cmr/concepts/variable.js
@@ -1,5 +1,3 @@
-import camelcaseKeys from 'camelcase-keys'
-
 import Concept from './concept'
 
 export default class Variable extends Concept {
@@ -8,73 +6,13 @@ export default class Variable extends Concept {
    * @param {Object} headers HTTP headers provided by the query
    * @param {Object} requestInfo Parsed data pertaining to the Graph query
    * @param {Object} params GraphQL query parameters
-   * @param {String} parentCollectionConceptId Optional collection-id passed for some child queries of search
    */
-  constructor(headers, requestInfo, params, parentCollectionConceptId) {
+  constructor(headers, requestInfo, params) {
     super('variables', headers, requestInfo, params)
-    this.parentCollectionConceptId = parentCollectionConceptId
 
     const { providerId } = params
 
     this.ingestPath = `providers/${providerId}/variables`
-  }
-
-  /**
-   * Set a value in the result set that a query has not requested but is necessary for other functionality
-   * @param {String} id Concept ID to set a value for within the result set
-   * @param {Object} item The item returned from the CMR json endpoint
-   */
-  setEssentialJsonValues(id, item) {
-    super.setEssentialJsonValues(id, item)
-
-    // Add the parent collection concept-id and pass it to the child queries from this variable
-    if (this.parentCollectionConceptId) {
-      this.setItemValue(id, 'parentCollectionConceptId', this.parentCollectionConceptId)
-    }
-  }
-
-  /**
-     * Set a value in the result set that a query has not requested but is necessary for other functionality
-     * @param {String} id Concept ID to set a value for within the result set
-     * @param {Object} item The item returned from the CMR json endpoint
-     */
-  setEssentialUmmValues(id, item) {
-    super.setEssentialUmmValues(id, item)
-
-    const { meta } = item
-    const { 'association-details': associationDetails } = meta
-
-    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
-
-    //  Associations on variables are used to retrieve order-options
-    if (associationDetails) {
-      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
-    }
-
-    // Add the parent collection concept-id and pass it to the child queries from this variable
-    if (this.parentCollectionConceptId) {
-      this.setItemValue(id, 'parentCollectionConceptId', this.parentCollectionConceptId)
-    }
-  }
-
-  /**
-   * Returns an array of keys representing supported search params for the json endpoint
-   */
-  getPermittedJsonSearchParams() {
-    return [
-      ...super.getPermittedJsonSearchParams(),
-      'type'
-    ]
-  }
-
-  /**
-     * Returns an array of keys representing supported search params for the umm endpoint
-     */
-  getPermittedUmmSearchParams() {
-    return [
-      ...super.getPermittedUmmSearchParams(),
-      'type'
-    ]
   }
 
   /**

--- a/src/cmr/concepts/variable.js
+++ b/src/cmr/concepts/variable.js
@@ -1,3 +1,5 @@
+import camelcaseKeys from 'camelcase-keys'
+
 import Concept from './concept'
 
 export default class Variable extends Concept {
@@ -6,9 +8,73 @@ export default class Variable extends Concept {
    * @param {Object} headers HTTP headers provided by the query
    * @param {Object} requestInfo Parsed data pertaining to the Graph query
    * @param {Object} params GraphQL query parameters
+   * @param {String} parentCollectionConceptId Optional collection-id passed for some child queries of search
    */
-  constructor(headers, requestInfo, params) {
+  constructor(headers, requestInfo, params, parentCollectionConceptId) {
     super('variables', headers, requestInfo, params)
+    this.parentCollectionConceptId = parentCollectionConceptId
+
+    const { providerId } = params
+
+    this.ingestPath = `providers/${providerId}/variables`
+  }
+
+  /**
+   * Set a value in the result set that a query has not requested but is necessary for other functionality
+   * @param {String} id Concept ID to set a value for within the result set
+   * @param {Object} item The item returned from the CMR json endpoint
+   */
+  setEssentialJsonValues(id, item) {
+    super.setEssentialJsonValues(id, item)
+
+    // Add the parent collection concept-id and pass it to the child queries from this variable
+    if (this.parentCollectionConceptId) {
+      this.setItemValue(id, 'parentCollectionConceptId', this.parentCollectionConceptId)
+    }
+  }
+
+  /**
+     * Set a value in the result set that a query has not requested but is necessary for other functionality
+     * @param {String} id Concept ID to set a value for within the result set
+     * @param {Object} item The item returned from the CMR json endpoint
+     */
+  setEssentialUmmValues(id, item) {
+    super.setEssentialUmmValues(id, item)
+
+    const { meta } = item
+    const { 'association-details': associationDetails } = meta
+
+    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
+
+    //  Associations on variables are used to retrieve order-options
+    if (associationDetails) {
+      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
+    }
+
+    // Add the parent collection concept-id and pass it to the child queries from this variable
+    if (this.parentCollectionConceptId) {
+      this.setItemValue(id, 'parentCollectionConceptId', this.parentCollectionConceptId)
+    }
+  }
+
+  /**
+   * Returns an array of keys representing supported search params for the json endpoint
+   */
+  getPermittedJsonSearchParams() {
+    return [
+      ...super.getPermittedJsonSearchParams(),
+      'type'
+    ]
+  }
+
+  /**
+     * Returns an array of keys representing supported search params for the umm endpoint
+     */
+  getPermittedUmmSearchParams() {
+    return [
+      ...super.getPermittedUmmSearchParams(),
+      'type'
+    ]
   }
 
   /**

--- a/src/datasources/__tests__/variable.test.js
+++ b/src/datasources/__tests__/variable.test.js
@@ -1,6 +1,9 @@
 import nock from 'nock'
 
-import variableDatasource from '../variable'
+import {
+  deleteVariable as variableSourceDelete,
+  fetchVariables as variableSourceFetch
+} from '../variable'
 
 let requestInfo
 
@@ -108,7 +111,7 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({}, {
+      const response = await variableSourceFetch({}, {
         headers: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -146,7 +149,7 @@ describe('variable', () => {
             }]
           })
 
-        const response = await variableDatasource({}, {
+        const response = await variableSourceFetch({}, {
           headers: {
             'Client-Id': 'eed-test-graphql',
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -180,7 +183,7 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({}, {
+      const response = await variableSourceFetch({}, {
         headers: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -212,7 +215,7 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({
+      const response = await variableSourceFetch({
         params: {
           concept_id: 'V100000-EDSC'
         }
@@ -287,7 +290,7 @@ describe('variable', () => {
           }]
         })
 
-      const response = await variableDatasource({
+      const response = await variableSourceFetch({
         params: {
           conceptId: 'V100000-EDSC'
         }
@@ -318,10 +321,103 @@ describe('variable', () => {
       })
 
     await expect(
-      variableDatasource({
+      variableSourceFetch({
         params: {
           conceptId: 'V100000-EDSC'
         }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})
+
+describe('variable#delete', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'deleteVariable',
+      alias: 'deleteVariable',
+      args: {
+        conceptId: 'V100000-EDSC',
+        nativeId: 'test-guid'
+      },
+      fieldsByTypeName: {
+        VariableMutationResponse: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          revisionId: {
+            name: 'revisionId',
+            alias: 'revisionId',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  test('returns the CMR results', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .delete(/ingest\/providers\/EDSC\/variables\/test-guid/)
+      .reply(201, {
+        'concept-id': 'V100000-EDSC',
+        'revision-id': '1'
+      })
+
+    const response = await variableSourceDelete({
+      nativeId: 'test-guid',
+      providerId: 'EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'V100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
+  test('catches errors received from cmrDelete', async () => {
+    nock(/example-cmr/)
+      .delete(/ingest\/providers\/EDSC\/variables\/test-guid/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      variableSourceDelete({
+        nativeId: 'test-guid',
+        providerId: 'EDSC'
       }, {
         headers: {
           'Client-Id': 'eed-test-graphql',

--- a/src/datasources/variable.js
+++ b/src/datasources/variable.js
@@ -4,13 +4,12 @@ import variableKeyMap from '../utils/umm/variableKeyMap.json'
 
 import Variable from '../cmr/concepts/variable'
 
-export const fetchVariables = async (params, context, parsedInfo, parentCollectionConceptId) => {
-  // For variable queries that are children of collections queries, parentCollectionConceptId is defined.
+export const fetchVariables = async (params, context, parsedInfo) => {
   const { headers } = context
 
   const requestInfo = parseRequestedFields(parsedInfo, variableKeyMap, 'variable')
 
-  const variable = new Variable(headers, requestInfo, params, parentCollectionConceptId)
+  const variable = new Variable(headers, requestInfo, params)
 
   // Query CMR
   variable.fetch(params)

--- a/src/datasources/variable.js
+++ b/src/datasources/variable.js
@@ -4,12 +4,13 @@ import variableKeyMap from '../utils/umm/variableKeyMap.json'
 
 import Variable from '../cmr/concepts/variable'
 
-export default async (params, context, parsedInfo) => {
+export const fetchVariables = async (params, context, parsedInfo, parentCollectionConceptId) => {
+  // For variable queries that are children of collections queries, parentCollectionConceptId is defined.
   const { headers } = context
 
   const requestInfo = parseRequestedFields(parsedInfo, variableKeyMap, 'variable')
 
-  const variable = new Variable(headers, requestInfo, params)
+  const variable = new Variable(headers, requestInfo, params, parentCollectionConceptId)
 
   // Query CMR
   variable.fetch(params)
@@ -19,4 +20,25 @@ export default async (params, context, parsedInfo) => {
 
   // Return a formatted JSON response
   return variable.getFormattedResponse()
+}
+
+export const deleteVariable = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, variableKeyMap, 'variable')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const variable = new Variable(headers, requestInfo, args)
+
+  // Contact CMR
+  variable.delete(args, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await variable.parseDelete(requestInfo)
+
+  // Return a formatted JSON response
+  return variable.getFormattedDeleteResponse()
 }

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -25,13 +25,18 @@ import orderOptionSource from '../datasources/orderOption'
 import serviceDraftSource from '../datasources/serviceDraft'
 import toolDraftSource from '../datasources/toolDraft'
 import variableDraftSource from '../datasources/variableDraft'
-import variableSource from '../datasources/variable'
 
 import { deleteTool as toolSourceDelete, fetchTools as toolSourceFetch } from '../datasources/tool'
+
 import {
   deleteService as serviceSourceDelete,
   fetchServices as serviceSourceFetch
 } from '../datasources/service'
+
+import {
+  deleteVariable as variableSourceDelete,
+  fetchVariables as variableSourceFetch
+} from '../datasources/variable'
 
 import {
   deleteSubscription as subscriptionSourceDelete,
@@ -170,7 +175,8 @@ export default startServerAndCreateLambdaHandler(
           toolSourceDelete,
           toolSourceFetch,
           variableDraftSource,
-          variableSource
+          variableSourceDelete,
+          variableSourceFetch
         },
         headers: requestHeaders,
         collectionLoader: new DataLoader(getCollectionsById, { cacheKeyFn: (obj) => obj.conceptId })

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -34,7 +34,7 @@ import {
 } from '../../../datasources/variable'
 import toolDraftSource from '../../../datasources/toolDraft'
 import variableDraftSource from '../../../datasources/variableDraft'
-// Import variableSource from '../../../datasources/variable'
+
 import {
   deleteDraft as draftSourceDelete,
   fetchDrafts as draftSourceFetch,

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -28,9 +28,13 @@ import {
   deleteService as serviceSourceDelete,
   fetchServices as serviceSourceFetch
 } from '../../../datasources/service'
+import {
+  deleteVariable as variableSourceDelete,
+  fetchVariables as variableSourceFetch
+} from '../../../datasources/variable'
 import toolDraftSource from '../../../datasources/toolDraft'
 import variableDraftSource from '../../../datasources/variableDraft'
-import variableSource from '../../../datasources/variable'
+// Import variableSource from '../../../datasources/variable'
 import {
   deleteDraft as draftSourceDelete,
   fetchDrafts as draftSourceFetch,
@@ -70,7 +74,8 @@ export const buildContextValue = (extraContext) => ({
     toolSourceDelete,
     toolSourceFetch,
     variableDraftSource,
-    variableSource
+    variableSourceDelete,
+    variableSourceFetch
   },
   headers: {
     'Client-Id': 'eed-test-graphql',

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1371,9 +1371,9 @@ describe('Draft', () => {
           }, {
             contextValue
           })
-          const { data } = response.body.singleResult
-
-          expect(data).toEqual({ publishDraft: null })
+          const { errors } = response.body.singleResult
+          const { message } = errors[0]
+          expect(message).toEqual('Invalid Argument, collectionConceptId. Collection Concept ID is only required when publishing a Variable Draft.')
         })
       })
     })
@@ -1814,7 +1814,7 @@ describe('Draft', () => {
           })
         })
 
-        test('returns the cmr result when collection concept not provided', async () => {
+        test('returns the cmr result when publishing a Publish Draft and collection concept not provided', async () => {
           nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
@@ -1858,9 +1858,9 @@ describe('Draft', () => {
           }, {
             contextValue
           })
-          const { data } = response.body.singleResult
-
-          expect(data).toEqual({ publishDraft: null })
+          const { errors } = response.body.singleResult
+          const { message } = errors[0]
+          expect(message).toEqual('collectionConceptId required. When publishing a Variable Draft, an associated Collection Concept Id is required')
         })
       })
     })

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1323,6 +1323,58 @@ describe('Draft', () => {
             }
           })
         })
+
+        test('returns the cmr result when collection concept provided but not needed', async () => {
+          nock(/example-cmr/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/publish\/TD100000-EDSC\/tool-1/)
+            .reply(201, {
+              'concept-id': 'T100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              draftConceptId: 'TD100000-EDSC',
+              nativeId: 'tool-1',
+              ummVersion: '1.0.0',
+              collectionConceptId: 'C100000-EDSC'
+            },
+            query: `mutation PublishDraft(
+                    $draftConceptId: String!
+                    $nativeId: String!
+                    $ummVersion: String!
+                    $collectionConceptId: String
+                  ) {
+                    publishDraft(
+                      draftConceptId: $draftConceptId
+                      nativeId: $nativeId
+                      ummVersion: $ummVersion
+                      collectionConceptId: $collectionConceptId
+                    ) {
+                      conceptId
+                      revisionId
+                      warnings
+                      existingErrors
+                    }
+                  }`
+          }, {
+            contextValue
+          })
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({ publishDraft: null })
+        })
       })
     })
   })
@@ -1701,9 +1753,68 @@ describe('Draft', () => {
         })
       })
 
-      // TODO MMT-3417
-      describe.skip('publishDraft', () => {
+      describe('publishDraft', () => {
         test('returns the cmr result', async () => {
+          nock(/example-cmr/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/publish\/VD100000-EDSC\/variable-1/)
+            .reply(201, {
+              'concept-id': 'V100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              draftConceptId: 'VD100000-EDSC',
+              nativeId: 'variable-1',
+              ummVersion: '1.0.0',
+              collectionConceptId: 'C100000-EDSC'
+            },
+            query: `mutation PublishDraft(
+              $draftConceptId: String!
+              $nativeId: String!
+              $ummVersion: String!
+              $collectionConceptId: String
+            ) {
+              publishDraft(
+                draftConceptId: $draftConceptId
+                nativeId: $nativeId
+                ummVersion: $ummVersion
+                collectionConceptId: $collectionConceptId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            publishDraft: {
+              conceptId: 'V100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+
+        test('returns the cmr result when collection concept not provided', async () => {
           nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
@@ -1729,35 +1840,27 @@ describe('Draft', () => {
               ummVersion: '1.0.0'
             },
             query: `mutation PublishDraft(
-              $draftConceptId: String!
-              $nativeId: String!
-              $ummVersion: String!
-            ) {
-              publishDraft(
-                draftConceptId: $draftConceptId
-                nativeId: $nativeId
-                ummVersion: $ummVersion
-              ) {
-                conceptId
-                revisionId
-                warnings
-                existingErrors
-              }
-            }`
+                    $draftConceptId: String!
+                    $nativeId: String!
+                    $ummVersion: String!
+                  ) {
+                    publishDraft(
+                      draftConceptId: $draftConceptId
+                      nativeId: $nativeId
+                      ummVersion: $ummVersion
+                    ) {
+                      conceptId
+                      revisionId
+                      warnings
+                      existingErrors
+                    }
+                  }`
           }, {
             contextValue
           })
-
           const { data } = response.body.singleResult
 
-          expect(data).toEqual({
-            publishDraft: {
-              conceptId: 'V100000-EDSC',
-              revisionId: '1',
-              warnings: null,
-              existingErrors: null
-            }
-          })
+          expect(data).toEqual({ publishDraft: null })
         })
       })
     })

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1814,7 +1814,7 @@ describe('Draft', () => {
           })
         })
 
-        test('returns the cmr result when publishing a Publish Draft and collection concept not provided', async () => {
+        test('returns the cmr result when collection concept id not provided', async () => {
           nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1324,7 +1324,7 @@ describe('Draft', () => {
           })
         })
 
-        test('returns the cmr result when collection concept provided but not needed', async () => {
+        test('returns an error when collection concept id not provided', async () => {
           nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',
@@ -1814,7 +1814,7 @@ describe('Draft', () => {
           })
         })
 
-        test('returns the cmr result when collection concept id not provided', async () => {
+        test('returns an error when collection concept id not provided', async () => {
           nock(/example-cmr/, {
             reqheaders: {
               accept: 'application/json',

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -416,4 +416,48 @@ describe('Variable', () => {
       })
     })
   })
+
+  describe('Mutation', () => {
+    test('deleteVariable', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .delete(/ingest\/providers\/EDSC\/variables\/test-guid/)
+        .reply(201, {
+          'concept-id': 'V100000-EDSC',
+          'revision-id': '1'
+        })
+
+      const response = await server.executeOperation({
+        variables: {
+          nativeId: 'test-guid',
+          providerId: 'EDSC'
+        },
+        query: `mutation DeleteVariable (
+            $providerId: String!
+            $nativeId: String!
+          ) {
+            deleteVariable (
+              providerId: $providerId
+              nativeId: $nativeId
+            ) {
+                conceptId
+                revisionId
+              }
+            }`
+      }, {
+        contextValue
+      })
+
+      const { data } = response.body.singleResult
+      expect(data).toEqual({
+        deleteVariable: {
+          conceptId: 'V100000-EDSC',
+          revisionId: '1'
+        }
+      })
+    })
+  })
 })

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -240,7 +240,7 @@ export default {
         }
       }
 
-      return dataSources.variableSource({
+      return dataSources.variableSourceFetch({
         conceptId: variableConceptIds,
         ...handlePagingParams(args, variables.length)
       }, context, parseResolveInfo(info))

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -32,12 +32,12 @@ export default {
 
       // Checks if collectionConceptId is present when publishing a Variable Draft
       if (isDraftConceptId(draftConceptId, 'variable') && !collectionConceptId) {
-        throw new Error('collectionConceptId required')
+        throw new Error('collectionConceptId required. When publishing a Variable Draft, an associated Collection Concept Id is required')
       }
 
       // Checks if collectionConcept is present when publishing a non Variable draft
       if (!isDraftConceptId(draftConceptId, 'variable') && collectionConceptId) {
-        throw new Error('Invalid Argument, collectionConceptId')
+        throw new Error('Invalid Argument, collectionConceptId. Collection Concept ID is only required when publishing a Variable Draft.')
       }
 
       const result = await dataSources.draftSourcePublish(

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -28,6 +28,17 @@ export default {
     },
     publishDraft: async (source, args, context, info) => {
       const { dataSources } = context
+      const { draftConceptId, collectionConceptId } = args
+
+      // Checks if collectionConceptId is present when publishing a Variable Draft
+      if (isDraftConceptId(draftConceptId, 'variable') && !collectionConceptId) {
+        throw new Error('collectionConceptId required')
+      }
+
+      // Checks if collectionConcept is present when publishing a non Variable draft
+      if (!isDraftConceptId(draftConceptId, 'variable') && collectionConceptId) {
+        throw new Error('Invalid Argument, collectionConceptId')
+      }
 
       const result = await dataSources.draftSourcePublish(
         args,

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -138,7 +138,7 @@ export default {
         }
       }
 
-      return dataSources.variableSource({
+      return dataSources.variableSourceFetch({
         conceptId: variableConceptIds,
         ...handlePagingParams(args, variables.length)
       }, context, parseResolveInfo(info))

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -29,7 +29,6 @@ export default {
   Mutation: {
     deleteVariable: async (source, args, context, info) => {
       const { dataSources } = context
-      console.log(args)
 
       return dataSources.variableSourceDelete(
         handlePagingParams(args),

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -8,16 +8,34 @@ export default {
     variables: async (source, args, context, info) => {
       const { dataSources } = context
 
-      return dataSources.variableSource(handlePagingParams(args), context, parseResolveInfo(info))
+      return dataSources.variableSourceFetch(
+        handlePagingParams(args),
+        context,
+
+        parseResolveInfo(info)
+      )
     },
     variable: async (source, args, context, info) => {
       const { dataSources } = context
 
-      const result = await dataSources.variableSource(args, context, parseResolveInfo(info))
+      const result = await dataSources.variableSourceFetch(args, context, parseResolveInfo(info))
 
       const [firstResult] = result
 
       return firstResult
+    }
+  },
+
+  Mutation: {
+    deleteVariable: async (source, args, context, info) => {
+      const { dataSources } = context
+      console.log(args)
+
+      return dataSources.variableSourceDelete(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
     }
   },
 

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -93,6 +93,8 @@ type Mutation {
     nativeId: String!
     "UMM Version of the record being published."
     ummVersion: String!
+    "Associated Collection concept-id "
+    collectionConceptId: String
   ): PublishDraftMutationResponse
 }
 

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -110,3 +110,19 @@ type Query {
     conceptId: String @deprecated(reason: "Use `params.conceptId`")
   ): Variable
 }
+
+type Mutation {
+  deleteVariable (
+    "Provider ID of the variable."
+    providerId: String!
+    "The native id of a varialbe."
+    nativeId: String!
+  ): VariableMutationResponse
+}
+
+type VariableMutationResponse {
+  "The unique concept id assigned to the variable."
+  conceptId: String!
+  "The revision of the variable."
+  revisionId: String!
+}

--- a/src/utils/__tests__/cmrIngest.test.js
+++ b/src/utils/__tests__/cmrIngest.test.js
@@ -35,16 +35,16 @@ describe('cmrIngest', () => {
         'revision-id': 1
       })
 
-    const response = await cmrIngest(
-      'subscriptions',
-      { collectionConceptId: 'C100000-EDSC' },
-      {
+    const response = await cmrIngest({
+      conceptType: 'subscriptions',
+      data: { collectionConceptId: 'C100000-EDSC' },
+      headers: {
         'CMR-Request-Id': 'abcd-1234-efgh-5678',
         'Client-Id': 'eed-test-graphql',
         'Content-Type': 'application/vnd.nasa.cmr.umm+json; version=1.0'
       },
-      'subscriptions'
-    )
+      ingestPath: 'subscriptions'
+    })
 
     const { data, headers } = response
 
@@ -79,18 +79,18 @@ describe('cmrIngest', () => {
           'revision-id': 1
         })
 
-      const response = await cmrIngest(
-        'subscriptions',
-        {
+      const response = await cmrIngest({
+        conceptType: 'subscriptions',
+        data: {
           collectionConceptId: 'C100000-EDSC',
           nativeId: 'provided-native-id'
         },
-        {
+        headers: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
-        'subscriptions'
-      )
+        ingestPath: 'subscriptions'
+      })
 
       const { data, headers } = response
 
@@ -127,16 +127,16 @@ describe('cmrIngest', () => {
           'revision-id': 1
         })
 
-      const response = await cmrIngest(
-        'subscriptions',
-        { collectionConceptId: 'C100000-EDSC' },
-        {
+      const response = await cmrIngest({
+        conceptType: 'subscriptions',
+        data: { collectionConceptId: 'C100000-EDSC' },
+        headers: {
           Authorization: 'Bearer test-token',
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
-        'subscriptions'
-      )
+        ingestPath: 'subscriptions'
+      })
 
       const { data, headers } = response
 
@@ -168,15 +168,15 @@ describe('cmrIngest', () => {
           errors: ['HTTP Error']
         })
 
-      const response = cmrIngest(
-        'subscriptions',
-        { collectionConceptId: 'C100000-EDSC' },
-        {
+      const response = cmrIngest({
+        conceptType: 'subscriptions',
+        data: { collectionConceptId: 'C100000-EDSC' },
+        headers: {
           'Client-Id': 'eed-test-graphql',
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         },
-        'subscriptions'
-      )
+        ingestPath: 'subscriptions'
+      })
 
       await expect(response).rejects.toThrow()
     })

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -7,10 +7,11 @@ import { pickIgnoringCase } from './pickIgnoringCase'
 
 /**
  * Make a request to CMR and return the promise
- * @param {String} conceptType Concept type to ingest
- * @param {Object} data Parameters to send to CMR
- * @param {Object} headers Headers to send to CMR
- * @param {String} ingestPath CMR path to call to ingest concept
+ * @param {Object} params
+ * @param {String} params.conceptType Concept type to ingest
+ * @param {Object} params.data Parameters to send to CMR
+ * @param {Object} params.headers Headers to send to CMR
+ * @param {String} params.ingestPath CMR path to call to ingest concept
  */
 export const cmrIngest = ({
   conceptType,

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -1,7 +1,5 @@
 import axios from 'axios'
 
-import camelcaseKeys from 'camelcase-keys'
-
 import { v4 as uuidv4 } from 'uuid'
 
 import { downcaseKeys } from './downcaseKeys'
@@ -16,7 +14,6 @@ import { pickIgnoringCase } from './pickIgnoringCase'
  */
 
 export const cmrIngest = ({
-  camelCaseKeys = true,
   conceptType,
   data,
   headers,
@@ -40,26 +37,13 @@ export const cmrIngest = ({
   ])
 
   // Use the provided native id if one is provided, default to a guid
-  const { nativeId = uuidv4(), collectionConceptId } = data
+  const { nativeId = uuidv4() } = data
 
   // Remove native id as it is not a supported key in umm
   // eslint-disable-next-line no-param-reassign
   delete data.nativeId
 
-  let cmrParameters = data
-
-  if (collectionConceptId) {
-    cmrParameters = {
-      'collection-concept-id': collectionConceptId || null
-    }
-  }
-
-  if (camelCaseKeys) {
-    cmrParameters = camelcaseKeys(data, {
-      pascalCase: true,
-      exclude: ['URL', 'DOI']
-    })
-  }
+  const cmrParameters = data
 
   const {
     'client-id': clientId,

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -48,14 +48,18 @@ export const cmrIngest = ({
 
   let cmrParameters = data
 
+  if (collectionConceptId) {
+    cmrParameters = {
+      'collection-concept-id': collectionConceptId || null
+    }
+  }
+
   if (camelCaseKeys) {
     cmrParameters = camelcaseKeys(data, {
       pascalCase: true,
       exclude: ['URL', 'DOI']
     })
   }
-
-  cmrParameters = { 'collection-concept-id': collectionConceptId }
 
   const {
     'client-id': clientId,

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -12,7 +12,6 @@ import { pickIgnoringCase } from './pickIgnoringCase'
  * @param {Object} headers Headers to send to CMR
  * @param {String} ingestPath CMR path to call to ingest concept
  */
-
 export const cmrIngest = ({
   conceptType,
   data,
@@ -43,15 +42,13 @@ export const cmrIngest = ({
   // eslint-disable-next-line no-param-reassign
   delete data.nativeId
 
-  const cmrParameters = data
-
   const {
     'client-id': clientId,
     'cmr-request-id': requestId
   } = downcaseKeys(permittedHeaders)
 
   const requestConfiguration = {
-    data: cmrParameters,
+    data,
     headers: permittedHeaders,
     method: 'PUT',
     url: `${process.env.cmrRootUrl}/ingest/${ingestPath}/${nativeId}`

--- a/src/utils/cmrIngest.js
+++ b/src/utils/cmrIngest.js
@@ -14,7 +14,14 @@ import { pickIgnoringCase } from './pickIgnoringCase'
  * @param {Object} headers Headers to send to CMR
  * @param {String} ingestPath CMR path to call to ingest concept
  */
-export const cmrIngest = async (conceptType, data, headers, ingestPath) => {
+
+export const cmrIngest = ({
+  camelCaseKeys = true,
+  conceptType,
+  data,
+  headers,
+  ingestPath
+}) => {
   // Default headers
   const defaultHeaders = {
     Accept: 'application/json'
@@ -33,16 +40,22 @@ export const cmrIngest = async (conceptType, data, headers, ingestPath) => {
   ])
 
   // Use the provided native id if one is provided, default to a guid
-  const { nativeId = uuidv4() } = data
+  const { nativeId = uuidv4(), collectionConceptId } = data
 
   // Remove native id as it is not a supported key in umm
   // eslint-disable-next-line no-param-reassign
   delete data.nativeId
 
-  const cmrParameters = camelcaseKeys(data, {
-    pascalCase: true,
-    exclude: ['URL']
-  })
+  let cmrParameters = data
+
+  if (camelCaseKeys) {
+    cmrParameters = camelcaseKeys(data, {
+      pascalCase: true,
+      exclude: ['URL', 'DOI']
+    })
+  }
+
+  cmrParameters = { 'collection-concept-id': collectionConceptId }
 
   const {
     'client-id': clientId,


### PR DESCRIPTION
# Overview

Added support for Publish Variable Draft and Published Delete Draft. 


List impacted areas.

# Testing
1.) Has a Published Collection Record handy.
2.) Publish a variable draft
```
    mutation PublishDraft(
      $draftConceptId: String!
      $nativeId: String!
      $ummVersion: String!
    ) {
      publishDraft(
        draftConceptId: $draftConceptId
        nativeId: $nativeId
        ummVersion: $ummVersion
      ) {
        conceptId
        revisionId
        warnings
        existingErrors
      }
    }
```
Variables: 
```
    {
      "draftConceptId": "VD1000000001-EXAMPLE",
      "nativeId": "service-1",
      "ummVersion": "1.2.0"
      "collectionConceptId: "C100000-EXAMPLE"
    }
```

Testing Delete
  ```
mutation DeleteService(
     $providerId: String!
     $nativeId: String!
   ) {
     deleteTool(
       providerId: $providerId
       nativeId: $nativeId
     ) {
       conceptId
       revisionId
     }
   }
```
Variables:
```
 {
      "providerId": "EXAMPLE",
      "nativeId": "variable-1"
    }
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
