### PR TITLE
GQL-27: Update Collection Query to support all Collection parameters

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -57,7 +57,9 @@ export default class Collection extends Concept {
       'consortium',
       'data_center',
       'data_center_h',
+      'doi',
       'entry_id',
+      'entry_title',
       'facets_size',
       'granule_data_format',
       'granule_data_format_h',
@@ -83,6 +85,9 @@ export default class Collection extends Concept {
       'project',
       'project_h',
       'provider',
+      'revision_date',
+      'updated_since',
+      'science_keywords',
       'science_keywords_h',
       'service_concept_id',
       'service_type',
@@ -92,7 +97,9 @@ export default class Collection extends Concept {
       'temporal',
       'tool_concept_id',
       'two_d_coordinate_system_name',
-      'variable_concept_id'
+      'variable_concept_id',
+      'version'
+
     ]
   }
 
@@ -110,7 +117,9 @@ export default class Collection extends Concept {
       'consortium',
       'data_center',
       'data_center_h',
+      'doi',
       'entry_id',
+      'entry_title',
       'granule_data_format',
       'granule_data_format_h',
       'has_granules_or_cwic',
@@ -133,6 +142,9 @@ export default class Collection extends Concept {
       'project',
       'project_h',
       'provider',
+      'updated_since',
+      'revision_date',
+      'science_keywords',
       'science_keywords_h',
       'service_concept_id',
       'service_type',
@@ -142,7 +154,9 @@ export default class Collection extends Concept {
       'temporal',
       'tool_concept_id',
       'two_d_coordinate_system_name',
-      'variable_concept_id'
+      'variable_concept_id',
+      'version'
+
     ]
   }
 
@@ -159,7 +173,9 @@ export default class Collection extends Concept {
       'consortium',
       'data_center',
       'data_center_h',
+      'doi',
       'entry_id',
+      'entry_title',
       'granule_data_format_h',
       'granule_data_format',
       'horizontal_data_resolution_range',
@@ -173,6 +189,9 @@ export default class Collection extends Concept {
       'processing_level_id_h',
       'project_h',
       'provider',
+      'updated_since',
+      'revision_date',
+      'science_keywords',
       'service_concept_id',
       'service_type',
       'short_name',
@@ -181,7 +200,8 @@ export default class Collection extends Concept {
       'tag_key',
       'tool_concept_id',
       'two_d_coordinate_system_name',
-      'variable_concept_id'
+      'variable_concept_id',
+      'version'
     ])
   }
 

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -53,6 +53,8 @@ type Collection {
   doi: JSON
   "The title of the collection described by the metadata."
   datasetId: String
+  "Entry Title"
+  entryTitle: String
   "An array containing all of the different formats of the underlying data of a collection."
   nativeDataFormats: [String]
   "True if there are multiple supported formats for any services associated with the collection."
@@ -379,6 +381,8 @@ input CollectionsInput {
   conceptId: [String]
   "The consortium value of the collection."
   consortium: [String]
+  "The DOI Value of the collection"
+  doi: String
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
   "Bounding boxes define an area on the earth aligned with longitude and latitude. The Bounding box parameters must be 4 comma-separated numbers: lower left longitude, lower left latitude, upper right longitude, upper right latitude."
@@ -389,6 +393,8 @@ input CollectionsInput {
   cloudHosted: Boolean
   "Type of the collection"
   collectionDataType: [String]
+  "The Entry Title of collection"
+  entryTitle: String
   "Data center assigned to the collection."
   dataCenter: String
   "Data centers assigned to the collection."
@@ -461,8 +467,12 @@ input CollectionsInput {
   provider: String
   "The name of the providers associated with the collections."
   providers: [String]
+  "The revision id of the collection"
+  revisionDate: String
   "Science Keywords associated with the collection, in facet form."
   scienceKeywordsH: JSON
+  "Science Keywords for searching term at all levels of the science keyword hierarchy"
+  scienceKeywords: JSON
   "UMM Service concept id."
   serviceConceptId: String
   "UMM Service type."
@@ -479,8 +489,11 @@ input CollectionsInput {
   tagKey: [String]
   "The temporal datetime has to be in yyyy-MM-ddTHH:mm:ssZ format."
   temporal: String
+  updatedSince: String
   "The 2D coordinate system associated with the collection"
   twoDCoordinateSystemName: [String]
+  "version of the collection"
+  version: String
   "UMM Variable concept id."
   variableConceptId: String
 }
@@ -510,6 +523,8 @@ type Query {
     cloudHosted: Boolean @deprecated(reason: "Use `params.cloudHosted`")
     "Type of the collection"
     collectionDataType: [String] @deprecated(reason: "Use `params.collectionDataType`")
+    "Entry Title"
+    entryTitle: String
     "Data center assigned to the collection."
     dataCenter: String @deprecated(reason: "Use `params.dataCenter`")
     "Data center assigned to the collection, in facet form."

--- a/src/utils/umm/collectionKeyMap.json
+++ b/src/utils/umm/collectionKeyMap.json
@@ -31,6 +31,7 @@
     "directDistributionInformation": "umm.DirectDistributionInformation",
     "directoryNames": "umm.DirectoryNames",
     "doi": "umm.DOI",
+    "entryTitle": "umm.EntryTitle",
     "hasFormats": "meta.has-formats",
     "hasSpatialSubsetting": "meta.has-spatial-subsetting",
     "hasTemporalSubsetting": "meta.has-temporal-subsetting",


### PR DESCRIPTION
# Overview

### What is the feature?

While working on [MMT-3483](https://bugs.earthdata.nasa.gov/browse/MMT-3483): Implement the Collection Association Form, noticed some of the fields were missing when searching by a given field for collection.

**For Example:** 
If I wanted to search for a collection by Entry Title using a wildcard search. Entry Title was not a field in cmr-graphql that I can search by:
```
	{
	  "params": {
	    "options": {
	      "EntryTitle": {
	        "pattern": true
	      }
	    },
	    "entryTitle": "*"
	  }
	}
```
The missing params/fields that were added are :
```
entryTitle
doi
revisionDate
scienceKeywords
updatedSince
version
```

# Testing

### Reproduction steps

- **Environment for testing:** SIT

Entry Title
```
       {
	  "params": {
	    "options": {
	      "EntryTitle": {
	        "pattern": true
	      }
	    },
	    "entryTitle": "*"
	  }
	}
```

Science Keywords
```
               {
		"params": {
	    "scienceKeywords": {
	      "0": {
	        "any": "SULFUR COMPOUNDS"
	      }
	    }
	  }
	}
```
### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
