### PR TITLE
MMT-3420: As a MMT dev, I want to be able to Delete UMM-C published in CMR GraphQL

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -14,6 +14,9 @@ export default class Collection extends Concept {
     super('collections', headers, requestInfo, params)
 
     this.facets = []
+    const { providerId } = params
+
+    this.ingestPath = `providers/${providerId}/collections`
   }
 
   /**

--- a/src/datasources/collection.js
+++ b/src/datasources/collection.js
@@ -4,7 +4,7 @@ import collectionKeyMap from '../utils/umm/collectionKeyMap.json'
 
 import Collection from '../cmr/concepts/collection'
 
-export default async (params, context, parsedInfo) => {
+export const fetchCollections = async (params, context, parsedInfo) => {
   const { headers } = context
 
   const requestInfo = parseRequestedFields(parsedInfo, collectionKeyMap, 'collection')
@@ -19,4 +19,25 @@ export default async (params, context, parsedInfo) => {
 
   // Return a formatted JSON response
   return collection.getFormattedResponse()
+}
+
+export const deleteCollection = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, collectionKeyMap, 'collection')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const collection = new Collection(headers, requestInfo, args)
+
+  // Query CMR
+  collection.delete(args, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await collection.parseDelete(requestInfo)
+
+  // Return a formatted JSON response
+  return collection.getFormattedDeleteResponse()
 }

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -14,7 +14,6 @@ import typeDefs from '../types'
 import aclSource from '../datasources/acl'
 import collectionDraftProposalSource from '../datasources/collectionDraftProposal'
 import collectionDraftSource from '../datasources/collectionDraft'
-import collectionSource from '../datasources/collection'
 import collectionVariableDraftsSource from '../datasources/collectionVariableDrafts'
 import dataQualitySummarySource from '../datasources/dataQualitySummary'
 import granuleSource from '../datasources/granule'
@@ -28,6 +27,11 @@ import toolDraftSource from '../datasources/toolDraft'
 import variableDraftSource from '../datasources/variableDraft'
 
 import { deleteTool as toolSourceDelete, fetchTools as toolSourceFetch } from '../datasources/tool'
+
+import {
+  deleteCollection as collectionSourceDelete,
+  fetchCollections as collectionSourceFetch
+} from '../datasources/collection'
 
 import {
   deleteService as serviceSourceDelete,
@@ -154,7 +158,8 @@ export default startServerAndCreateLambdaHandler(
           aclSource,
           collectionDraftProposalSource,
           collectionDraftSource,
-          collectionSource,
+          collectionSourceDelete,
+          collectionSourceFetch,
           collectionVariableDraftsSource,
           dataQualitySummarySource,
           draftSourceDelete,

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -6,7 +6,6 @@ import typeDefs from '../../../types'
 import aclSource from '../../../datasources/acl'
 import collectionDraftProposalSource from '../../../datasources/collectionDraftProposal'
 import collectionDraftSource from '../../../datasources/collectionDraft'
-import collectionSource from '../../../datasources/collection'
 import collectionVariableDraftsSource from '../../../datasources/collectionVariableDrafts'
 import dataQualitySummarySource from '../../../datasources/dataQualitySummary'
 import granuleSource from '../../../datasources/granule'
@@ -43,6 +42,11 @@ import {
   publishDraft as draftSourcePublish
 } from '../../../datasources/draft'
 
+import {
+  deleteCollection as collectionSourceDelete,
+  fetchCollections as collectionSourceFetch
+} from '../../../datasources/collection'
+
 export const server = new ApolloServer({
   typeDefs,
   resolvers
@@ -53,7 +57,8 @@ export const buildContextValue = (extraContext) => ({
     aclSource,
     collectionDraftProposalSource,
     collectionDraftSource,
-    collectionSource,
+    collectionSourceDelete,
+    collectionSourceFetch,
     collectionVariableDraftsSource,
     dataQualitySummarySource,
     draftSourceDelete,

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -2485,4 +2485,48 @@ describe('Collection', () => {
       })
     })
   })
+
+  describe('Mutation', () => {
+    test('deleteCollection', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .delete(/ingest\/providers\/EDSC\/collections\/test-guid/)
+        .reply(201, {
+          'concept-id': 'C100000-EDSC',
+          'revision-id': '1'
+        })
+
+      const response = await server.executeOperation({
+        variables: {
+          nativeId: 'test-guid',
+          providerId: 'EDSC'
+        },
+        query: `mutation DeleteCollection (
+            $providerId: String!
+            $nativeId: String!
+          ) {
+            deleteCollection (
+              providerId: $providerId
+              nativeId: $nativeId
+            ) {
+                conceptId
+                revisionId
+              }
+            }`
+      }, {
+        contextValue
+      })
+
+      const { data } = response.body.singleResult
+      expect(data).toEqual({
+        deleteCollection: {
+          conceptId: 'C100000-EDSC',
+          revisionId: '1'
+        }
+      })
+    })
+  })
 })

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -8,16 +8,32 @@ export default {
     collections: async (source, args, context, info) => {
       const { dataSources } = context
 
-      return dataSources.collectionSource(handlePagingParams(args), context, parseResolveInfo(info))
+      return dataSources.collectionSourceFetch(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
     },
     collection: async (source, args, context, info) => {
       const { dataSources } = context
 
-      const result = await dataSources.collectionSource(args, context, parseResolveInfo(info))
+      const result = await dataSources.collectionSourceFetch(args, context, parseResolveInfo(info))
 
       const [firstResult] = result
 
       return firstResult
+    }
+  },
+
+  Mutation: {
+    deleteCollection: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.collectionSourceDelete(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
     }
   },
 

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -55,7 +55,7 @@ export default {
         ...args
       })
 
-      return dataSources.collectionSource(requestedParams, context, parseResolveInfo(info))
+      return dataSources.collectionSourceFetch(requestedParams, context, parseResolveInfo(info))
     },
     orderOptions: async (source, args, context, info) => {
       const { dataSources } = context

--- a/src/resolvers/subscription.js
+++ b/src/resolvers/subscription.js
@@ -46,7 +46,7 @@ export default {
         ...args
       })
 
-      const result = await dataSources.collectionSource(
+      const result = await dataSources.collectionSourceFetch(
         requestedParams,
         context,
         parseResolveInfo(info)

--- a/src/resolvers/tool.js
+++ b/src/resolvers/tool.js
@@ -45,7 +45,7 @@ export default {
         ...args
       })
 
-      return dataSources.collectionSource(requestedParams, context, parseResolveInfo(info))
+      return dataSources.collectionSourceFetch(requestedParams, context, parseResolveInfo(info))
     }
   }
 }

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -77,7 +77,7 @@ export default {
         ...args
       })
 
-      return dataSources.collectionSource(requestedParams, context, parseResolveInfo(info))
+      return dataSources.collectionSourceFetch(requestedParams, context, parseResolveInfo(info))
     }
   }
 }

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -605,3 +605,19 @@ type Query {
     includeTags: String @deprecated(reason: "Use `params.includeTags`")
   ): Collection
 }
+
+type Mutation {
+  deleteCollection (
+    "Provider ID of the collection."
+    providerId: String!
+    "The native id of a collection."
+    nativeId: String!
+  ): CollectionMutationResponse
+}
+
+type CollectionMutationResponse {
+  "The unique concept id assigned to the collection."
+  conceptId: String!
+  "The revision of the collection."
+  revisionId: String!
+}


### PR DESCRIPTION
# Overview
Added `deleteCollection` mutation

### What is the feature?

Given a publish Collections native-id and provider-id, graphql now can call CMR DELETE endpoint and delete the given collection.

# Testing
```
mutation Mutation($providerId: String!, $nativeId: String!) {
  deleteCollection(providerId: $providerId, nativeId: $nativeId) {
    conceptId
    revisionId
  }
}
```
Variables: 
```
{
  "providerId": "SEDAC",
  "nativeId": "collection0"
}
```
# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
