### PR TITLE
MMT-3411: As a metadata user, I want to publish a UMM record

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
     ummGranuleVersion: '1.5'
     ummServiceVersion: '1.5.2'
     ummSubscriptionVersion: '1.1'
-    ummToolVersion: '1.1'
+    ummToolVersion: '1.2.0'
     ummVariableVersion: '1.9.0'
 
   vpc:


### PR DESCRIPTION
# Overview

When working on creating a publish mutation in MMT React, I noticed when trying to publish a draft with Related URL, the validation from CMR was failing. CMR was returning with errors "MimeType and Format are extraneous keys"

After debugging noticed there was a version miss match where MMT is using 1.2.0 for the schema but when publish GraphQL is sending version 1.1 to CMR. 

So CMR is trying to validate a 1.2.0 draft with version 1.1.

### What is the Solution?

Updating the version for UMM-T in the serverless.yml to the latest. 
