### PR TITLE
MMT-3493: Adding providers query

### DIFF
--- a/src/cmr/concepts/__tests__/provider.test.js
+++ b/src/cmr/concepts/__tests__/provider.test.js
@@ -1,0 +1,55 @@
+import nock from 'nock'
+
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
+import Provider from '../provider'
+import providerKeyMap from '../../../utils/umm/providerKeyMap.json'
+
+process.env.cmrRootUrl = 'http://example.com'
+
+describe('Provider concept', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+  })
+
+  describe('when fetching', () => {
+    test('requests the json', async () => {
+      nock('http://example.com')
+        .get('/ingest/providers')
+        .reply(200, { data: 'test' })
+
+      const parsedInfo = {
+        name: 'provider',
+        alias: 'providers',
+        args: {},
+        fieldsByTypeName: {
+          ProviderList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, providerKeyMap, 'provider')
+
+      const provider = new Provider({}, requestInfo, {})
+
+      await provider.fetch({
+        params: {
+          keyword: 'test',
+          limit: 5,
+          offset: 0,
+          provider: null,
+          sortKey: null
+        },
+        pageSize: 5
+      })
+
+      const response = await provider.response
+
+      expect(await response[0].config.data).toEqual(undefined)
+      expect(await response[0].config.url).toEqual('http://example.com/ingest/providers')
+    })
+  })
+})

--- a/src/cmr/concepts/provider.js
+++ b/src/cmr/concepts/provider.js
@@ -1,0 +1,107 @@
+import snakecaseKeys from 'snakecase-keys'
+import { kebabCase, pick } from 'lodash'
+import { mergeParams } from '../../utils/mergeParams'
+import { providersQuery } from '../../utils/providersQuery'
+import Concept from './concept'
+import { parseError } from '../../utils/parseError'
+
+export default class Provider extends Concept {
+  /**
+   * Instantiates a Provider object
+   * @param {Object} headers HTTP headers provided by the query
+   * @param {Object} requestInfo Parsed data pertaining to the Graph query
+   * @param {Object} params GraphQL query parameters
+   */
+  constructor(headers, requestInfo, params) {
+    super('providers', headers, requestInfo, params)
+  }
+
+  /**
+   * Parses the response from each endpoint after a request is made
+   * @param {Object} requestInfo Parsed data pertaining to the Graph query
+   */
+  async parse(requestInfo) {
+    try {
+      const {
+        jsonKeys
+      } = requestInfo
+      const response = await this.getResponse()
+
+      const [jsonResponse] = response
+      if (jsonResponse) {
+        await this.parseJson(jsonResponse, jsonKeys)
+      }
+    } catch (e) {
+      parseError(e, { reThrowError: true })
+    }
+  }
+
+  /**
+   * Parses the response from the json endpoint
+   * @param {Object} jsonResponse HTTP response from the CMR endpoint
+   * @param {Array} jsonKeys Array of the keys requested in the query
+   */
+  async parseJson(jsonResponse, jsonKeys) {
+    this.setJsonItemCount(jsonResponse.data.length)
+
+    const items = this.parseJsonBody(jsonResponse)
+    items.forEach((item) => {
+      const normalizedItem = this.normalizeJsonItem(item)
+      const { 'provider-id': providerId } = normalizedItem
+      this.setEssentialJsonValues(providerId, normalizedItem)
+
+      jsonKeys.forEach((jsonKey) => {
+        const cmrKey = kebabCase(jsonKey)
+        const { [cmrKey]: keyValue } = normalizedItem
+        // Snake case the key requested and any children of that key
+        this.setItemValue(providerId, jsonKey, keyValue)
+      })
+    })
+  }
+
+  /**
+   * Parse and return the array of data from the nested response body
+   * @param {Object} jsonResponse HTTP response from the CMR endpoint
+   */
+  parseJsonBody(jsonResponse) {
+    const { data } = jsonResponse
+
+    return data
+  }
+
+  fetch(searchParams) {
+    const params = mergeParams(searchParams)
+
+    // Default an array to hold the promises we need to make depending on the requested fields
+    const promises = []
+
+    const { jsonKeys } = this.requestInfo
+
+    const jsonHeaders = {
+      ...this.headers
+    }
+    promises.push(
+      this.fetchProviders(params, jsonKeys, jsonHeaders)
+    )
+
+    this.response = Promise.all(promises)
+  }
+
+  /**
+   * Query the CMR JSON API endpoint to retrieve requested data
+   * @param {Object} searchParams Parameters provided by the query
+   * @param {Array} requestedKeys Keys requested by the query
+   * @param {Object} providedHeaders Headers requested by the query
+   */
+  fetchProviders(searchParams, requestedKeys, providedHeaders) {
+    this.logKeyRequest(requestedKeys, 'json')
+
+    // Construct the promise that will request data from the json endpoint
+    return providersQuery({
+      conceptType: this.getConceptType(),
+      params: pick(snakecaseKeys(searchParams), this.getPermittedJsonSearchParams()),
+      nonIndexedKeys: this.getNonIndexedKeys(),
+      headers: providedHeaders
+    })
+  }
+}

