### PR TITLE
EDSC-3988 updates umm-g version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,7 +29,7 @@ provider:
 
     # Pinned UMM versions
     ummCollectionVersion: '1.17.2'
-    ummGranuleVersion: '1.5'
+    ummGranuleVersion: '1.6.5'
     ummServiceVersion: '1.5.2'
     ummSubscriptionVersion: '1.1'
     ummToolVersion: '1.2.0'


### PR DESCRIPTION
# Overview

### What is the feature?

The granule info panel wasn't showing certain fields

### What is the Solution?

Updated umm-g version

### What areas of the application does this impact?

Granule searches

# Testing

### Reproduction steps

Navigate to granule information and verify SizeInBytes is there, and ENVI format is present when its in the metadata.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
