### PR TITLE
MMT-3552: Adding provider param and fixing request issue

### DIFF
--- a/src/cmr/concepts/__tests__/collection.test.js
+++ b/src/cmr/concepts/__tests__/collection.test.js
@@ -1,0 +1,62 @@
+import nock from 'nock'
+
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
+import Collection from '../collection'
+import collectionKeyMap from '../../../utils/umm/collectionKeyMap.json'
+
+process.env.cmrRootUrl = 'http://example.com'
+
+describe('Collection concept', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+  })
+
+  describe('when fetching with params defined', () => {
+    test('requests the json with the correct params', async () => {
+      nock('http://example.com')
+        .post('/search/collections.json')
+        .reply(200, { data: 'test' })
+
+      const parsedInfo = {
+        name: 'collections',
+        alias: 'collections',
+        args: {
+          params: {
+            keyword: 'test',
+            limit: 25,
+            offset: 0,
+            provider: null,
+            sortKey: null
+          }
+        },
+        fieldsByTypeName: {
+          CollectionList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, collectionKeyMap, 'collection')
+
+      const collection = new Collection({}, requestInfo, {})
+
+      await collection.fetch({
+        params: {
+          keyword: 'test',
+          limit: 5,
+          offset: 0,
+          provider: null,
+          sortKey: null
+        },
+        pageSize: 5
+      })
+
+      const response = await collection.response
+
+      expect(await response[0].config.data).toEqual('keyword=test&offset=0&page_size=5&sort_key=&provider=')
+    })
+  })
+})

--- a/src/cmr/concepts/__tests__/service.test.js
+++ b/src/cmr/concepts/__tests__/service.test.js
@@ -1,7 +1,19 @@
+import nock from 'nock'
+
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
 import Service from '../service'
+import serviceKeyMap from '../../../utils/umm/serviceKeyMap.json'
+
+process.env.cmrRootUrl = 'http://example.com'
 
 describe('Service concept', () => {
   beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+  })
+
+  afterEach(() => {
     jest.resetAllMocks()
 
     jest.restoreAllMocks()
@@ -18,6 +30,53 @@ describe('Service concept', () => {
           expect(service.parentCollectionConceptId).toEqual('C1234567889')
         })
       })
+    })
+  })
+
+  describe('when fetching with params defined', () => {
+    test('requests the json with the correct params', async () => {
+      nock('http://example.com')
+        .post('/search/services.json')
+        .reply(200, { data: 'test' })
+
+      const parsedInfo = {
+        name: 'services',
+        alias: 'services',
+        args: {
+          params: {
+            keyword: 'test',
+            limit: 25,
+            offset: 0,
+            provider: null,
+            sortKey: null
+          }
+        },
+        fieldsByTypeName: {
+          ServiceList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, serviceKeyMap, 'service')
+
+      const service = new Service({}, requestInfo, {}, 'C1234567889')
+
+      await service.fetch({
+        params: {
+          keyword: 'test',
+          limit: 5,
+          offset: 0,
+          provider: null,
+          sortKey: null
+        },
+        pageSize: 5
+      })
+
+      const response = await service.response
+
+      expect(await response[0].config.data).toEqual('keyword=test&provider=&offset=0&page_size=5&sort_key=')
     })
   })
 })

--- a/src/cmr/concepts/__tests__/tool.test.js
+++ b/src/cmr/concepts/__tests__/tool.test.js
@@ -1,0 +1,62 @@
+import nock from 'nock'
+
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
+import Tool from '../tool'
+import toolKeyMap from '../../../utils/umm/toolKeyMap.json'
+
+process.env.cmrRootUrl = 'http://example.com'
+
+describe('Tool concept', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+  })
+
+  describe('when fetching with params defined', () => {
+    test('requests the json with the correct params', async () => {
+      nock('http://example.com')
+        .post('/search/tools.json')
+        .reply(200, { data: 'test' })
+
+      const parsedInfo = {
+        name: 'tools',
+        alias: 'tools',
+        args: {
+          params: {
+            keyword: 'test',
+            limit: 25,
+            offset: 0,
+            provider: null,
+            sortKey: null
+          }
+        },
+        fieldsByTypeName: {
+          ToolList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, toolKeyMap, 'tool')
+
+      const tool = new Tool({}, requestInfo, {})
+
+      await tool.fetch({
+        params: {
+          keyword: 'test',
+          limit: 5,
+          offset: 0,
+          provider: null,
+          sortKey: null
+        },
+        pageSize: 5
+      })
+
+      const response = await tool.response
+
+      expect(await response[0].config.data).toEqual('provider=&keyword=test&offset=0&page_size=5&sort_key=')
+    })
+  })
+})

