### PR TITLE
GQL-28: Adds keyword parameter to service, tool, and variable searching

### DIFF
--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -96,6 +96,8 @@ input ServicesInput {
   conceptId: [String]
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+  "Keyword search value."
+  keyword: String
   "The number of services requested by the user."
   limit: Int
   "Zero based offset of individual results."

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -92,6 +92,8 @@ input ToolsInput {
   conceptId: [String]
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+  "Keyword search value."
+  keyword: String
   "The number of tools requested by the user."
   limit: Int
   "Zero based offset of individual results."

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -82,6 +82,8 @@ input VariablesInput {
   conceptId: [String]
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+  "Keyword search value."
+  keyword: String
   "The number of variables requested by the user."
   limit: Int
   "The name of a variable."


### PR DESCRIPTION
# Overview

### What is the feature?

Adds keyword parameter to service, tool, and variable searching

### What is the Solution?

Added the params to the schema

### What areas of the application does this impact?

Services, Tools, and Variables schemas

# Testing

### Reproduction steps

- **Environment for testing:** ANY
- **Collection to test with:** N/A

1. Search for a service with a keyword parameter and confirm results are returned
2. Search for a tool with a keyword parameter and confirm results are returned
3. Search for a variable with a keyword parameter and confirm results are returned

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
