### PR TITLE
GQL-25: As MMT, I want query the raw UMM metadata for published record

### DIFF
--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -143,6 +143,8 @@ type Collection {
   timeEnd: String
   "The title of the collection described by the metadata."
   title: String
+  "Raw UMM Metadata of the Collection Record."
+  ummMetadata: JSON
   "Designed to protect privacy and/or intellectual property by allowing the author to specify how the collection may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness. Note: Use Constraints describe how the item may be used once access has been granted; and is distinct from Access Constraints, which refers to any constraints in accessing the item."
   useConstraints: JSON
   "The version description of the collection."

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -49,6 +49,8 @@ type Service {
   serviceQuality: JSON
   "The type of the service."
   type: String
+  "Raw UMM Metadata of the Service Record."
+  ummMetadata: JSON
   "Represents the Internet site where you can directly access the back-end service."
   url: JSON
   "Information on how the item (service, software, or tool) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness."

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -63,6 +63,8 @@ type Tool {
   version: String
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
+  "Raw UMM Metadata of the Tool Record."
+  ummMetadata: JSON
 
   collections (
     "Collections query parameters"

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -55,6 +55,8 @@ type Tool {
   toolKeywords: JSON
   "The type of the downloadable tool or web user interface."
   type: String
+  "Raw UMM Metadata of the Tool Record."
+  ummMetadata: JSON
   "The URL where you can directly access the web user interface or downloadable tool."
   url: JSON
   "Information on how the item (downloadable tool or web user interface) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness."
@@ -63,8 +65,6 @@ type Tool {
   version: String
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
-  "Raw UMM Metadata of the Tool Record."
-  ummMetadata: JSON
 
   collections (
     "Collections query parameters"

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -45,6 +45,8 @@ type Variable {
   sets: JSON
   "This is the more formal or scientific name, .e.g., the CF Standard Name."
   standardName: String
+  "Raw UMM Metadata of the Variable Record."
+  ummMetadata: JSON
   "The units associated with a variable."
   units: String
   "Valid ranges of variable data values."

--- a/src/utils/umm/collectionKeyMap.json
+++ b/src/utils/umm/collectionKeyMap.json
@@ -64,6 +64,7 @@
     "temporalKeywords": "umm.TemporalKeywords",
     "tilingIdentificationSystems": "umm.TilingIdentificationSystems",
     "title": "umm.EntryTitle",
+    "ummMetadata": "umm",
     "useConstraints": "umm.UseConstraints",
     "version": "umm.Version",
     "versionDescription": "umm.VersionDescription",

--- a/src/utils/umm/serviceKeyMap.json
+++ b/src/utils/umm/serviceKeyMap.json
@@ -30,6 +30,7 @@
     "supportedOutputProjections": "umm.ServiceOptions.SupportedOutputProjections",
     "supportedReformattings": "umm.ServiceOptions.SupportedReformattings",
     "type": "umm.Type",
+    "ummMetadata": "umm",
     "url": "umm.URL",
     "useConstraints": "umm.UseConstraints",
     "version": "umm.Version",

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -32,11 +32,11 @@
     "supportedOutputFormats": "umm.SupportedOutputFormats",
     "supportedSoftwareLanguages": "umm.SupportedSoftwareLanguages",
     "toolKeywords": "umm.ToolKeywords",
+    "ummMetadata": "umm",
     "type": "umm.Type",
     "url": "umm.URL",
     "useConstraints": "umm.UseConstraints",
     "version": "umm.Version",
-    "versionDescription": "umm.VersionDescription",
-    "ummMetadata": "umm"
+    "versionDescription": "umm.VersionDescription"
   }
 }

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -36,6 +36,7 @@
     "url": "umm.URL",
     "useConstraints": "umm.UseConstraints",
     "version": "umm.Version",
-    "versionDescription": "umm.VersionDescription"
+    "versionDescription": "umm.VersionDescription",
+    "ummMetadata": "umm"
   }
 }

--- a/src/utils/umm/variableKeyMap.json
+++ b/src/utils/umm/variableKeyMap.json
@@ -28,6 +28,7 @@
     "scienceKeywords": "umm.ScienceKeywords",
     "sets": "umm.Sets",
     "standardName": "umm.StandardName",
+    "ummMetadata": "umm",
     "units": "umm.Units",
     "validRanges": "umm.ValidRanges",
     "variableSubType": "umm.VariableSubType",


### PR DESCRIPTION
# Overview

When working on the Edit Publish Button in MMT, we noticed we needed the raw UMM metadata from GraphQL like how drafts supports it right now.  

Please summarize the feature or fix.

For Collection, Service, Variable and Tool added a `ummMetadata` field that will show the raw UMM value that is being returned from CMR.
