### PR TITLE
DAS-1958: Allow graphql collection query to search on entryId and provider. Also update the earthdata-varinfo library.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-earthdata-varinfo==2.1.0
+earthdata-varinfo==2.2.0

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -481,11 +481,15 @@ input CollectionsInput {
 
 input CollectionInput {
   "The unique concept id assigned to the collection."
-  conceptId: String!
+  conceptId: String
   "If this parameter is set to 'true' this will include a flag indicating true or false if the collection has any granules at all."
   includeHasGranules: Boolean
   "If this parameter is set (e.g. include_tags=gov.nasa.earthdata.search.*,gov.nasa.echo.*), the collection results will contain an additional field 'tags' within each collection. The value of the tags field is a list of tag_keys that are associated with the collection. Only the tags with tag_key matching the values of include_tags parameter (with wildcard support) are included in the results."
   includeTags: String
+  "Entry ID of the collection."
+  entryId: String
+  "The name of the provider associated with the collection."
+  provider: String
 }
 
 type Query {


### PR DESCRIPTION
…vider

# Overview

### What is the feature?

Allow collection query to search via provider and entry ID

### What is the Solution?

added the entryId and provider to the input parameters

### What areas of the application does this impact?

A collection can now be found via entryId and provider

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Query a collection with the entryId and provider populated. Make sure the right collection is returned

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
