### PR TITLE
GQL-10: Related URL tab is showing No value for provided message

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -668,7 +668,23 @@ export default class Concept {
         }
 
         if (keyValue != null) {
-          const camelCasedObject = camelcaseKeys({ [ummKey]: keyValue }, { deep: true })
+          const camelCasedObject = camelcaseKeys({ [ummKey]: keyValue }, {
+            deep: true,
+            exclude: ['RelatedURLs']
+          })
+
+          // CamelcaseKey converts RelatedURLs to relatedUrLs, so excluding RelatedURLs above.
+          // This will remove RelatedURLs and create a new
+          // key called relatedUrls and assign the value to it so MMT and graphql response matches.
+          if (ummKey === 'previewMetadata') {
+            const { previewMetadata } = camelCasedObject
+            camelCasedObject.previewMetadata = {
+              ...previewMetadata,
+              relatedUrls: previewMetadata.RelatedURLs
+            }
+
+            delete camelCasedObject.previewMetadata.RelatedURLs
+          }
 
           const { [ummKey]: camelCasedValue } = camelCasedObject
 


### PR DESCRIPTION
# Overview
Fixed the bug that was causing the Related URL tab to have no values in MMT. 