--- a/src/cmr/concepts/__tests__/variable.test.js
+++ b/src/cmr/concepts/__tests__/variable.test.js
@@ -1,0 +1,62 @@
+import nock from 'nock'
+
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
+import Variable from '../variable'
+import variableKeyMap from '../../../utils/umm/variableKeyMap.json'
+
+process.env.cmrRootUrl = 'http://example.com'
+
+describe('Variable concept', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+  })
+
+  describe('when fetching with params defined', () => {
+    test('requests the json with the correct params', async () => {
+      nock('http://example.com')
+        .post('/search/variables.json')
+        .reply(200, { data: 'test' })
+
+      const parsedInfo = {
+        name: 'variables',
+        alias: 'variables',
+        args: {
+          params: {
+            keyword: 'test',
+            limit: 25,
+            offset: 0,
+            provider: null,
+            sortKey: null
+          }
+        },
+        fieldsByTypeName: {
+          VariableList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, variableKeyMap, 'variable')
+
+      const variable = new Variable({}, requestInfo, {})
+
+      await variable.fetch({
+        params: {
+          keyword: 'test',
+          limit: 5,
+          offset: 0,
+          provider: null,
+          sortKey: null
+        },
+        pageSize: 5
+      })
+
+      const response = await variable.response
+
+      expect(await response[0].config.data).toEqual('provider=&keyword=test&offset=0&page_size=5&sort_key=')
+    })
+  })
+})

--- a/src/cmr/concepts/service.js
+++ b/src/cmr/concepts/service.js
@@ -63,7 +63,9 @@ export default class Service extends Concept {
   getPermittedJsonSearchParams() {
     return [
       ...super.getPermittedJsonSearchParams(),
-      'type'
+      'type',
+      'keyword',
+      'provider'
     ]
   }
 
@@ -73,7 +75,9 @@ export default class Service extends Concept {
   getPermittedUmmSearchParams() {
     return [
       ...super.getPermittedUmmSearchParams(),
-      'type'
+      'type',
+      'keyword',
+      'provider'
     ]
   }
 

--- a/src/cmr/concepts/tool.js
+++ b/src/cmr/concepts/tool.js
@@ -16,6 +16,28 @@ export default class Tool extends Concept {
   }
 
   /**
+   * Returns an array of keys representing supported search params for the json endpoint
+   */
+  getPermittedJsonSearchParams() {
+    return [
+      ...super.getPermittedJsonSearchParams(),
+      'provider',
+      'keyword'
+    ]
+  }
+
+  /**
+   * Returns an array of keys representing supported search params for the umm endpoint
+   */
+  getPermittedUmmSearchParams() {
+    return [
+      ...super.getPermittedUmmSearchParams(),
+      'keyword',
+      'provider'
+    ]
+  }
+
+  /**
    * Parse and return the array of data from the nested response body
    * @param {Object} jsonResponse HTTP response from the CMR endpoint
    */

--- a/src/cmr/concepts/variable.js
+++ b/src/cmr/concepts/variable.js
@@ -16,6 +16,28 @@ export default class Variable extends Concept {
   }
 
   /**
+   * Returns an array of keys representing supported search params for the json endpoint
+   */
+  getPermittedJsonSearchParams() {
+    return [
+      ...super.getPermittedJsonSearchParams(),
+      'provider',
+      'keyword'
+    ]
+  }
+
+  /**
+   * Returns an array of keys representing supported search params for the umm endpoint
+   */
+  getPermittedUmmSearchParams() {
+    return [
+      ...super.getPermittedUmmSearchParams(),
+      'keyword',
+      'provider'
+    ]
+  }
+
+  /**
    * Parse and return the array of data from the nested response body
    * @param {Object} jsonResponse HTTP response from the CMR endpoint
    */

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -102,6 +102,8 @@ input ServicesInput {
   limit: Int
   "Zero based offset of individual results."
   offset: Int
+  "The name of the provider associated with the service."
+  provider: String
   "The type of the service."
   type: String
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -98,6 +98,8 @@ input ToolsInput {
   limit: Int
   "Zero based offset of individual results."
   offset: Int
+  "The name of the provider associated with the tool."
+  provider: String
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: String
 }

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -90,6 +90,8 @@ input VariablesInput {
   name: String
   "Zero based offset of individual results."
   offset: Int
+  "The name of the provider associated with the variable."
+  provider: String
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: String
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Adding provider param and fixing request issue in services, variables, and tools

### What is the Solution?

Adds the provider param and adds the provider and keyword to the permitted keys

### What areas of the application does this impact?

Services, Tools, and Variables queries

# Testing

### Reproduction steps

- **Environment for testing:** ANY
- **Collection to test with:** n/a

1. Confirm the provider and keyword parameters filter the search results for Tools in cmr-graphql
2. Confirm the provider and keyword parameters filter the search results for Services in cmr-graphql
3. Confirm the provider and keyword parameters filter the search results for Variables in cmr-graphql

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