--- a/src/cmr/concepts/provider.js
+++ b/src/cmr/concepts/provider.js
@@ -3,7 +3,6 @@ import { kebabCase, pick } from 'lodash'
 import { mergeParams } from '../../utils/mergeParams'
 import { providersQuery } from '../../utils/providersQuery'
 import Concept from './concept'
-import { parseError } from '../../utils/parseError'
 
 export default class Provider extends Concept {
   /**
@@ -14,26 +13,6 @@ export default class Provider extends Concept {
    */
   constructor(headers, requestInfo, params) {
     super('providers', headers, requestInfo, params)
-  }
-
-  /**
-   * Parses the response from each endpoint after a request is made
-   * @param {Object} requestInfo Parsed data pertaining to the Graph query
-   */
-  async parse(requestInfo) {
-    try {
-      const {
-        jsonKeys
-      } = requestInfo
-      const response = await this.getResponse()
-
-      const [jsonResponse] = response
-      if (jsonResponse) {
-        await this.parseJson(jsonResponse, jsonKeys)
-      }
-    } catch (e) {
-      parseError(e, { reThrowError: true })
-    }
   }
 
   /**

--- a/src/datasources/__tests__/provider.test.js
+++ b/src/datasources/__tests__/provider.test.js
@@ -1,0 +1,123 @@
+import nock from 'nock'
+
+import providerDatasource from '../provider'
+
+let requestInfo
+
+describe('provider', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'providers',
+      alias: 'providers',
+      args: {},
+      fieldsByTypeName: {
+        ProviderList: {
+          items: {
+            name: 'items',
+            alias: 'items',
+            args: {},
+            fieldsByTypeName: {
+              Provider: {
+                conceptId: {
+                  name: 'providerId',
+                  alias: 'providerId',
+                  args: {},
+                  fieldsByTypeName: {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('without params', () => {
+    test('returns the parsed provider results', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/ingest\/providers/)
+        .reply(200, [
+          {
+            'provider-id': 'ESA',
+            'short-name': 'ESA',
+            'cmr-only': false,
+            small: false,
+            consortiums: 'CEOS FEDEO'
+          },
+          {
+            'provider-id': 'GHRC',
+            'short-name': 'GHRC',
+            'cmr-only': false,
+            small: false,
+            consortiums: 'EOSDIS GEOSS'
+          },
+          {
+            'provider-id': 'ECHO',
+            'short-name': 'ECHO',
+            'cmr-only': false,
+            small: true
+          }])
+
+      const response = await providerDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 3,
+        cursor: null,
+        items: [
+          {
+            providerId: 'ESA'
+          },
+          {
+            providerId: 'GHRC'
+          },
+          {
+            providerId: 'ECHO'
+          }
+        ]
+      })
+    })
+  })
+
+  test('Catches errors received from queryCmr', async () => {
+    nock(/example-cmr/)
+      .get(/providers/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      providerDatasource({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})

--- a/src/datasources/provider.js
+++ b/src/datasources/provider.js
@@ -1,0 +1,18 @@
+import { parseRequestedFields } from '../utils/parseRequestedFields'
+import providerKeyMap from '../utils/umm/providerKeyMap.json'
+
+import Provider from '../cmr/concepts/provider'
+
+export default async (params, context, parsedInfo) => {
+  const { headers } = context
+  const requestInfo = parseRequestedFields(parsedInfo, providerKeyMap, 'provider')
+  const provider = new Provider(headers, requestInfo, params)
+  // Query CMR
+  provider.fetch(params)
+
+  // Parse the response from CMR
+  await provider.parse(requestInfo)
+
+  // Return a formatted JSON response
+  return provider.getFormattedResponse()
+}

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -22,6 +22,7 @@ import graphDbSource from '../datasources/graphDb'
 import gridSource from '../datasources/grid'
 import maxItemsPerOrderSource from '../datasources/maxItemsPerOrder'
 import orderOptionSource from '../datasources/orderOption'
+import providerSource from '../datasources/provider'
 import serviceDraftSource from '../datasources/serviceDraft'
 import tagDefinitionSource from '../datasources/tagDefinition'
 import toolDraftSource from '../datasources/toolDraft'
@@ -153,6 +154,8 @@ export default startServerAndCreateLambdaHandler(
 
       requestHeaders.User = context.edlUsername
 
+      console.log('🚀 ~ context: ~ providerSource:', providerSource)
+
       return {
         ...context,
         dataSources: {
@@ -173,6 +176,7 @@ export default startServerAndCreateLambdaHandler(
           gridSource,
           maxItemsPerOrderSource,
           orderOptionSource,
+          providerSource,
           serviceDraftSource,
           serviceSourceDelete,
           serviceSourceFetch,

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -154,8 +154,6 @@ export default startServerAndCreateLambdaHandler(
 
       requestHeaders.User = context.edlUsername
 
-      console.log('🚀 ~ context: ~ providerSource:', providerSource)
-
       return {
         ...context,
         dataSources: {

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -14,6 +14,7 @@ import graphDbSource from '../../../datasources/graphDb'
 import gridSource from '../../../datasources/grid'
 import maxItemsPerOrderSource from '../../../datasources/maxItemsPerOrder'
 import orderOptionSource from '../../../datasources/orderOption'
+import providerSource from '../../../datasources/provider'
 import serviceDraftSource from '../../../datasources/serviceDraft'
 import {
   deleteSubscription as subscriptionSourceDelete,
@@ -72,6 +73,7 @@ export const buildContextValue = (extraContext) => ({
     gridSource,
     maxItemsPerOrderSource,
     orderOptionSource,
+    providerSource,
     serviceDraftSource,
     serviceSourceDelete,
     serviceSourceFetch,

--- a/src/resolvers/__tests__/provider.test.js
+++ b/src/resolvers/__tests__/provider.test.js
@@ -1,0 +1,100 @@
+import nock from 'nock'
+
+import { buildContextValue, server } from './__mocks__/mockServer'
+
+const contextValue = buildContextValue()
+
+describe('Provider', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('Query', () => {
+    test('all provider fields', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/providers/)
+        .reply(200, [
+          {
+            'provider-id': 'ESA',
+            'short-name': 'ESA',
+            'cmr-only': false,
+            small: false,
+            consortiums: 'CEOS FEDEO'
+          },
+          {
+            'provider-id': 'GHRC',
+            'short-name': 'GHRC',
+            'cmr-only': false,
+            small: false,
+            consortiums: 'EOSDIS GEOSS'
+          },
+          {
+            'provider-id': 'ECHO',
+            'short-name': 'ECHO',
+            'cmr-only': false,
+            small: true
+          }])
+
+      const response = await server.executeOperation({
+        variables: {},
+        query: `{
+          providers {
+            count
+            items {
+              providerId
+              shortName
+              cmrOnly
+              small
+              consortiums
+            }
+          }
+        }`
+      }, {
+        contextValue
+      })
+
+      const { data } = response.body.singleResult
+
+      expect(data).toEqual({
+        providers: {
+          count: 3,
+          items: [
+            {
+              providerId: 'ESA',
+              shortName: 'ESA',
+              cmrOnly: false,
+              small: false,
+              consortiums: 'CEOS FEDEO'
+            },
+            {
+              providerId: 'GHRC',
+              shortName: 'GHRC',
+              cmrOnly: false,
+              small: false,
+              consortiums: 'EOSDIS GEOSS'
+            },
+            {
+              providerId: 'ECHO',
+              shortName: 'ECHO',
+              cmrOnly: false,
+              small: true,
+              consortiums: null
+            }
+          ]
+        }
+      })
+    })
+  })
+})

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -9,6 +9,7 @@ import draftResolver from './draft'
 import granuleResolver from './granule'
 import gridResolver from './grid'
 import orderOptionResolver from './orderOption'
+import providerResolver from './provider'
 import serviceResolver from './service'
 import serviceDraftResolver from './serviceDraft'
 import subscriptionResolver from './subscription'
@@ -28,6 +29,7 @@ const resolvers = [
   granuleResolver,
   gridResolver,
   orderOptionResolver,
+  providerResolver,
   serviceResolver,
   serviceDraftResolver,
   subscriptionResolver,

--- a/src/resolvers/provider.js
+++ b/src/resolvers/provider.js
@@ -1,0 +1,17 @@
+import { parseResolveInfo } from 'graphql-parse-resolve-info'
+
+import { handlePagingParams } from '../utils/handlePagingParams'
+
+export default {
+  Query: {
+    providers: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.providerSource(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    }
+  }
+}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -8,6 +8,7 @@ import draft from './draft.graphql'
 import granule from './granule.graphql'
 import grid from './grid.graphql'
 import json from './json.graphql'
+import provider from './provider.graphql'
 import service from './service.graphql'
 import serviceDraft from './serviceDraft.graphql'
 import subscription from './subscription.graphql'
@@ -30,6 +31,7 @@ export default mergeTypeDefs(
     grid,
     json,
     orderOption,
+    provider,
     service,
     serviceDraft,
     subscription,

--- a/src/types/provider.graphql
+++ b/src/types/provider.graphql
@@ -1,0 +1,23 @@
+type Provider {
+  "The provider id"
+  providerId: String
+  "The provider short name"
+  shortName: String
+  "The provider CMR only flag"
+  cmrOnly: Boolean
+  "The provider small flag"
+  small: Boolean
+  "The consortiums associated with the provider"
+  consortiums: String
+}
+
+type ProviderList {
+  "The number of providers."
+  count: Int
+  "The list of provider results."
+  items: [Provider]
+}
+
+type Query {
+  providers: ProviderList!
+}

--- a/src/utils/providersQuery.js
+++ b/src/utils/providersQuery.js
@@ -1,0 +1,74 @@
+import axios from 'axios'
+import { downcaseKeys } from './downcaseKeys'
+import { pickIgnoringCase } from './pickIgnoringCase'
+
+/**
+ * Make a request to retrieve a list of providers and return the promise
+ * @param {Object} params
+ * @param {Object} params.headers Headers to send to the ACL service
+ * @param {Object} params.options Additional Options (format)
+ */
+
+export const providersQuery = ({
+  headers
+}) => {
+  // Default headers
+  const defaultHeaders = {}
+
+  // Merge default headers into the provided headers and then pick out only permitted values
+  const permittedHeaders = pickIgnoringCase({
+    ...defaultHeaders,
+    ...headers
+  }, [
+    'Accept',
+    'Authorization',
+    'Client-Id',
+    'CMR-Request-Id',
+    'CMR-Search-After'
+  ])
+
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
+
+  const requestConfiguration = {
+    headers: permittedHeaders,
+    method: 'GET',
+    url: `${process.env.cmrRootUrl}/ingest/providers`
+  }
+
+  // Interceptors require an instance of axios
+  const instance = axios.create()
+  const { interceptors } = instance
+  const {
+    request: requestInterceptor,
+    response: responseInterceptor
+  } = interceptors
+
+  // Intercept the request to inject timing information
+  requestInterceptor.use((config) => {
+    // eslint-disable-next-line no-param-reassign
+    config.headers['request-startTime'] = process.hrtime()
+
+    return config
+  })
+
+  // If the response has providers ids then it is working
+  responseInterceptor.use((response) => {
+    // Determine total time to complete this request
+    const start = response.config.headers['request-startTime']
+    const end = process.hrtime(start)
+    const milliseconds = Math.round((end[0] * 1000) + (end[1] / 1000000))
+
+    // Retrieve the reported timing from CMR
+    const { 'cmr-took': cmrTook } = downcaseKeys(response.headers)
+    response.headers['request-duration'] = milliseconds
+
+    console.log(`Request ${requestId} from ${clientId} completed external request in [reported: ${cmrTook} ms, observed: ${milliseconds} ms]`)
+
+    return response
+  })
+
+  return instance.request(requestConfiguration)
+}

--- a/src/utils/umm/providerKeyMap.json
+++ b/src/utils/umm/providerKeyMap.json
@@ -1,0 +1,11 @@
+{
+  "jsonKeys": [
+    "providerId",
+    "shortName",
+    "cmrOnly",
+    "small",
+    "consortiums"
+  ],
+  "sharedKeys": [],
+  "ummKeyMappings": {}
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Adds a query to get all providers using the `/ingest/providers` endpoint for use in MMT

### What is the Solution?

Adds a provider type, concept, and resolver to query the endpoint

### What areas of the application does this impact?

Providers query

# Testing

### Reproduction steps

- **Environment for testing:** ANY
- **Collection to test with:** N/A

1. Query for providers
2. Confirm the count and items are returned as expected

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
