### PR TITLE
GQL-36: As a MMT dev, I want to be able to CRUD Order Options in CMR GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,43 +84,49 @@ When querying for multiple items there are three high level parameters that can 
 
 ###### First Request:
 
-    {
-      concept {
-        count
-        cursor
-        items {
-          conceptId
-        }
-      }
+```gql
+{
+  concept {
+    count
+    cursor
+    items {
+      conceptId
     }
+  }
+}
+```
 
 Which will return something similar to the following:
 
-    {
-      "data": {
-        "concept": {
-          "count": 2483,
-          "cursor": "eyJqc29uIjoiLTQ2OTA0MDY3NyJ9=",
-          "items": [
-            {
-              "conceptId": "C1000000001-EXAMPLE"
-            },
-            ...
-        }
-      }
+```json
+{
+  "data": {
+    "concept": {
+      "count": 2483,
+      "cursor": "eyJqc29uIjoiLTQ2OTA0MDY3NyJ9=",
+      "items": [
+        {
+          "conceptId": "C1000000001-EXAMPLE"
+        },
+        ...
     }
+  }
+}
+```
 
 ###### Subsequent Requests
 
-    {
-      concept(cursor: "eyJqc29uIjoiLTQ2OTA0MDY3NyJ9=") {
-        count
-        cursor
-        items {
-          conceptId
-        }
-      }
+```gql
+{
+  concept(cursor: "eyJqc29uIjoiLTQ2OTA0MDY3NyJ9=") {
+    count
+    cursor
+    items {
+      conceptId
     }
+  }
+}
+```
 
 A couple of things to keep in mind when using a cursor
 
@@ -133,37 +139,43 @@ When all results have been returned, the response will be an empty array and the
 
 `facets` will return the data provided by CMR determined by which facets you requested in your query. In order for this data to be provided by CMR you will need to include the `includeFacets` parameter in your query. For more information regarding facets refer to the [CMR documentation](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#facets). See below for a basic example:
 
-    {
-      collections(
-        includeFacets:"v2"
-      ) {
-        facets
-        items {
-          conceptId
-        }
-      }
+```gql
+{
+  collections(
+    includeFacets:"v2"
+  ) {
+    facets
+    items {
+      conceptId
     }
+  }
+}
+```
 
 ##### Items
 
 `items` is where you will provide the columns you'd like returned from CMR.
 
-    {
-      concept {
-        count
-        items {
-          conceptId
-        }
-      }
+```gql
+{
+  concept {
+    count
+    items {
+      conceptId
     }
+  }
+}
+```
 
 If you're querying single objects `count` is not available and therefore `items` isn't necessary -- you can simply list the columns you'd like returned from CMR as a direct child of your query.
 
-    {
-      concept {
-        conceptId
-      }
-    }
+```gql
+{
+  concept {
+    conceptId
+  }
+}
+```
 
 Note that the response you get will match the structure of your query, meaning that in the event you've requested data from a list query you'll receive the results in an `items` array whereas with a single query request you will not.
 
@@ -176,79 +188,83 @@ For all supported arguments and columns, see [the schema](src/types/collection.g
 
 ##### Example Queries
 
-###### Single
+###### Query for a single collection
 
-    {
-      collection(conceptId:"C1000000001-EXAMPLE") {
+```gql
+{
+  collection(conceptId:"C1000000001-EXAMPLE") {
+    title
+    granules {
+      count
+      items {
+        conceptId
         title
-        granules {
-          count
-          items {
-            conceptId
-            title
-          }
-        }
-        services {
-          count
-          items {
-            conceptId
-            type
-          }
-        }
-        tools {
-          count
-          items {
-            conceptId
-            supportedBrowsers
-          }
-        }
-        variables {
-          count
-          items {
-            conceptId
-            name
-          }
-        }
       }
     }
+    services {
+      count
+      items {
+        conceptId
+        type
+      }
+    }
+    tools {
+      count
+      items {
+        conceptId
+        supportedBrowsers
+      }
+    }
+    variables {
+      count
+      items {
+        conceptId
+        name
+      }
+    }
+  }
+}
+```
 
-###### Multiple
+###### Query for multiple collections
 
-    {
-      collections(
-        conceptId:["C1000000001-EXAMPLE", "C1000000002-EXAMPLE"]
-      ) {
+```gql
+{
+  collections(
+    conceptId:["C1000000001-EXAMPLE", "C1000000002-EXAMPLE"]
+  ) {
+    count
+    items {
+      title
+      granules {
+        count
+        title
+      }
+      services {
         count
         items {
-          title
-          granules {
-            count
-            title
-          }
-          services {
-            count
-            items {
-              conceptId
-              type
-            }
-          }
-          tools {
-            count
-            items {
-              conceptId
-              supportedBrowsers
-            }
-          }
-          variables {
-            count
-            items {
-              conceptId
-              name
-            }
-          }
+          conceptId
+          type
+        }
+      }
+      tools {
+        count
+        items {
+          conceptId
+          supportedBrowsers
+        }
+      }
+      variables {
+        count
+        items {
+          conceptId
+          name
         }
       }
     }
+  }
+}
+```
 
 #### Granules
 
@@ -266,113 +282,127 @@ A subset of the supported arguments for [Collections](#collections) will be pass
 
 For all supported arguments and columns, see [the schema](src/types/granule.graphql).
 
-##### Example Queries
+##### Granule Queries
 
-###### Single
+###### Query for a single granule
 
-    {
-      granule(conceptId:"G1000000001-EXAMPLE") {
-        conceptId
-        title
-      }
+```gql
+{
+  granule(conceptId:"G1000000001-EXAMPLE") {
+    conceptId
+    title
+  }
+}
+```
+
+###### Query for multiple granules
+
+```gql
+{
+  granules(collectionConceptId:"G1000000001-EXAMPLE") {
+    items {
+      conceptId
+      title
     }
-
-###### Multiple
-
-    {
-      granules(collectionConceptId:"G1000000001-EXAMPLE") {
-        items {
-          conceptId
-          title
-        }
-      }
-    }
-
+  }
+}
+```
 
 #### Services
 
 For all supported arguments and columns, see [the schema](src/types/service.graphql).
 
-##### Example Queries
+##### Service Queries
 
-###### Single
+###### Query for a single service
 
-    {
-      service(conceptId:"S1000000001-EXAMPLE") {
-        conceptId
-        type
-      }
+```gql
+{
+  service(conceptId:"S1000000001-EXAMPLE") {
+    conceptId
+    type
+  }
+}
+```
+
+###### Query for multiple services
+
+```gql
+{
+  services {
+    count
+    items {
+      conceptId
+      type
+      description
     }
-
-###### Multiple
-
-    {
-      services {
-        count
-        items {
-          conceptId
-          type
-          description
-        }
-      }
-    }
-
+  }
+}
+```
 
 #### Subscriptions
 
 For all supported arguments and columns, see [the schema](src/types/subscription.graphql).
 
-##### Example Queries
+##### Subscription Queries
 
-###### Single
+###### Query for a single subscription
 
-    {
-      subscription(conceptId:"SUB1000000001-EXAMPLE") {
-        conceptId
-        nativeId
-        query
-      }
-    }
+```gql
+{
+  subscription(conceptId:"SUB1000000001-EXAMPLE") {
+    conceptId
+    nativeId
+    query
+  }
+}
+```
 
 *To also retrieve details pertaining to the associated collection:*
 
-    {
-      subscription(conceptId:"SUB1000000001-EXAMPLE") {
-        conceptId
-        nativeId
-        query
-        collection {
-          title
-        }
-      }
+```gql
+{
+  subscription(conceptId:"SUB1000000001-EXAMPLE") {
+    conceptId
+    nativeId
+    query
+    collection {
+      title
     }
+  }
+}
+```
 
-###### Multiple
+###### Query for multiple subscriptions
 
-    {
-      subscriptions {
-        count
-        items {
-          conceptId
-          query
-        }
-      }
+```gql
+{
+  subscriptions {
+    count
+    items {
+      conceptId
+      query
     }
+  }
+}
+```
 
 *To also retrieve details pertaining to the associated collections:*
 
-    {
-      subscriptions {
-        count
-        items {
-          conceptId
-          query
-          collection {
-            title
-          }
-        }
+```gql
+{
+  subscriptions {
+    count
+    items {
+      conceptId
+      query
+      collection {
+        title
       }
     }
+  }
+}
+```
 
 ##### Mutations
 
@@ -380,147 +410,167 @@ For all supported arguments and columns, see [the schema](src/types/subscription
 
 If no `nativeId` is provided, CMR-GraphQL will generate a GUID and supply it.
 
-    mutation {
-      createSubscription(
-        collectionConceptId: "C1000000001-EXAMPLE"
-        name: "Example Subscription"
-        query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
-        subscriberId: "username"
-      ) {
-        conceptId
-        revisionId
-      }
-    }
+```gql
+mutation {
+  createSubscription(
+    collectionConceptId: "C1000000001-EXAMPLE"
+    name: "Example Subscription"
+    query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+    subscriberId: "username"
+  ) {
+    conceptId
+    revisionId
+  }
+}
+```
 
 To set the `nativeId` to a desired value, simply provide it as an argument and it will be used.
 
-    mutation {
-      createSubscription(
-        collectionConceptId: "C1000000001-EXAMPLE"
-        name: "Example Subscription"
-        nativeId: "SUPPLIED-NATIVE-ID"
-        query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
-        subscriberId: "username"
-      ) {
-        conceptId
-        revisionId
-      }
-    }
+```gql
+mutation {
+  createSubscription(
+    collectionConceptId: "C1000000001-EXAMPLE"
+    name: "Example Subscription"
+    nativeId: "SUPPLIED-NATIVE-ID"
+    query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+    subscriberId: "username"
+  ) {
+    conceptId
+    revisionId
+  }
+}
+```
 
 ##### Updating a Subscription
 
 CMR defines a record as unique based on the `nativeId`, in order to update a subscription supply a `nativeId` that belongs an existing record.
 
-    mutation {
-      updateSubscription(
-        collectionConceptId: "C1000000001-EXAMPLE"
-        name: "Example Subscription"
-        nativeId: "EXISTING-NATIVE-ID"
-        query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
-        subscriberId: "username"
-      ) {
-        conceptId
-        revisionId
-      }
-    }
+```gql
+mutation {
+  updateSubscription(
+    collectionConceptId: "C1000000001-EXAMPLE"
+    name: "Example Subscription"
+    nativeId: "EXISTING-NATIVE-ID"
+    query: "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78"
+    subscriberId: "username"
+  ) {
+    conceptId
+    revisionId
+  }
+}
+```
 
 **NOTES**:
 
-  - Due to the way in which CMR works, `createSubscription` and `updateSubscription` will operate identically when supplying an existing `nativeId` however, this may not always be the case so we encourage you to use the explicit `updateSubscription` mutation noted below.
+- Due to the way in which CMR works, `createSubscription` and `updateSubscription` will operate identically when supplying an existing `nativeId` however, this may not always be the case so we encourage you to use the explicit `updateSubscription` mutation noted below.
 
 ##### Deleting a Subscription
 
 CMR defines a record as unique based on the `nativeId`, in order to delete a subscription supply a `nativeId` that belongs an existing record.
 
-    mutation {
-      deleteSubscription(
-        conceptId: "SUB1000000001-EXAMPLE"
-        nativeId: "EXISTING-NATIVE-ID"
-      ) {
-        conceptId
-        revisionId
-      }
-    }
+```gql
+mutation {
+  deleteSubscription(
+    conceptId: "SUB1000000001-EXAMPLE"
+    nativeId: "EXISTING-NATIVE-ID"
+  ) {
+    conceptId
+    revisionId
+  }
+}
+```
 
 #### Tools
 
 For all supported arguments and columns, see [the schema](src/types/tool.graphql).
 
-##### Example Queries
+##### Tool Queries
 
-###### Single
+###### Query for a single tool
 
-    {
-      tool(conceptId:"T1000000001-EXAMPLE") {
-        conceptId
-        scienceKeywords
-        supportedBrowsers
-      }
+```gql
+{
+  tool(conceptId:"T1000000001-EXAMPLE") {
+    conceptId
+    scienceKeywords
+    supportedBrowsers
+  }
+}
+```
+
+###### Query for multiple tools
+
+```gql
+{
+  tools {
+    count
+    items {
+      conceptId
+      toolKeywords
+      supportedBrowsers
     }
-
-###### Multiple
-
-    {
-      tools {
-        count
-        items {
-          conceptId
-          toolKeywords
-          supportedBrowsers
-        }
-      }
-    }
+  }
+}
+```
 
 ###### Deleting a Tool
 
-    mutation DeleteTool(
-      $providerId: String!
-      $nativeId: String!
-    ) {
-      deleteTool(
-        providerId: $providerId
-        nativeId: $nativeId
-      ) {
-        conceptId
-        revisionId
-      }
-    }
+```gql
+mutation DeleteTool(
+  $providerId: String!
+  $nativeId: String!
+) {
+  deleteTool(
+    providerId: $providerId
+    nativeId: $nativeId
+  ) {
+    conceptId
+    revisionId
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "providerId": "EXAMPLE",
-      "nativeId": "tool-1"
-    }
+```json
+{
+  "providerId": "EXAMPLE",
+  "nativeId": "tool-1"
+}
+```
 
 #### Variables
 
 For all supported arguments and columns, see [the schema](src/types/variable.graphql).
 
-##### Example Queries
+##### Grid Queries
 
-###### Single
+###### Query for a single grid
 
-    {
-      variable(conceptId:"V1000000001-EXAMPLE") {
-        conceptId
-        scienceKeywords
-        variableType
-      }
+```gql
+{
+  variable(conceptId:"V1000000001-EXAMPLE") {
+    conceptId
+    scienceKeywords
+    variableType
+  }
+}
+```
+
+###### Query for multiple variables
+
+```gql
+{
+  variables {
+    count
+    items {
+      conceptId
+      scienceKeywords
+      variableType
     }
-
-###### Multiple
-
-    {
-      variables {
-        count
-        items {
-          conceptId
-          scienceKeywords
-          variableType
-        }
-      }
-    }
+  }
+}
+```
 
 #### Grids
 
@@ -528,118 +578,209 @@ For all supported arguments and columns, see [the schema](src/types/grid.graphql
 
 ##### Example Queries
 
-###### Single
+###### Query for a singe grid
 
-    {
-      grid(conceptId:"GRD1000000001-EXAMPLE") {
-        conceptId
-        title
-      }
+```gql
+{
+  grid(conceptId:"GRD1000000001-EXAMPLE") {
+    conceptId
+    title
+  }
+}
+```
+
+###### Query for multiple grids
+
+```gql
+{
+  grids {
+    items {
+      conceptId
+      name
+      longName
+      description
     }
+  }
+}
+```
 
-###### Multiple
-
-    {
-      grids {
-        items {
-          conceptId
-          name
-          longName
-          description
-        }
-      }
-    }
-
-#### Order-options
+#### Order Options
 
 For all supported arguments and columns, see [the schema](src/types/orderOption.graphql).
 
-##### Example Queries
+##### Order Option Queries
 
-###### Single
+###### Query for a single order option
 
-    {
-      query ($params: OrderOptionInput) {
-        orderOption(params: $params) {
-          associationDetails
-          conceptId
-          id
-          name
-          nativeId
-          description
-          form
-        }
-      }
+```gql
+{
+  query ($params: OrderOptionInput) {
+    orderOption(params: $params) {
+      associationDetails
+      conceptId
+      id
+      name
+      nativeId
+      description
+      form
     }
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "params": {
-        "conceptId": "OO1000000001-EXAMPLE"
-      }
+```json
+{
+  "params": {
+    "conceptId": "OO1000000001-EXAMPLE"
+  }
+}
+```
+
+###### Query for multiple order options
+
+```gql
+{
+  orderOptions {
+    count
+    items {
+      conceptId
+      name
+      nativeId
+      id
+      description
+      scope
+      form
+      sortKey
     }
+  }
+}
+```
 
-###### Multiple
+##### Order Option Mutations
 
-    {
-      orderOptions {
-        count
-        items {
-          conceptId
-          name
-          nativeId
-          id
-          description
-          scope
-          form
-          sortKey
-        }
-      }
-    }
+###### Creating an order option
 
-#### Data-Quality-Summaries
+Query:
+
+```gql
+mutation CreateOrderOption($description: String!, $name: String!, $providerId:
+String!, $form: String!, $nativeId: String) {
+  createOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
+    conceptId
+    revisionId
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "description": "This is a description",
+  "form": "This is the form",
+  "name": "This is another new name",
+  "nativeId": "test-native-id-2",
+  "providerId": "MMT_1",
+}
+```
+
+###### Updating an order option
+
+Query:
+
+```gql
+mutation UpdateOrderOption($providerId: String!, $description: String!, $form: String!, $nativeId: String!, $name: String!) {
+  updateOrderOption(providerId: $providerId, description: $description, form: $form, nativeId: $nativeId, name: $name) {
+    conceptId
+    revisionId
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "description": "This is a new description",
+  "form": "something new",
+  "name": "this is a name",
+  "nativeId": "collection1",
+  "providerId": "MMT_1",
+}
+```
+
+###### Deleting an order option
+
+Query:
+
+```gql
+mutation DeleteOrderOption($nativeId: String!, $providerId: String!) {
+  deleteOrderOption(nativeId: $nativeId, providerId: $providerId) {
+    conceptId
+    revisionId
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "nativeId": "b4876280-c7ff-41ab-b08f-af91369fe464",
+  "providerId": "MMT_1"
+}
+```
+
+#### Data Quality Summaries
 
 For all supported arguments and columns, see [the schema](src/types/dataQualitySummary.graphql).
 
-##### Example Queries
+##### Data Quality Summary Queries
 
-###### Single
+###### Query for a single data quality summary
 
-    {
-      query ($params: DataQualitySummaryInput) {
-        dataQualitySummary(params: $params) {
-          associationDetails
-          conceptId
-          id
-          name
-          nativeId
-          summary
-        }
-      }
+```gql
+{
+  query ($params: DataQualitySummaryInput) {
+    dataQualitySummary(params: $params) {
+      associationDetails
+      conceptId
+      id
+      name
+      nativeId
+      summary
     }
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "params": {
-        "conceptId": "DQS1000000001-EXAMPLE"
-      }
+```json
+{
+  "params": {
+    "conceptId": "DQS1000000001-EXAMPLE"
+  }
+}
+```
+
+###### Query for multiple data quality summaries
+
+```gql
+{
+  dataQualitySummaries {
+    items {
+      conceptId
+      associationDetails
+      name
+      summary
+      id
     }
-
-###### Multiple
-
-    {
-      dataQualitySummaries {
-        items {
-          conceptId
-          associationDetails
-          name
-          summary
-          id
-        }
-      }
-    }
+  }
+}
+```
 
 #### Related Collections
 
@@ -653,69 +794,73 @@ We use [GraphQL interfaces](https://graphql.org/learn/schema/#interfaces) in ord
 
 ##### Example Queries
 
-    {
-      conceptId
-      relatedCollections (
-        limit: 1
-      ) {
-        count
-        items {
-          id
-          title
-          doi
-          relationships {
-            relationshipType
-            ... on GraphDbProject {
-              name
-            }
-            ... on GraphDbPlatformInstrument {
-              platform
-              instrument
-            }
-            ... on GraphDbRelatedUrl {
-              url
-              description
-              type
-              subtype
-            }
-          }
+```gql
+{
+  conceptId
+  relatedCollections (
+    limit: 1
+  ) {
+    count
+    items {
+      id
+      title
+      doi
+      relationships {
+        relationshipType
+        ... on GraphDbProject {
+          name
+        }
+        ... on GraphDbPlatformInstrument {
+          platform
+          instrument
+        }
+        ... on GraphDbRelatedUrl {
+          url
+          description
+          type
+          subtype
         }
       }
     }
+  }
+}
+```
 
 ##### Example Response
 
-    {
-      "conceptId": "C1000000001-EXAMPLE",
-      "relatedCollections": {
-        "count": 18,
-        "items": [
+```json
+{
+  "conceptId": "C1000000001-EXAMPLE",
+  "relatedCollections": {
+    "count": 18,
+    "items": [
+      {
+        "id": "C2000000001-EXAMPLE",
+        "title": "Infrared Global Geostationary Composite Demo 4",
+        "doi": "10.5067/GHRC/AMSU-A/DATA303",
+        "relationships": [
           {
-            "id": "C2000000001-EXAMPLE",
-            "title": "Infrared Global Geostationary Composite Demo 4",
-            "doi": "10.5067/GHRC/AMSU-A/DATA303",
-            "relationships": [
-              {
-                "relationshipType": "platformInstrument",
-                "platform": "MTSAT-1R",
-                "instrument": "VISSR"
-              },
-              {
-                "relationshipType": "relatedUrl",
-                "url": "https://doi.org/10.5067/9LNYIYOBNBR5",
-                "description": "Another Related URL for Demo",
-                "type": "VIEW RELATED INFORMATION",
-                "subtype": "DATA RECIPE"
-              },
-              {
-                "relationshipType": "project",
-                "name": "Project2"
-              }
-            ]
+            "relationshipType": "platformInstrument",
+            "platform": "MTSAT-1R",
+            "instrument": "VISSR"
+          },
+          {
+            "relationshipType": "relatedUrl",
+            "url": "https://doi.org/10.5067/9LNYIYOBNBR5",
+            "description": "Another Related URL for Demo",
+            "type": "VIEW RELATED INFORMATION",
+            "subtype": "DATA RECIPE"
+          },
+          {
+            "relationshipType": "project",
+            "name": "Project2"
           }
         ]
       }
-    }
+    ]
+  }
+}
+```
 
 #### Generate Collection Variable Drafts
 
@@ -725,87 +870,16 @@ CMR-GraphQL queries an earthdata-varinfo lambda in order to generate collection 
 
 `generateVariableDrafts` will return collection generated variable drafts, using the earthdata-varinfo project(https://github.com/nasa/earthdata-varinfo)
 
-##### Example Queries
+##### Collection Variable Draft Queries
 
-    {
-      query Collection($params: CollectionInput) {
-        collection(params: $params) {
-          conceptId
-          generateVariableDrafts {
-            count
-            items {
-              dataType
-              definition
-              dimensions
-              longName
-              name
-              standardName
-              units
-              metadataSpecification
-            }
-          }
-        }
-      }
-    }
-
-variables:
-
-    {
-      "params": {
-        "conceptId": "C1000000001-EXAMPLE"
-      }
-    }
-
-##### Example Response
-
-     {
-      "data": {
-        "collection": {
-          "conceptId": "C1000000001-EXAMPLE",
-          "generateVariableDrafts": {
-            "count": 16,
-            "items": [
-              {
-                "dataType": "int32",
-                "definition": "Grid/time",
-                "dimensions": [
-                  {
-                    "Name": "Grid/time",
-                    "Size": 1,
-                    "Type": "TIME_DIMENSION"
-                  }
-                ],
-                "longName": "Grid/time",
-                "name": "Grid/time",
-                "standardName": "time",
-                "units": "seconds since 1970-01-01 00:00:00 UTC",
-                "metadataSpecification": {
-                  "URL": "https://cdn.earthdata.nasa.gov/umm/variable/v1.8.2",
-                  "Name": "UMM-Var",
-                  "Version": "1.8.2"
-                }
-              }
-            ]
-          }
-        }
-      }
-    }
-
-#### Publish Generated Collection Variable Drafts
-
-For all supported arguments and columns, see [the schema](src/types/variable.graphql).
-
-CMR-GraphQL queries an earthdata-varinfo lambda in order to generate and publish collection variable drafts. The resulting variables can be returned as part of the Variable type response.
-
-`publishVariableDrafts` will return collection generated variables, using the earthdata-varinfo project(https://github.com/nasa/earthdata-varinfo)
-
-##### Example Mutation
-
-    mutation PublishGeneratedVariables($conceptId: String!) {
-      publishGeneratedVariables(conceptId: $conceptId) {
+```gql
+{
+  query Collection($params: CollectionInput) {
+    collection(params: $params) {
+      conceptId
+      generateVariableDrafts {
         count
         items {
-          conceptId
           dataType
           definition
           dimensions
@@ -817,44 +891,128 @@ CMR-GraphQL queries an earthdata-varinfo lambda in order to generate and publish
         }
       }
     }
+  }
+}
+```
 
-    variables:
-    {
-      "conceptId": "C1000000001-EXAMPLE"
-    }
+Variables:
+
+```json
+{
+  "params": {
+    "conceptId": "C1000000001-EXAMPLE"
+  }
+}
+```
 
 ##### Example Response
 
-     {
-      "data": {
-        "publishGeneratedVariables": {
-          "count": 1,
-          "items": [
-            {
-              "conceptId": "V1000000001-EXAMPLE",
-              "dataType": "int32",
-              "definition": "Grid/time",
-              "dimensions": [
-                {
-                  "Name": "Grid/time",
-                  "Size": 1,
-                  "Type": "TIME_DIMENSION"
-                }
-              ],
-              "longName": "Grid/time",
-              "name": "Grid/time",
-              "standardName": "time",
-              "units": "seconds since 1970-01-01 00:00:00 UTC",
-              "metadataSpecification": {
-                "URL": "https://cdn.earthdata.nasa.gov/umm/variable/v1.8.2",
-                "Name": "UMM-Var",
-                "Version": "1.8.2"
+```json
+  {
+  "data": {
+    "collection": {
+      "conceptId": "C1000000001-EXAMPLE",
+      "generateVariableDrafts": {
+        "count": 16,
+        "items": [
+          {
+            "dataType": "int32",
+            "definition": "Grid/time",
+            "dimensions": [
+              {
+                "Name": "Grid/time",
+                "Size": 1,
+                "Type": "TIME_DIMENSION"
               }
+            ],
+            "longName": "Grid/time",
+            "name": "Grid/time",
+            "standardName": "time",
+            "units": "seconds since 1970-01-01 00:00:00 UTC",
+            "metadataSpecification": {
+              "URL": "https://cdn.earthdata.nasa.gov/umm/variable/v1.8.2",
+              "Name": "UMM-Var",
+              "Version": "1.8.2"
             }
-          ]
-        }
+          }
+        ]
       }
     }
+  }
+}
+```
+
+#### Publish Generated Collection Variable Drafts
+
+For all supported arguments and columns, see [the schema](src/types/variable.graphql).
+
+CMR-GraphQL queries an earthdata-varinfo lambda in order to generate and publish collection variable drafts. The resulting variables can be returned as part of the Variable type response.
+
+`publishVariableDrafts` will return collection generated variables, using the earthdata-varinfo project(https://github.com/nasa/earthdata-varinfo)
+
+##### Generate Collection Variable Drafts Mutation
+
+```gql
+mutation PublishGeneratedVariables($conceptId: String!) {
+  publishGeneratedVariables(conceptId: $conceptId) {
+    count
+    items {
+      conceptId
+      dataType
+      definition
+      dimensions
+      longName
+      name
+      standardName
+      units
+      metadataSpecification
+    }
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "conceptId": "C1000000001-EXAMPLE"
+}
+```
+
+##### Example Response
+
+```json
+  {
+  "data": {
+    "publishGeneratedVariables": {
+      "count": 1,
+      "items": [
+        {
+          "conceptId": "V1000000001-EXAMPLE",
+          "dataType": "int32",
+          "definition": "Grid/time",
+          "dimensions": [
+            {
+              "Name": "Grid/time",
+              "Size": 1,
+              "Type": "TIME_DIMENSION"
+            }
+          ],
+          "longName": "Grid/time",
+          "name": "Grid/time",
+          "standardName": "time",
+          "units": "seconds since 1970-01-01 00:00:00 UTC",
+          "metadataSpecification": {
+            "URL": "https://cdn.earthdata.nasa.gov/umm/variable/v1.8.2",
+            "Name": "UMM-Var",
+            "Version": "1.8.2"
+          }
+        }
+      ]
+    }
+  }
+}
+```
 
 #### Drafts
 
@@ -864,296 +1022,390 @@ The Draft type utilizes the `PreviewMetadata` union type, which means you can re
 
 ##### Example Queries
 
-###### Single
+###### Query for a single draft
 
-    query Draft($params: DraftInput) {
-      draft(params: $params) {
-        conceptId
-        conceptType
-        deleted
+```gql
+query Draft($params: DraftInput) {
+  draft(params: $params) {
+    conceptId
+    conceptType
+    deleted
+    name
+    nativeId
+    providerId
+    revisionDate
+    revisionId
+    ummMetadata
+    previewMetadata {
+      ... on Tool {
         name
-        nativeId
-        providerId
-        revisionDate
-        revisionId
-        ummMetadata
-        previewMetadata {
-          ... on Tool {
-            name
-            longName
-            collections {
-              count
-            }
-          }
+        longName
+        collections {
+          count
         }
       }
     }
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "params": {
-        "conceptId": "TD1000000001-EXAMPLE",
-        "conceptType": "Tool"
-      }
-    }
+```json
+{
+  "params": {
+    "conceptId": "TD1000000001-EXAMPLE",
+    "conceptType": "Tool"
+  }
+}
+```
 
-###### Multiple
+###### Query for multiple drafts
 
-    query Drafts($params: DraftsInput) {
-      drafts(params: $params) {
-        count
-        items {
-          conceptId
-          conceptType
-          deleted
+```gql
+query Drafts($params: DraftsInput) {
+  drafts(params: $params) {
+    count
+    items {
+      conceptId
+      conceptType
+      deleted
+      name
+      nativeId
+      providerId
+      revisionDate
+      revisionId
+      ummMetadata
+      previewMetadata {
+        ... on Tool {
           name
-          nativeId
-          providerId
-          revisionDate
-          revisionId
-          ummMetadata
-          previewMetadata {
-            ... on Tool {
-              name
-              longName
-              collections {
-                count
-              }
-            }
+          longName
+          collections {
+            count
           }
         }
       }
     }
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "params": {
-        "conceptType": "Tool"
-      }
-    }
+```json
+{
+  "params": {
+    "conceptType": "Tool"
+  }
+}
+```
 
 ###### Ingesting a draft
 
-    mutation IngestDraft(
-      $conceptType: DraftConceptType!
-      $metadata: JSON!
-      $nativeId: String!
-      $providerId: String!
-      $ummVersion: String!
-    ) {
-      ingestDraft(
-        conceptType: $conceptType
-        metadata: $metadata
-        nativeId: $nativeId
-        providerId: $providerId
-        ummVersion: $ummVersion
-      ) {
-        conceptId
-        revisionId
-        warnings
-        existingErrors
-      }
-    }
+```gql
+mutation IngestDraft(
+  $conceptType: DraftConceptType!
+  $metadata: JSON!
+  $nativeId: String!
+  $providerId: String!
+  $ummVersion: String!
+) {
+  ingestDraft(
+    conceptType: $conceptType
+    metadata: $metadata
+    nativeId: $nativeId
+    providerId: $providerId
+    ummVersion: $ummVersion
+  ) {
+    conceptId
+    revisionId
+    warnings
+    existingErrors
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "conceptType": "Tool",
-      "metadata": {
-        "Name": "Test Tool",
-        "MetadataSpecification": {
-          "URL": "https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0",
-          "Name": "UMM-T",
-          "Version": "1.2.0"
-        }
-      },
-      "nativeId": "sampleNativeId",
-      "providerId": "EXAMPLE",
-      "ummVersion": "1.0.0"
+```json
+{
+  "conceptType": "Tool",
+  "metadata": {
+    "Name": "Test Tool",
+    "MetadataSpecification": {
+      "URL": "https://cdn.earthdata.nasa.gov/umm/tool/v1.2.0",
+      "Name": "UMM-T",
+      "Version": "1.2.0"
     }
+  },
+  "nativeId": "sampleNativeId",
+  "providerId": "EXAMPLE",
+  "ummVersion": "1.0.0"
+}
+```
 
 ###### Deleting a draft
 
-    mutation DeleteDraft(
-      $conceptType: DraftConceptType!
-      $nativeId: String!
-      $providerId: String!
-    ) {
-      deleteDraft(
-        conceptType: $conceptType
-        nativeId: $nativeId
-        providerId: $providerId
-      ) {
-        conceptId
-        revisionId
-        warnings
-        existingErrors
-      }
-    }
+```gql
+mutation DeleteDraft(
+  $conceptType: DraftConceptType!
+  $nativeId: String!
+  $providerId: String!
+) {
+  deleteDraft(
+    conceptType: $conceptType
+    nativeId: $nativeId
+    providerId: $providerId
+  ) {
+    conceptId
+    revisionId
+    warnings
+    existingErrors
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "conceptType": "Tool",
-      "nativeId": "tool-3",
-      "providerId": "EXAMPLE"
-    }
+```json
+{
+  "conceptType": "Tool",
+  "nativeId": "tool-3",
+  "providerId": "EXAMPLE"
+}
+```
 
 ###### Publishing a draft
 
-    mutation PublishDraft(
-      $draftConceptId: String!
-      $nativeId: String!
-      $ummVersion: String!
-    ) {
-      publishDraft(
-        draftConceptId: $draftConceptId
-        nativeId: $nativeId
-        ummVersion: $ummVersion
-      ) {
-        conceptId
-        revisionId
-        warnings
-        existingErrors
-      }
-    }
+```gql
+mutation PublishDraft(
+  $draftConceptId: String!
+  $nativeId: String!
+  $ummVersion: String!
+) {
+  publishDraft(
+    draftConceptId: $draftConceptId
+    nativeId: $nativeId
+    ummVersion: $ummVersion
+  ) {
+    conceptId
+    revisionId
+    warnings
+    existingErrors
+  }
+}
+```
 
-variables:
+Variables:
 
-    {
-      "draftConceptId": "TD1000000001-EXAMPLE",
-      "nativeId": "tool-1",
-      "ummVersion": "1.2.0"
-    }
-
+```json
+{
+  "draftConceptId": "TD1000000001-EXAMPLE",
+  "nativeId": "tool-1",
+  "ummVersion": "1.2.0"
+}
+```
 
 #### Associations
 For all supported arguments and columns, see [the schema](src/types/association.graphql).
 
-The association supports associating a Tool, Variable, or Service record to a collection. 
-##### Example Query
+The association supports associating a Tool, Variable, or Service record to a collection.
+
+##### Association Query
 
 ##### Associating a Tool to a Collection
-    Mutation CreateAssociation(
-      $conceptId: String!
-      $collectionConceptIds: [JSON]!
-      $conceptType: ConceptType!
-      ){
-        createAssociation(
-          conceptId: $conceptId
-          collectionConceptIds: $collectionConceptIds
-          conceptType: $conceptType
-          ) {
-          associatedItem
-          toolAssociation
-        }
-      }
 
-variables:
+```gql
+Mutation CreateAssociation(
+  $conceptId: String!
+  $collectionConceptIds: [JSON]!
+  $conceptType: ConceptType!
+){
+  createAssociation(
+    conceptId: $conceptId
+    collectionConceptIds: $collectionConceptIds
+    conceptType: $conceptType
+    ) {
+    associatedItem
+    toolAssociation
+  }
+}
+```
 
+Variables:
+
+```json
+{
+  "conceptId": "T1000000001-EXAMPLE",
+  "conceptType": "Tool",
+  "collectionConceptIds": [
     {
-      "conceptId": "T1000000001-EXAMPLE",
-      "conceptType": "Tool",
-      "collectionConceptIds": [
-        {
-          "conceptId": "C1000000001-EXAMPLE"
-        }
-      ]
+      "conceptId": "C1000000001-EXAMPLE"
     }
+  ]
+}
+```
 
 ##### Associating a Variable to a Collection
-  Note for Variable association, nativeId and metadata are required params.
 
-    Mutation CreateAssociation(
-      $conceptId: String!
-      $collectionConceptIds: [JSON]!
-      $conceptType: ConceptType!
-      $nativeId: String
-      $metadata: JSON
-      ){
-        createAssociation(
-          conceptId: $conceptId
-          collectionConceptIds: $collectionConceptIds
-          conceptType: $conceptType
-          nativeId: $nativeId
-          metadata: $metadata
-          ) {
-          associatedItem
-          variableAssociation
-        }
-      }
+Note for Variable association, nativeId and metadata are required params.
 
-variables:
+```gql
+Mutation CreateAssociation(
+  $conceptId: String!
+  $collectionConceptIds: [JSON]!
+  $conceptType: ConceptType!
+  $nativeId: String
+  $metadata: JSON
+){
+  createAssociation(
+    conceptId: $conceptId
+    collectionConceptIds: $collectionConceptIds
+    conceptType: $conceptType
+    nativeId: $nativeId
+    metadata: $metadata
+    ) {
+    associatedItem
+    variableAssociation
+  }
+}
+```
 
+Variables:
+
+```json
+{
+  "conceptId": "V1000000001-EXAMPLE",
+  "conceptType": "Variable",
+  "collectionConceptIds": [
     {
-      "conceptId": "V1000000001-EXAMPLE",
-      "conceptType": "Variable",
-      "collectionConceptIds": [
-        {
-          "conceptId": "C1000000001-EXAMPLE"
-        }
-      ],
-      "nativeId": "Variable native id",
-      "metadata": {} 
+      "conceptId": "C1000000001-EXAMPLE"
     }
+  ],
+  "nativeId": "Variable native id",
+  "metadata": {}
+}
+```
 
 ##### Disassociation a Tool to a Collection (Delete)
-    Mutation DeleteAssociation(
-      $conceptId: String!
-      $collectionConceptIds: [JSON]!
-      $conceptType: ConceptType!
-      ){
-        deleteAssociation(
-          conceptId: $conceptId
-          collectionConceptIds: $collectionConceptIds
-          conceptType: $conceptType
-          ) {
-          associatedItem
-          toolAssociation
-        }
-      }
 
-variables:
+```
+Mutation DeleteAssociation(
+  $conceptId: String!
+  $collectionConceptIds: [JSON]!
+  $conceptType: ConceptType!
+){
+  deleteAssociation(
+    conceptId: $conceptId
+    collectionConceptIds: $collectionConceptIds
+    conceptType: $conceptType
+    ) {
+    associatedItem
+    toolAssociation
+  }
+}
+```
 
+Variables:
+
+```json
+{
+  "conceptId": "TL12000000-EXAMPLE",
+  "conceptType": "Tool",
+  "collectionConceptIds": [
     {
-      "conceptId": "TL12000000-EXAMPLE",
-      "conceptType": "Tool",
-      "collectionConceptIds": [
-        {
-          "conceptId": "C1000000001-EXAMPLE"
-        }
-      ]
+      "conceptId": "C1000000001-EXAMPLE"
     }
+  ]
+}
+```
 
 #### ACLs
 
 For all supported arguments and columns, see [the schema](src/types/acl.graphql).
 
-##### Example Queries
+##### ACL Queries
 
-###### Single
+###### Query for a single ACL
 
-    query Acl($conceptId: String) {
-      acl(conceptId: $conceptId) {
-        name
-        groupPermissions
+```gql
+query Acl($conceptId: String) {
+  acl(conceptId: $conceptId) {
+    name
+    groupPermissions
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "conceptId": "ACL1000000001-EXAMPLE"
+}
+```
+
+##### Example ACL Query Response
+
+```json
+{
+  "data": {
+    "acl": {
+      "groupPermissions": [
+        {
+          "group_id": "ACL1000000001-EXAMPLE",
+          "permissions": [
+            "read"
+          ]
+        },
+        {
+          "group_id": "ACL1000000002-EXAMPLE",
+          "permissions": [
+            "read"
+          ]
+        }
+      ],
+      "providerIdentity": {
+        "target": "PROVIDER_CONTEXT",
+        "provider_id": "EXAMPLE"
       }
     }
-    
-variables:
+  }
+}
+```
 
-    {
-      "conceptId": "ACL1000000001-EXAMPLE"
+###### Query for multiple ACLs
+
+```gql
+query Acls($params: AclsInput) {
+  acls(params: $params) {
+    items {
+      systemIdentity
+      providerIdentity
     }
-    
+  }
+}
+```
 
-##### Example Response
+Variables:
 
-    {
-      "data": {
-        "acl": {
+```json
+{
+  "params": {
+    "permittedUser": "typical",
+    "target": "PROVIDER_CONTEXT"
+  }
+}
+```
+
+##### Example ACLs Query Response
+
+```json
+{
+  "data": {
+    "acls": {
+      "items": [
+        {
           "groupPermissions": [
             {
               "group_id": "ACL1000000001-EXAMPLE",
@@ -1173,191 +1425,164 @@ variables:
             "provider_id": "EXAMPLE"
           }
         }
-      }
+      ]
     }
+  }
+}
+```
 
-###### Multiple
-
-    query Acls($params: AclsInput) {
-      acls(params: $params) {
-        items {
-          systemIdentity
-          providerIdentity
-        }
-      }
-    }
-
-variables:
-
-    {
-      "params": {
-        "permittedUser": "typical",
-        "target": "PROVIDER_CONTEXT"
-      }
-    }
-
-##### Example Response
-
-    {
-      "data": {
-        "acls": {
-          "items": [
-            {
-              "groupPermissions": [
-                {
-                  "group_id": "ACL1000000001-EXAMPLE",
-                  "permissions": [
-                    "read"
-                  ]
-                },
-                {
-                  "group_id": "ACL1000000002-EXAMPLE",
-                  "permissions": [
-                    "read"
-                  ]
-                }
-              ],
-              "providerIdentity": {
-                "target": "PROVIDER_CONTEXT",
-                "provider_id": "EXAMPLE"
-              }
-            }
-          ]
-        }
-      }
-    }
-
-##### Mutations
+##### ACL Mutations
 
 ###### Creating an ACL
 
-    mutation CreateAcl(
-    	$groupPermissions: JSON
-        $catalogItemIdentity: JSON
-      ) {
-      createAcl(
-        groupPermissions: $groupPermissions
-        catalogItemIdentity: $catalogItemIdentity
-      ) {
-        revisionId
-        conceptId
-      }
-    }
+```gql
+mutation CreateAcl(
+  $groupPermissions: JSON
+    $catalogItemIdentity: JSON
+  ) {
+  createAcl(
+    groupPermissions: $groupPermissions
+    catalogItemIdentity: $catalogItemIdentity
+  ) {
+    revisionId
+    conceptId
+  }
+}
+```
 
 ###### Updating an ACL
 
-    mutation UpdateAcl(
-    	$conceptId: String!
-        $catalogItemIdentity: JSON
-        $groupPermissions: JSON
-    ) {
-      updateAcl(
-        conceptId: $conceptId
-        catalogItemIdentity: $catalogItemIdentity
-        groupPermissions: $groupPermissions
-      ) {
-	    revisionId
-	    conceptId
-      }
-    }
-    
-variables:
+```gql
+mutation UpdateAcl(
+  $conceptId: String!
+    $catalogItemIdentity: JSON
+    $groupPermissions: JSON
+) {
+  updateAcl(
+    conceptId: $conceptId
+    catalogItemIdentity: $catalogItemIdentity
+    groupPermissions: $groupPermissions
+  ) {
+  revisionId
+  conceptId
+  }
+}
+```
 
-    {
-      "conceptId": "ACL1000000001-EXAMPLE",
-      "catalogItemIdentity": {
-            "name": "ACL Example Renamed",
-            "provider_id": "EXAMPLE",
-            "granule_applicable": true
-        },
-        "groupPermissions": [{
-            "user_type": "guest",
-            "permissions": ["read"]
-        }
-      ]
+Variables:
+
+```json
+{
+  "conceptId": "ACL1000000001-EXAMPLE",
+  "catalogItemIdentity": {
+        "name": "ACL Example Renamed",
+        "provider_id": "EXAMPLE",
+        "granule_applicable": true
+    },
+    "groupPermissions": [{
+        "user_type": "guest",
+        "permissions": ["read"]
     }
+  ]
+}
+```
 
 ###### Deleting an ACL
 
-    mutation DeleteAcl($conceptId: String!) {
-      deleteAcl(conceptId: $conceptId) {
-        conceptId
-        revisionId
-      }
-    }
-    
-variables:
+```gql
+mutation DeleteAcl($conceptId: String!) {
+  deleteAcl(conceptId: $conceptId) {
+    conceptId
+    revisionId
+  }
+}
+```
 
-    {
-      "conceptId": "ACL1000000001-EXAMPLE"
-    }
+Variables:
+
+```json
+{
+  "conceptId": "ACL1000000001-EXAMPLE"
+}
+```
 
 #### Permissions
 
 ###### Searching by Concept ID
 
-    query GetPermissions($params: PermissionsInput) {
-      permissions(params: $params) {
-        count
-        items {
-          conceptId
-          permissions
-        }
-      }
+```gql
+query GetPermissions($params: PermissionsInput) {
+  permissions(params: $params) {
+    count
+    items {
+      conceptId
+      permissions
     }
-    
-variables:
+  }
+}
+```
 
-    {
-      "params": {
-        "userType": "registered",
-        "conceptId": "C1000000001-EXAMPLE"
-      }
-    }
-    
+Variables:
+
+```json
+{
+  "params": {
+    "userType": "registered",
+    "conceptId": "C1000000001-EXAMPLE"
+  }
+}
+```
+
 ###### Searching by System Object
 
-    query GetPermissions($params: PermissionsInput) {
-      permissions(params: $params) {
-        count
-        items {
-          systemObject
-          permissions
-        }
-      }
+```gql
+query GetPermissions($params: PermissionsInput) {
+  permissions(params: $params) {
+    count
+    items {
+      systemObject
+      permissions
     }
-    
-variables:
+  }
+}
+```
 
-    {
-      "params": {
-        "userType": "registered",
-        "systemObject": "USER"
-      }
-    }
+Variables:
+
+```json
+{
+  "params": {
+    "userType": "registered",
+    "systemObject": "USER"
+  }
+}
+```
 
 ###### Searching by Target & Provider
 
-    query GetPermissions($params: PermissionsInput) {
-      permissions(params: $params) {
-        count
-        items {
-          target
-          permissions
-        }
-      }
+```gql
+query GetPermissions($params: PermissionsInput) {
+  permissions(params: $params) {
+    count
+    items {
+      target
+      permissions
     }
-  
-variables:
-    
-    {
-      "params": {
-        "userType": "registered",
-        "target": "GROUP",
-        "provider": "EXAMPLE",
-      }
-    }
-    
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "params": {
+    "userType": "registered",
+    "target": "GROUP",
+    "provider": "EXAMPLE",
+  }
+}
+```
 
 
 #### Local graph database:

--- a/serverless-configs/env.yml
+++ b/serverless-configs/env.yml
@@ -28,14 +28,15 @@ default_env: &default_env
     # Pinned UMM versions
     ummCollectionVersion: '1.17.2'
     ummGranuleVersion: '1.6.5'
+    ummOrderOptionVersion: '1.0.0'
     ummServiceVersion: '1.5.2'
     ummSubscriptionVersion: '1.1'
     ummToolVersion: '1.2.0'
     ummVariableVersion: '1.9.0'
-    
+
     stage: ${self:provider.stage}
 
-development: 
+development:
   <<: *default_env
 
 sit:

--- a/src/cmr/concepts/__tests__/acl.test.js
+++ b/src/cmr/concepts/__tests__/acl.test.js
@@ -76,7 +76,7 @@ describe('Acl concept', () => {
 
       const response = await acl.response
 
-      expect(await response[0].config.url).toEqual('http://example.com/access-control/acls?permitted_user=test&include_full_acl=true')
+      expect(await response[0].config.url).toEqual('http://example.com/access-control/acls?include_full_acl=true&permitted_user=test')
     })
   })
 })

--- a/src/cmr/concepts/__tests__/orderOption.test.js
+++ b/src/cmr/concepts/__tests__/orderOption.test.js
@@ -1,0 +1,308 @@
+import nock from 'nock'
+
+import { v4 } from 'uuid'
+import orderOptionKeyMap from '../../../utils/umm/orderOptionKeyMap.json'
+import { parseRequestedFields } from '../../../utils/parseRequestedFields'
+import OrderOption from '../orderOption'
+
+process.env.cmrRootUrl = 'http://example.com'
+process.env.ummOrderOptionVersion = '1.0.0'
+
+vi.mock('uuid', () => ({
+  v4: vi.fn()
+}))
+
+describe('OrderOption concept', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.resetAllMocks()
+  })
+
+  describe('when fetching without params defined', () => {
+    test('requests the json with the default params', async () => {
+      nock('http://example.com')
+        .post('/search/order-options.json')
+        .reply(200, {
+          hits: 1,
+          took: 100,
+          items: [
+            {
+              concept_id: 'OO12341234_TEST',
+              revision_id: 1,
+              provider_id: 'TEST',
+              native_id: 'test-native-id',
+              name: 'This is a test name'
+            }
+          ]
+        })
+
+      const parsedInfo = {
+        name: 'order-options',
+        alias: 'order-options',
+        args: {},
+        fieldsByTypeName: {
+          OrderOptionList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
+
+      const orderOption = new OrderOption({}, requestInfo)
+
+      await orderOption.fetch()
+
+      const response = await orderOption.response
+
+      expect(await response[0].config.url).toEqual('http://example.com/search/order-options.json')
+      expect(await response[0].config.data).toEqual('')
+    })
+  })
+
+  describe('when fetching with params defined', () => {
+    test('requests the json with the params', async () => {
+      nock('http://example.com')
+        .post('/search/order-options.json')
+        .reply(200, {
+          hits: 1,
+          took: 100,
+          items: [
+            {
+              concept_id: 'OO12341234_TEST',
+              revision_id: 1,
+              provider_id: 'TEST',
+              native_id: 'test-native-id',
+              name: 'This is a test name'
+            }
+          ]
+        })
+
+      const parsedInfo = {
+        name: 'order-options',
+        alias: 'order-options',
+        args: {
+          params: {
+            conceptId: 'OO12341234_TEST'
+          }
+        },
+        fieldsByTypeName: {
+          OrderOptionList: {
+            count: {},
+            items: {}
+          }
+        }
+      }
+
+      const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
+
+      const orderOption = new OrderOption({}, requestInfo)
+
+      await orderOption.fetch({
+        params: { conceptId: 'OO12341234_TEST' }
+      })
+
+      const response = await orderOption.response
+      console.log('🚀 ~ test ~ response:', response)
+
+      expect(await response[0].config.url).toEqual('http://example.com/search/order-options.json')
+      expect(await response[0].config.data).toEqual('concept_id=OO12341234_TEST')
+    })
+  })
+
+  test('sets the metadataSpecification correctly', () => {
+    const orderOption = new OrderOption({}, {}, {
+      conceptId: 'OO12341234_TEST'
+    })
+
+    expect(orderOption.metadataSpecification).toEqual({
+      Name: 'Order Option',
+      URL: 'https://cdn.earthdata.nasa.gov/generics/order-option/v1.0.0',
+      Version: '1.0.0'
+    })
+  })
+
+  describe('when calling ingest', () => {
+    test('sends a request to the correct endpoint', async () => {
+      nock('http://example.com')
+        .put('/ingest/providers/TEST/order-options/test-native-id')
+        .reply(200, {
+          'concept-id': 'OO1200481598-MMT_1',
+          'revision-id': 1
+        })
+
+      const orderOption = new OrderOption({}, {}, {
+        conceptId: 'OO12341234_TEST'
+      })
+
+      const params = {
+        name: 'Test name',
+        description: 'Test description',
+        nativeId: 'test-native-id',
+        providerId: 'TEST',
+        form: 'This is a form'
+      }
+
+      const requestedKeys = ['conceptId', 'revisionId']
+
+      await orderOption.ingest(params, requestedKeys, {})
+
+      const response = await orderOption.response
+
+      expect(await response.config.url).toEqual('http://example.com/ingest/providers/TEST/order-options/test-native-id')
+    })
+
+    test('sends a request with the correct data', async () => {
+      nock('http://example.com')
+        .put('/ingest/providers/TEST/order-options/test-native-id')
+        .reply(200, {
+          'concept-id': 'OO1200481598-MMT_1',
+          'revision-id': 1
+        })
+
+      const orderOption = new OrderOption({}, {}, {
+        conceptId: 'OO12341234_TEST'
+      })
+
+      const params = {
+        name: 'Test name',
+        description: 'Test description',
+        nativeId: 'test-native-id',
+        providerId: 'TEST',
+        form: 'This is a form'
+      }
+
+      const requestedKeys = ['conceptId', 'revisionId']
+
+      await orderOption.ingest(params, requestedKeys, {})
+
+      const response = await orderOption.response
+
+      const responseData = {
+        Name: 'Test name',
+        Description: 'Test description',
+        Form: 'This is a form',
+        MetadataSpecification: {
+          URL: 'https://cdn.earthdata.nasa.gov/generics/order-option/v1.0.0',
+          Name: 'Order Option',
+          Version: '1.0.0'
+        }
+      }
+
+      expect(await response.config.data).toEqual(JSON.stringify(responseData))
+    })
+
+    describe('when a native id is not provided', () => {
+      test('generates a native id for the request', async () => {
+        v4.mockReturnValue('generated-native-id')
+
+        nock('http://example.com')
+          .put('/ingest/providers/TEST/order-options/generated-native-id')
+          .reply(200, {
+            'concept-id': 'OO1200481598-MMT_1',
+            'revision-id': 1
+          })
+
+        const orderOption = new OrderOption({}, {}, {
+          conceptId: 'OO12341234_TEST'
+        })
+
+        const params = {
+          name: 'Test name',
+          description: 'Test description',
+          providerId: 'TEST',
+          form: 'This is a form'
+        }
+
+        const requestedKeys = ['conceptId', 'revisionId']
+
+        await orderOption.ingest(params, requestedKeys, {})
+
+        const response = await orderOption.response
+
+        const responseData = {
+          Name: 'Test name',
+          Description: 'Test description',
+          Form: 'This is a form',
+          MetadataSpecification: {
+            URL: 'https://cdn.earthdata.nasa.gov/generics/order-option/v1.0.0',
+            Name: 'Order Option',
+            Version: '1.0.0'
+          }
+        }
+
+        expect(await response.config.data).toEqual(JSON.stringify(responseData))
+      })
+    })
+  })
+
+  describe('when parsing the json response', () => {
+    test('returns the items', () => {
+      const orderOption = new OrderOption({}, {}, {
+        conceptId: 'OO12341234_TEST'
+      })
+
+      const jsonBody = {
+        data: {
+          items: [
+            {
+              test: 'test'
+            }
+          ]
+        }
+      }
+
+      const items = orderOption.parseJsonBody(jsonBody)
+
+      expect(items).toEqual([{ test: 'test' }])
+    })
+  })
+
+  describe('when fetching umm json', () => {
+    test('returns the request', async () => {
+      nock('http://example.com')
+        .post('/search/order-options.umm_json')
+        .reply(200, {
+          hits: 1,
+          took: 100,
+          items: [
+            {
+              meta: {
+                'revision-id': 1,
+                deleted: false,
+                'provider-id': 'TEST',
+                'user-id': 'test',
+                'native-id': 'test-native-id',
+                'concept-id': 'OO12341234_TEST',
+                'revision-date': '2024-04-12T17:07:15.534Z',
+                'concept-type': 'order-option'
+              },
+              umm: {
+                Description: 'This is a test description',
+                Form: 'This is a test form',
+                Name: 'This is a test name',
+                MetadataSpecification: {
+                  URL: 'https://cdn.earthdata.nasa.gov/generics/order-option/v1.0.0',
+                  Name: 'Order Option',
+                  Version: '1.0.0'
+                }
+              }
+            }
+          ]
+        })
+
+      const orderOption = new OrderOption({}, {}, {
+        conceptId: 'OO12341234_TEST'
+      })
+
+      const searchParams = { conceptId: 'OO12341234-TEST' }
+      const ummKeys = ['conceptId', 'description', 'nativeId']
+
+      const ummResponse = await orderOption.fetchUmm(searchParams, ummKeys, {})
+
+      expect(ummResponse.config.url).toEqual('http://example.com/search/order-options.umm_json')
+      expect(ummResponse.config.data).toEqual('concept_id=OO12341234-TEST')
+    })
+  })
+})

--- a/src/cmr/concepts/__tests__/orderOption.test.js
+++ b/src/cmr/concepts/__tests__/orderOption.test.js
@@ -104,7 +104,6 @@ describe('OrderOption concept', () => {
       })
 
       const response = await orderOption.response
-      console.log('🚀 ~ test ~ response:', response)
 
       expect(await response[0].config.url).toEqual('http://example.com/search/order-options.json')
       expect(await response[0].config.data).toEqual('concept_id=OO12341234_TEST')

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -47,7 +47,7 @@ export default class Concept {
       collectionConceptIds: 'collectionConceptId',
       conceptIds: 'conceptId',
       dataCenters: 'dataCenter',
-      providers: 'provider',
+      providerIds: 'providerId',
       shortNames: 'shortName'
     }
   }
@@ -266,17 +266,18 @@ export default class Concept {
    */
   getPermittedJsonSearchParams() {
     return [
-      'concept_id',
-      'offset',
-      'page_size',
-      'sort_key',
-      'permitted_user',
-      'include_full_acl',
       'all_revisions',
+      'concept_id',
+      'include_full_acl',
+      'offset',
+      'originator_id',
       'page_num',
-      'target',
+      'page_size',
+      'permitted_user',
+      'provider_id',
+      'sort_key',
       'tag_key',
-      'originator_id'
+      'target'
     ]
   }
 
@@ -285,10 +286,11 @@ export default class Concept {
    */
   getPermittedUmmSearchParams() {
     return [
+      'all_revisions',
       'concept_id',
       'offset',
       'page_size',
-      'all_revisions',
+      'provider_id',
       'sort_key'
     ]
   }
@@ -299,14 +301,15 @@ export default class Concept {
   getNonIndexedKeys() {
     return [
       'concept_id',
-      'offset',
-      'page_size',
-      'sort_key',
-      'permitted_user',
       'include_full_acl',
+      'offset',
       'page_num',
-      'target',
-      'tag_key'
+      'page_size',
+      'permitted_user',
+      'provider_id',
+      'sort_key',
+      'tag_key',
+      'target'
     ]
   }
 

--- a/src/datasources/__tests__/orderOption.test.js
+++ b/src/datasources/__tests__/orderOption.test.js
@@ -1,6 +1,6 @@
 import nock from 'nock'
 
-import orderOptionDatasource from '../orderOption'
+import { fetchOrderOption } from '../orderOption'
 
 let requestInfo
 
@@ -47,86 +47,49 @@ describe('Order Option', () => {
     process.env = OLD_ENV
   })
 
-  describe('cursor', () => {
-    beforeEach(() => {
-    // Overwrite default requestInfo
-      requestInfo = {
-        name: 'orderOptions',
-        alias: 'orderOptions',
-        args: {},
-        fieldsByTypeName: {
-          OrderOptionList: {
-            cursor: {
-              name: 'cursor',
-              alias: 'cursor',
-              args: {},
-              fieldsByTypeName: {}
-            },
-            items: {
-              name: 'items',
-              alias: 'items',
-              args: {},
-              fieldsByTypeName: {
-                OrderOption: {
-                  conceptId: {
-                    name: 'conceptId',
-                    alias: 'conceptId',
-                    args: {},
-                    fieldsByTypeName: {}
-                  },
-                  description: {
-                    name: 'description',
-                    alias: 'description',
-                    args: {},
-                    fieldsByTypeName: {}
+  describe('when fetching order options', () => {
+    describe('cursor', () => {
+      beforeEach(() => {
+      // Overwrite default requestInfo
+        requestInfo = {
+          name: 'orderOptions',
+          alias: 'orderOptions',
+          args: {},
+          fieldsByTypeName: {
+            OrderOptionList: {
+              cursor: {
+                name: 'cursor',
+                alias: 'cursor',
+                args: {},
+                fieldsByTypeName: {}
+              },
+              items: {
+                name: 'items',
+                alias: 'items',
+                args: {},
+                fieldsByTypeName: {
+                  OrderOption: {
+                    conceptId: {
+                      name: 'conceptId',
+                      alias: 'conceptId',
+                      args: {},
+                      fieldsByTypeName: {}
+                    },
+                    description: {
+                      name: 'description',
+                      alias: 'description',
+                      args: {},
+                      fieldsByTypeName: {}
+                    }
                   }
                 }
               }
             }
           }
         }
-      }
-    })
-
-    test('returns a cursor', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Hits': 84,
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678',
-          'CMR-Search-After': '["xyz", 789, 999]'
-        })
-        .post(/order-options\.umm_json/)
-        .reply(200, {
-          items: [{
-            meta: {
-              'concept-id': 'OO100000-EDSC'
-            },
-            umm: {
-              Description: 'Parturient Dolor Cras Aenean Dapibus'
-            }
-          }]
-        })
-
-      const response = await orderOptionDatasource({}, {
-        headers: {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        }
-      }, requestInfo)
-
-      expect(response).toEqual({
-        count: 84,
-        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
-        items: [{
-          conceptId: 'OO100000-EDSC',
-          description: 'Parturient Dolor Cras Aenean Dapibus'
-        }]
       })
-    })
 
-    describe('when a cursor is requested', () => {
-      test('requests a cursor', async () => {
+      test('returns a cursor', async () => {
         nock(/example-cmr/)
           .defaultReplyHeaders({
             'CMR-Hits': 84,
@@ -146,7 +109,7 @@ describe('Order Option', () => {
             }]
           })
 
-        const response = await orderOptionDatasource({}, {
+        const response = await fetchOrderOption({}, {
           headers: {
             'Client-Id': 'eed-test-graphql',
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
@@ -162,166 +125,205 @@ describe('Order Option', () => {
           }]
         })
       })
-    })
-  })
 
-  describe('without params', () => {
-    test('returns the parsed orderOption results', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Hits': 84,
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      describe('when a cursor is requested', () => {
+        test('requests a cursor', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 84,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678',
+              'CMR-Search-After': '["xyz", 789, 999]'
+            })
+            .post(/order-options\.umm_json/)
+            .reply(200, {
+              items: [{
+                meta: {
+                  'concept-id': 'OO100000-EDSC'
+                },
+                umm: {
+                  Description: 'Parturient Dolor Cras Aenean Dapibus'
+                }
+              }]
+            })
+
+          const response = await fetchOrderOption({}, {
+            headers: {
+              'Client-Id': 'eed-test-graphql',
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            }
+          }, requestInfo)
+
+          expect(response).toEqual({
+            count: 84,
+            cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
+            items: [{
+              conceptId: 'OO100000-EDSC',
+              description: 'Parturient Dolor Cras Aenean Dapibus'
+            }]
+          })
         })
-        .post(/order-options\.json/)
-        .reply(200, {
-          items: [{
-            concept_id: 'OO100000-EDSC'
-          }]
-        })
-
-      const response = await orderOptionDatasource({}, {
-        headers: {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        }
-      }, requestInfo)
-
-      expect(response).toEqual({
-        count: 84,
-        cursor: null,
-        items: [{
-          conceptId: 'OO100000-EDSC'
-        }]
       })
     })
-  })
 
-  describe('with params', () => {
-    test('returns the parsed orderOption results', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Hits': 84,
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/order-options\.json/, 'concept_id=OO100000-EDSC')
-        .reply(200, {
+    describe('without params', () => {
+      test('returns the parsed orderOption results', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/order-options\.json/)
+          .reply(200, {
+            items: [{
+              concept_id: 'OO100000-EDSC'
+            }]
+          })
+
+        const response = await fetchOrderOption({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: null,
           items: [{
-            concept_id: 'OO100000-EDSC'
+            conceptId: 'OO100000-EDSC'
           }]
         })
-
-      const response = await orderOptionDatasource({
-        params: {
-          concept_id: 'OO100000-EDSC'
-        }
-      }, {
-        headers: {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        }
-      }, requestInfo)
-
-      expect(response).toEqual({
-        count: 84,
-        cursor: null,
-        items: [{
-          conceptId: 'OO100000-EDSC'
-        }]
       })
     })
-  })
 
-  describe('with only umm keys', () => {
-    beforeEach(() => {
-      // Overwrite default requestInfo
-      requestInfo = {
-        name: 'orderOptions',
-        alias: 'orderOptions',
-        args: {},
-        fieldsByTypeName: {
-          OrderOptionList: {
-            items: {
-              name: 'items',
-              alias: 'items',
-              args: {},
-              fieldsByTypeName: {
-                OrderOption: {
-                  description: {
-                    name: 'description',
-                    alias: 'description',
-                    args: {},
-                    fieldsByTypeName: {}
+    describe('with params', () => {
+      test('returns the parsed orderOption results', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/order-options\.json/, 'concept_id=OO100000-EDSC')
+          .reply(200, {
+            items: [{
+              concept_id: 'OO100000-EDSC'
+            }]
+          })
+
+        const response = await fetchOrderOption({
+          params: {
+            concept_id: 'OO100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: null,
+          items: [{
+            conceptId: 'OO100000-EDSC'
+          }]
+        })
+      })
+    })
+
+    describe('with only umm keys', () => {
+      beforeEach(() => {
+        // Overwrite default requestInfo
+        requestInfo = {
+          name: 'orderOptions',
+          alias: 'orderOptions',
+          args: {},
+          fieldsByTypeName: {
+            OrderOptionList: {
+              items: {
+                name: 'items',
+                alias: 'items',
+                args: {},
+                fieldsByTypeName: {
+                  OrderOption: {
+                    description: {
+                      name: 'description',
+                      alias: 'description',
+                      args: {},
+                      fieldsByTypeName: {}
+                    }
                   }
                 }
               }
             }
           }
         }
-      }
-    })
+      })
 
-    test('returns the parsed orderOption results', async () => {
-      nock(/example-cmr/)
-        .defaultReplyHeaders({
-          'CMR-Hits': 84,
-          'CMR-Took': 7,
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        })
-        .post(/order-options\.umm_json/)
-        .reply(200, {
+      test('returns the parsed orderOption results', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .post(/order-options\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'OO100000-EDSC'
+              },
+              umm: {
+                Description: 'Parturient Dolor Cras Aenean Dapibus'
+              }
+            }]
+          })
+
+        const response = await fetchOrderOption({
+          params: {
+            concept_id: 'OO100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: null,
           items: [{
-            meta: {
-              'concept-id': 'OO100000-EDSC'
-            },
-            umm: {
-              Description: 'Parturient Dolor Cras Aenean Dapibus'
-            }
+            description: 'Parturient Dolor Cras Aenean Dapibus'
           }]
         })
-
-      const response = await orderOptionDatasource({
-        params: {
-          concept_id: 'OO100000-EDSC'
-        }
-      }, {
-        headers: {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        }
-      }, requestInfo)
-
-      expect(response).toEqual({
-        count: 84,
-        cursor: null,
-        items: [{
-          description: 'Parturient Dolor Cras Aenean Dapibus'
-        }]
       })
     })
-  })
 
-  test('Catches errors received from queryCmr', async () => {
-    nock(/example-cmr/)
-      .post(/order-options/)
-      .reply(500, {
-        errors: ['HTTP Error']
-      }, {
-        'cmr-request-id': 'abcd-1234-efgh-5678'
-      })
+    test('Catches errors received from queryCmr', async () => {
+      nock(/example-cmr/)
+        .post(/order-options/)
+        .reply(500, {
+          errors: ['HTTP Error']
+        }, {
+          'cmr-request-id': 'abcd-1234-efgh-5678'
+        })
 
-    await expect(
-      orderOptionDatasource({
-        params: {
-          conceptId: 'OO100000-EDSC'
-        }
-      }, {
-        headers: {
-          'Client-Id': 'eed-test-graphql',
-          'CMR-Request-Id': 'abcd-1234-efgh-5678'
-        }
-      }, requestInfo)
-    ).rejects.toThrow(Error)
+      await expect(
+        fetchOrderOption({
+          params: {
+            conceptId: 'OO100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+      ).rejects.toThrow(Error)
+    })
   })
 })

--- a/src/datasources/orderOption.js
+++ b/src/datasources/orderOption.js
@@ -4,7 +4,7 @@ import orderOptionKeyMap from '../utils/umm/orderOptionKeyMap.json'
 
 import OrderOption from '../cmr/concepts/orderOption'
 
-export default async (params, context, parsedInfo) => {
+export const fetchOrderOption = async (params, context, parsedInfo) => {
   // This passes orderOption and will transform to the OrderOption graphql type
   const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
 
@@ -20,4 +20,44 @@ export default async (params, context, parsedInfo) => {
 
   // Return a formatted JSON response
   return orderOption.getFormattedResponse()
+}
+
+export const ingestOrderOption = async (args, context, parsedInfo) => {
+  console.log('🚀 ~ ingestOrderOption ~ args:', args)
+  const { headers } = context
+  const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const orderOption = new OrderOption(headers, requestInfo, args)
+  // Query CMR
+  orderOption.ingest(args, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await orderOption.parseIngest(requestInfo)
+
+  // Return a formatted JSON response
+  return orderOption.getFormattedIngestResponse()
+}
+
+export const deleteOrderOption = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const orderOption = new OrderOption(headers, requestInfo, args)
+
+  // Query CMR
+  orderOption.delete(args, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await orderOption.parseDelete(requestInfo)
+
+  // Return a formatted JSON response
+  return orderOption.getFormattedDeleteResponse()
 }

--- a/src/datasources/orderOption.js
+++ b/src/datasources/orderOption.js
@@ -23,7 +23,6 @@ export const fetchOrderOption = async (params, context, parsedInfo) => {
 }
 
 export const ingestOrderOption = async (args, context, parsedInfo) => {
-  console.log('🚀 ~ ingestOrderOption ~ args:', args)
   const { headers } = context
   const requestInfo = parseRequestedFields(parsedInfo, orderOptionKeyMap, 'orderOption')
   const {

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -31,7 +31,6 @@ import graphDbDuplicateCollectionsSource from '../datasources/graphDbDuplicateCo
 import graphDbSource from '../datasources/graphDb'
 import gridSource from '../datasources/grid'
 import maxItemsPerOrderSource from '../datasources/maxItemsPerOrder'
-import orderOptionSource from '../datasources/orderOption'
 import permissionSource from '../datasources/permission'
 import providerSource from '../datasources/provider'
 import serviceDraftSource from '../datasources/serviceDraft'
@@ -68,6 +67,12 @@ import {
   ingestDraft as draftSourceIngest,
   publishDraft as draftSourcePublish
 } from '../datasources/draft'
+
+import {
+  deleteOrderOption as orderOptionSourceDelete,
+  fetchOrderOption as orderOptionSourceFetch,
+  ingestOrderOption as orderOptionSourceIngest
+} from '../datasources/orderOption'
 
 import { downcaseKeys } from '../utils/downcaseKeys'
 import { verifyEDLJwt } from '../utils/verifyEDLJwt'
@@ -189,7 +194,9 @@ export default startServerAndCreateLambdaHandler(
           graphDbSource,
           gridSource,
           maxItemsPerOrderSource,
-          orderOptionSource,
+          orderOptionSourceDelete,
+          orderOptionSourceFetch,
+          orderOptionSourceIngest,
           permissionSource,
           providerSource,
           serviceDraftSource,

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -23,7 +23,6 @@ import graphDbDuplicateCollectionsSource from '../../../datasources/graphDbDupli
 import graphDbSource from '../../../datasources/graphDb'
 import gridSource from '../../../datasources/grid'
 import maxItemsPerOrderSource from '../../../datasources/maxItemsPerOrder'
-import orderOptionSource from '../../../datasources/orderOption'
 import permissionSource from '../../../datasources/permission'
 import providerSource from '../../../datasources/provider'
 import serviceDraftSource from '../../../datasources/serviceDraft'
@@ -60,6 +59,12 @@ import {
   fetchCollections as collectionSourceFetch
 } from '../../../datasources/collection'
 
+import {
+  deleteOrderOption as orderOptionSourceDelete,
+  fetchOrderOption as orderOptionSourceFetch,
+  ingestOrderOption as orderOptionSourceIngest
+} from '../../../datasources/orderOption'
+
 export const server = new ApolloServer({
   typeDefs,
   resolvers
@@ -88,7 +93,9 @@ export const buildContextValue = (extraContext) => ({
     graphDbSource,
     gridSource,
     maxItemsPerOrderSource,
-    orderOptionSource,
+    orderOptionSourceDelete,
+    orderOptionSourceFetch,
+    orderOptionSourceIngest,
     permissionSource,
     providerSource,
     serviceDraftSource,

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -70,8 +70,6 @@ describe('OrderOption', () => {
       }, {
         contextValue
       })
-      console.log('🚀 ~ test.only ~ response:', response)
-
       const { data } = response.body.singleResult
 
       expect(data).toEqual({
@@ -240,8 +238,7 @@ describe('OrderOption', () => {
             contextValue
           })
 
-          const { data, errors } = response.body.singleResult
-          console.log('🚀 ~ test.only ~ errors:', errors)
+          const { data } = response.body.singleResult
 
           expect(data).toEqual({
             createOrderOption: {

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -210,7 +210,7 @@ describe('OrderOption', () => {
 
     describe('Mutation', () => {
       describe('createOrderOption', () => {
-        test('calls the ingest endpoint to create an order option', async () => {
+        test.only('calls the ingest endpoint to create an order option', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
@@ -240,7 +240,8 @@ describe('OrderOption', () => {
             contextValue
           })
 
-          const { data } = response.body.singleResult
+          const { data, errors } = response.body.singleResult
+          console.log('🚀 ~ test.only ~ errors:', errors)
 
           expect(data).toEqual({
             createOrderOption: {

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -41,7 +41,6 @@ describe('OrderOption', () => {
               }
             },
             umm: {
-              Id: '0B4E0AF0BB4E0AF0BB4R0AF00',
               Name: 'With Browse',
               Description: 'Parturient Dolor Cras Aenean Dapibus',
               Form: "<form xmlns=\"http://echo.nasa.gov/v9/echoforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <model> <instance> <ecs:options xmlns:ecs=\"http://ecs.nasa.gov/options\"> <!-- ECS distribution options example --> <ecs:distribution> <ecs:mediatype> <ecs:value>FtpPull</ecs:value> </ecs:mediatype> <ecs:mediaformat> <ecs:ftppull-format> <ecs:value>FILEFORMAT</ecs:value> </ecs:ftppull-format> </ecs:mediaformat> </ecs:distribution> <ecs:do-ancillaryprocessing>true</ecs:do-ancillaryprocessing> <ecs:ancillary> <ecs:orderBrowse/> </ecs:ancillary> </ecs:options> </instance> </model> <ui> <group id=\"mediaOptionsGroup\" label=\"Media Options\" ref=\"ecs:distribution\"> <output id=\"MediaTypeOutput\" label=\"Media Type:\" relevant=\"ecs:mediatype/ecs:value ='FtpPull'\" type=\"xsd:string\" value=\"'HTTPS Pull'\"/> <output id=\"FtpPullMediaFormatOutput\" label=\"Media Format:\" relevant=\"ecs:mediaformat/ecs:ftppull-format/ecs:value='FILEFORMAT'\" type=\"xsd:string\" value=\"'File'\"/> </group> <group id=\"checkancillaryoptions\" label=\"Additional file options:\" ref=\"ecs:ancillary\" relevant=\"//ecs:do-ancillaryprocessing = 'true'\"> <input label=\"Include associated Browse file in order\" ref=\"ecs:orderBrowse\" type=\"xsd:boolean\"/> </group> </ui> </form>",
@@ -61,7 +60,6 @@ describe('OrderOption', () => {
               conceptId
               description
               form
-              id
               name
               nativeId
               scope
@@ -72,8 +70,10 @@ describe('OrderOption', () => {
       }, {
         contextValue
       })
+      console.log('🚀 ~ test.only ~ response:', response)
 
-      const { data } = response.body.singleResult
+      const { data, errors } = response.body.singleResult
+      console.log('🚀 ~ test.only ~ errors:', errors)
 
       expect(data).toEqual({
         orderOptions: {
@@ -89,7 +89,6 @@ describe('OrderOption', () => {
             conceptId: 'OO100000-EDSC',
             description: 'Parturient Dolor Cras Aenean Dapibus',
             form: "<form xmlns=\"http://echo.nasa.gov/v9/echoforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"> <model> <instance> <ecs:options xmlns:ecs=\"http://ecs.nasa.gov/options\"> <!-- ECS distribution options example --> <ecs:distribution> <ecs:mediatype> <ecs:value>FtpPull</ecs:value> </ecs:mediatype> <ecs:mediaformat> <ecs:ftppull-format> <ecs:value>FILEFORMAT</ecs:value> </ecs:ftppull-format> </ecs:mediaformat> </ecs:distribution> <ecs:do-ancillaryprocessing>true</ecs:do-ancillaryprocessing> <ecs:ancillary> <ecs:orderBrowse/> </ecs:ancillary> </ecs:options> </instance> </model> <ui> <group id=\"mediaOptionsGroup\" label=\"Media Options\" ref=\"ecs:distribution\"> <output id=\"MediaTypeOutput\" label=\"Media Type:\" relevant=\"ecs:mediatype/ecs:value ='FtpPull'\" type=\"xsd:string\" value=\"'HTTPS Pull'\"/> <output id=\"FtpPullMediaFormatOutput\" label=\"Media Format:\" relevant=\"ecs:mediaformat/ecs:ftppull-format/ecs:value='FILEFORMAT'\" type=\"xsd:string\" value=\"'File'\"/> </group> <group id=\"checkancillaryoptions\" label=\"Additional file options:\" ref=\"ecs:ancillary\" relevant=\"//ecs:do-ancillaryprocessing = 'true'\"> <input label=\"Include associated Browse file in order\" ref=\"ecs:orderBrowse\" type=\"xsd:boolean\"/> </group> </ui> </form>",
-            id: '0B4E0AF0BB4E0AF0BB4R0AF00',
             name: 'With Browse',
             nativeId: 'test-guid',
             scope: 'PROVIDER',
@@ -205,6 +204,133 @@ describe('OrderOption', () => {
 
           expect(data).toEqual({
             orderOption: null
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('createOrderOption', () => {
+        test('calls the ingest endpoint to create an order option', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put('/ingest/providers/TEST/order-options/test-native-id-2')
+            .reply(200, {
+              'concept-id': 'OO12341234-TEST',
+              'revision-id': 1
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              description: 'This is a description',
+              name: 'This is another new name',
+              providerId: 'TEST',
+              nativeId: 'test-native-id-2',
+              form: 'This is the form'
+            },
+            query: `mutation CreateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String) {
+              createOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
+                conceptId
+                revisionId
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            createOrderOption: {
+              conceptId: 'OO12341234-TEST',
+              revisionId: '1'
+            }
+          })
+        })
+      })
+
+      describe('updateOrderOption', () => {
+        test('calls the ingest endpoint to update an order option', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put('/ingest/providers/TEST/order-options/test-native-id-2')
+            .reply(200, {
+              'concept-id': 'OO12341234-TEST',
+              'revision-id': 2
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              description: 'This is a description',
+              name: 'This is another new name',
+              providerId: 'TEST',
+              nativeId: 'test-native-id-2',
+              form: 'This is the form'
+            },
+            query: `mutation UpdateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String!) {
+              updateOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
+                conceptId
+                revisionId
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+          console.log('🚀 ~ test.only ~ errors:', errors)
+
+          expect(data).toEqual({
+            updateOrderOption: {
+              conceptId: 'OO12341234-TEST',
+              revisionId: '2'
+            }
+          })
+        })
+      })
+
+      describe('deleteOrderOption', () => {
+        test('calls the ingest endpoint to delete an order option', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete('/ingest/providers/TEST/order-options/test-native-id-2')
+            .reply(200, {
+              'concept-id': 'OO12341234-TEST',
+              'revision-id': 2
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              providerId: 'TEST',
+              nativeId: 'test-native-id-2'
+            },
+            query: `mutation DeleteOrderOption($nativeId: String!, $providerId: String!) {
+              deleteOrderOption(nativeId: $nativeId, providerId: $providerId) {
+                conceptId
+                revisionId
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+          console.log('🚀 ~ test.only ~ errors:', errors)
+
+          expect(data).toEqual({
+            deleteOrderOption: {
+              conceptId: 'OO12341234-TEST',
+              revisionId: '2'
+            }
           })
         })
       })

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -72,8 +72,7 @@ describe('OrderOption', () => {
       })
       console.log('🚀 ~ test.only ~ response:', response)
 
-      const { data, errors } = response.body.singleResult
-      console.log('🚀 ~ test.only ~ errors:', errors)
+      const { data } = response.body.singleResult
 
       expect(data).toEqual({
         orderOptions: {
@@ -147,7 +146,7 @@ describe('OrderOption', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/order-options\.json/, 'concept_id=OO100000-EDSC')
+            .post(/order-options\.json/, 'concept_id[]=OO100000-EDSC')
             .reply(200, {
               items: [{
                 concept_id: 'OO100000-EDSC',
@@ -183,7 +182,7 @@ describe('OrderOption', () => {
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .post(/order-options\.json/, 'concept_id=OO100000-EDSC')
+            .post(/order-options\.json/, 'concept_id[]=OO100000-EDSC')
             .reply(200, {
               items: []
             })
@@ -283,8 +282,7 @@ describe('OrderOption', () => {
             contextValue
           })
 
-          const { data, errors } = response.body.singleResult
-          console.log('🚀 ~ test.only ~ errors:', errors)
+          const { data } = response.body.singleResult
 
           expect(data).toEqual({
             updateOrderOption: {
@@ -323,8 +321,7 @@ describe('OrderOption', () => {
             contextValue
           })
 
-          const { data, errors } = response.body.singleResult
-          console.log('🚀 ~ test.only ~ errors:', errors)
+          const { data } = response.body.singleResult
 
           expect(data).toEqual({
             deleteOrderOption: {

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -208,7 +208,7 @@ describe('OrderOption', () => {
 
     describe('Mutation', () => {
       describe('createOrderOption', () => {
-        test.only('calls the ingest endpoint to create an order option', async () => {
+        test('calls the ingest endpoint to create an order option', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,

--- a/src/resolvers/orderOption.js
+++ b/src/resolvers/orderOption.js
@@ -6,7 +6,7 @@ export default {
     orderOptions: async (source, args, context, info) => {
       const { dataSources } = context
 
-      return dataSources.orderOptionSource(
+      return dataSources.orderOptionSourceFetch(
         handlePagingParams(args),
         context,
         parseResolveInfo(info)
@@ -14,11 +14,31 @@ export default {
     },
     orderOption: async (source, args, context, info) => {
       const { dataSources } = context
-      const result = await dataSources.orderOptionSource(args, context, parseResolveInfo(info))
+      const result = await dataSources.orderOptionSourceFetch(args, context, parseResolveInfo(info))
 
       const [firstResult] = result
 
       return firstResult
+    }
+  },
+
+  Mutation: {
+    createOrderOption: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.orderOptionSourceIngest(args, context, parseResolveInfo(info))
+    },
+
+    updateOrderOption: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.orderOptionSourceIngest(args, context, parseResolveInfo(info))
+    },
+
+    deleteOrderOption: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.orderOptionSourceDelete(args, context, parseResolveInfo(info))
     }
   }
 }

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -107,7 +107,7 @@ export default {
         }
       }
 
-      return dataSources.orderOptionSource({
+      return dataSources.orderOptionSourceFetch({
         conceptId: orderOptionConceptIds,
         ...handlePagingParams(args, orderOptionConceptIds.length)
       }, context, parseResolveInfo(info))

--- a/src/types/orderOption.graphql
+++ b/src/types/orderOption.graphql
@@ -1,20 +1,25 @@
 type OrderOption {
   "The list of concepts and any data on the relationship between this order option and other permitted concepts"
   associationDetails: JSON
+
   "The concept id created by CMR for this orderOption"
   conceptId: String!
+
   "The description for this order option"
   description: String
+
   "The ECHO Forms schema for this order option"
   form: String
-  "The guid-id for this order option"
-  id: String!
+
   "The orderOption name."
   name: String
-  "The native id to set on the order option."  
+
+  "The native id to set on the order option."
   nativeId: String
-  "The two levels of order options, provider or system"
+
+  "The two levels of order options, `PROVIDER` or `SYSTEM`"
   scope: String
+
   "The sort key is used to indicate the preferred display order among other definitions"
   sortKey: String
 }
@@ -22,8 +27,10 @@ type OrderOption {
 type OrderOptionList {
   "The number of hits for a given search."
   count: Int
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "The list of orderOption search results."
   items: [OrderOption]
 }
@@ -31,10 +38,13 @@ type OrderOptionList {
 input OrderOptionsInput {
   "The unique concept-id assigned to the order-option."
   conceptId: [String]
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "The number of variables requested by the user."
   limit: Int
+
   "Zero based offset of individual results."
   offset: Int
 }
@@ -45,13 +55,82 @@ input OrderOptionInput {
 }
 
 type Query {
-  orderOptions(
-    "Order option's query parameters"
-    params: OrderOptionsInput
-  ): OrderOptionList!
-
   orderOption(
     "Order option's query parameters"
     params: OrderOptionInput
   ): OrderOption
+
+  orderOptions(
+    "Order option's query parameters"
+    params: OrderOptionsInput
+  ): OrderOptionList!
+}
+
+type OrderOptionMutationResponse {
+  "The concept id of the draft."
+  conceptId: String!
+
+  "The revision id of the draft."
+  revisionId: String!
+}
+
+enum OrderOptionScopeType {
+  PROVIDER
+  SYSTEM
+}
+
+type Mutation {
+  createOrderOption(
+    "The order option description."
+    description: String!
+
+    "The order option form."
+    form: String!
+
+    "The native id for the order option."
+    nativeId: String
+
+    "The order option name."
+    name: String!
+
+    "The provider id for the order option."
+    providerId: String!
+
+    "The two levels of order options, `PROVIDER` or `SYSTEM`"
+    scope: OrderOptionScopeType
+
+    "The sort key is used to indicate the preferred display order among other definitions"
+    sortKey: String
+  ): OrderOptionMutationResponse
+
+  updateOrderOption(
+    "The order option description."
+    description: String!
+
+    "The order option form."
+    form: String!
+
+    "The order option name."
+    name: String!
+
+    "The native id for the order option."
+    nativeId: String!
+
+    "The provider id for the order option."
+    providerId: String!
+
+    "The two levels of order options, `PROVIDER` or `SYSTEM`"
+    scope: OrderOptionScopeType
+
+    "The sort key is used to indicate the preferred display order among other definitions"
+    sortKey: String
+  ): OrderOptionMutationResponse
+
+  deleteOrderOption(
+    "The native id of the order option to be deleted."
+    nativeId: String!
+
+    "The provider id of the order option to be deleted."
+    providerId: String!
+  ): OrderOptionMutationResponse
 }

--- a/src/types/orderOption.graphql
+++ b/src/types/orderOption.graphql
@@ -2,25 +2,31 @@ type OrderOption {
   "The list of concepts and any data on the relationship between this order option and other permitted concepts"
   associationDetails: JSON
 
-  "The concept id created by CMR for this orderOption"
+  "The concept ID created by CMR for this order option"
   conceptId: String!
 
-  "The description for this order option"
+  "Indicates if the definition is deprecated. Deprecated definitions will be returned to the client and will be considered valid when validating an order, however new order items cannot be added using the definition and existing order items cannot be updated using the definition. This flag is ignored when creating an option definition, however it will always be set and returned once the definition has been created."
+  deprecated: Boolean
+
+  "The description is a longer, human-readable description of the order option type or contents, intended for client display."
   description: String
 
-  "The ECHO Forms schema for this order option"
+  "Contents must conform to ECHO Forms schema. See the ECHO Forms Specification for more information."
   form: String
 
-  "The orderOption name."
+  "The name is a shortened name used to distinguish between other option definitions."
   name: String
 
-  "The native id to set on the order option."
+  "The native ID to set on the order option."
   nativeId: String
 
-  "The two levels of order options, `PROVIDER` or `SYSTEM`"
-  scope: String
+  "The revision date for the order option."
+  revisionDate: String
 
-  "The sort key is used to indicate the preferred display order among other definitions"
+  "There are two levels of order options, provider and system. Only administrators may add system level options and only providers may add provider level options."
+  scope: OrderOptionScopeType
+
+  "The sort key is used to indicate the preferred display order among other definitions."
   sortKey: String
 }
 
@@ -36,7 +42,7 @@ type OrderOptionList {
 }
 
 input OrderOptionsInput {
-  "The unique concept-id assigned to the order-option."
+  "The unique concept ID assigned to the order-option."
   conceptId: [String]
 
   "Cursor that points to the/a specific position in a list of requested records."
@@ -48,35 +54,32 @@ input OrderOptionsInput {
   "Zero based offset of individual results."
   offset: Int
 
-  "The provider id."
+  "The provider ID."
   providerId: [String]
 }
 
 input OrderOptionInput {
-  "The unique concept id assigned to the order-option."
+  "The unique concept ID assigned to the order-option."
   conceptId: [String]
-
-  "The provider id."
-  providerId: [String]
 }
 
 type Query {
   orderOption(
-    "Order option's query parameters"
+    "The order option query parameters."
     params: OrderOptionInput
   ): OrderOption
 
   orderOptions(
-    "Order option's query parameters"
+    "The order option query parameters."
     params: OrderOptionsInput
   ): OrderOptionList!
 }
 
 type OrderOptionMutationResponse {
-  "The concept id of the draft."
+  "The concept ID of the draft."
   conceptId: String!
 
-  "The revision id of the draft."
+  "The revision ID of the draft."
   revisionId: String!
 }
 
@@ -87,22 +90,22 @@ enum OrderOptionScopeType {
 
 type Mutation {
   createOrderOption(
-    "The order option description."
-    description: String!
+    "The description is a longer, human-readable description of the order option type or contents, intended for client display."
+    description: String
 
-    "The order option form."
-    form: String!
+    "Contents must conform to ECHO Forms schema. See the ECHO Forms Specification for more information."
+    form: String
 
-    "The native id for the order option."
+    "The native ID for the order option."
     nativeId: String
 
-    "The order option name."
-    name: String!
+    "The name is a shortened name used to distinguish between other option definitions. This field must be unique per provider and is restricted to 30 characters."
+    name: String
 
-    "The provider id for the order option."
+    "The provider ID for the order option."
     providerId: String!
 
-    "The two levels of order options, `PROVIDER` or `SYSTEM`"
+    "There are two levels of order options, provider and system. Only administrators may add system level options and only providers may add provider level options."
     scope: OrderOptionScopeType
 
     "The sort key is used to indicate the preferred display order among other definitions"
@@ -110,22 +113,25 @@ type Mutation {
   ): OrderOptionMutationResponse
 
   updateOrderOption(
-    "The order option description."
-    description: String!
+    "Indicates if the definition is deprecated. Deprecated definitions will be returned to the client and will be considered valid when validating an order, however new order items cannot be added using the definition and existing order items cannot be updated using the definition. This flag is ignored when creating an option definition, however it will always be set and returned once the definition has been created."
+    deprecated: Boolean
 
-    "The order option form."
-    form: String!
+    "The description is a longer, human-readable description of the order option type or contents, intended for client display."
+    description: String
 
-    "The order option name."
-    name: String!
+    "Contents must conform to ECHO Forms schema. See the ECHO Forms Specification for more information."
+    form: String
 
-    "The native id for the order option."
+    "The name is a shortened name used to distinguish between other option definitions. This field must be unique per provider and is restricted to 30 characters."
+    name: String
+
+    "The native ID for the order option."
     nativeId: String!
 
-    "The provider id for the order option."
+    "The provider ID for the order option."
     providerId: String!
 
-    "The two levels of order options, `PROVIDER` or `SYSTEM`"
+    "There are two levels of order options, provider and system. Only administrators may add system level options and only providers may add provider level options."
     scope: OrderOptionScopeType
 
     "The sort key is used to indicate the preferred display order among other definitions"
@@ -133,10 +139,10 @@ type Mutation {
   ): OrderOptionMutationResponse
 
   deleteOrderOption(
-    "The native id of the order option to be deleted."
+    "The native ID of the order option to be deleted."
     nativeId: String!
 
-    "The provider id of the order option to be deleted."
+    "The provider ID of the order option to be deleted."
     providerId: String!
   ): OrderOptionMutationResponse
 }

--- a/src/types/orderOption.graphql
+++ b/src/types/orderOption.graphql
@@ -47,11 +47,17 @@ input OrderOptionsInput {
 
   "Zero based offset of individual results."
   offset: Int
+
+  "The provider id."
+  providerId: [String]
 }
 
 input OrderOptionInput {
   "The unique concept id assigned to the order-option."
-  conceptId: String!
+  conceptId: [String]
+
+  "The provider id."
+  providerId: [String]
 }
 
 type Query {

--- a/src/utils/orderOptionRequest.js
+++ b/src/utils/orderOptionRequest.js
@@ -1,0 +1,94 @@
+import axios from 'axios'
+
+import snakecaseKeys from 'snakecase-keys'
+import { downcaseKeys } from './downcaseKeys'
+import { pickIgnoringCase } from './pickIgnoringCase'
+import { prepKeysForCmr } from './prepKeysForCmr'
+
+/**
+ * Make a request to CMR and return the promise
+ * @param {Object} params
+ * @param {Object} params.data Parameters to send to CMR
+ * @param {Object} params.headers Headers to send to CMR
+ * @param {String} params.method Method to make the request with
+ * @param {String} params.path Path to make the request to
+ */
+export const orderOptionRequest = ({
+  headers,
+  method,
+  nonIndexedKeys,
+  params,
+  path
+}) => {
+  // Default headers
+  const defaultHeaders = {
+    Accept: 'application/json'
+  }
+
+  // Merge default headers into the provided headers and then pick out only permitted values
+  const permittedHeaders = pickIgnoringCase({
+    ...defaultHeaders,
+    ...headers
+  }, [
+    'Accept',
+    'Authorization',
+    'Client-Id',
+    'Content-Type',
+    'CMR-Request-Id',
+    'CMR-Search-After'
+  ])
+
+  const {
+    'client-id': clientId,
+    'cmr-request-id': requestId
+  } = downcaseKeys(permittedHeaders)
+
+  const requestConfiguration = {
+    headers: permittedHeaders,
+    method,
+    url: `${process.env.cmrRootUrl}/providers/${params.providerId}/${path}/${params.nativeId}`
+  }
+
+  if (params) {
+    if (['POST', 'PUT'].includes(method)) {
+      requestConfiguration.data = params.data
+    }
+
+    if (method === 'GET') {
+      const cmrParameters = prepKeysForCmr(snakecaseKeys(params), nonIndexedKeys)
+
+      requestConfiguration.url += `?${cmrParameters}`
+    }
+  }
+
+  // Interceptors require an instance of axios
+  const instance = axios.create()
+  const { interceptors } = instance
+  const {
+    request: requestInterceptor,
+    response: responseInterceptor
+  } = interceptors
+
+  // Intercept the request to inject timing information
+  requestInterceptor.use((config) => {
+    // eslint-disable-next-line no-param-reassign
+    config.headers['request-startTime'] = process.hrtime()
+
+    return config
+  })
+
+  responseInterceptor.use((response) => {
+    // Determine total time to complete this request
+    const start = response.config.headers['request-startTime']
+    const end = process.hrtime(start)
+    const milliseconds = Math.round((end[0] * 1000) + (end[1] / 1000000))
+
+    response.headers['request-duration'] = milliseconds
+
+    console.log(`Request ${requestId} from ${clientId} to order-options completed external request in [observed: ${milliseconds} ms]`)
+
+    return response
+  })
+
+  return instance.request(requestConfiguration)
+}

--- a/src/utils/umm/orderOptionKeyMap.json
+++ b/src/utils/umm/orderOptionKeyMap.json
@@ -7,12 +7,13 @@
   "ummKeyMappings": {
     "associationDetails": "meta.association-details",
     "conceptId": "meta.concept-id",
+    "deprecated": "umm.Deprecated",
     "description": "umm.Description",
     "form": "umm.Form",
     "name": "umm.Name",
     "nativeId": "meta.native-id",
+    "revisionDate": "meta.revision-date",
     "scope": "umm.Scope",
-    "sortKey": "umm.SortKey",
-    "deprecated": "umm.Deprecated"
+    "sortKey": "umm.SortKey"
   }
 }

--- a/src/utils/umm/orderOptionKeyMap.json
+++ b/src/utils/umm/orderOptionKeyMap.json
@@ -1,19 +1,18 @@
 {
-    "sharedKeys": [
-      "conceptId",
-      "id",
-      "name",
-      "nativeId"
-    ],
-    "ummKeyMappings": {
-      "associationDetails": "meta.association-details",
-      "conceptId": "meta.concept-id",
-      "description": "umm.Description",
-      "form": "umm.Form",
-      "id": "umm.Id",
-      "name": "umm.Name",
-      "nativeId": "meta.native-id",
-      "scope": "umm.Scope",
-      "sortKey": "umm.SortKey"
-    }
+  "sharedKeys": [
+    "conceptId",
+    "name",
+    "nativeId"
+  ],
+  "ummKeyMappings": {
+    "associationDetails": "meta.association-details",
+    "conceptId": "meta.concept-id",
+    "description": "umm.Description",
+    "form": "umm.Form",
+    "name": "umm.Name",
+    "nativeId": "meta.native-id",
+    "scope": "umm.Scope",
+    "sortKey": "umm.SortKey",
+    "deprecated": "umm.Deprecated"
   }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Adds the ability to create, update, and delete an order option

### What is the Solution?

Adds the relevant mutations

### What areas of the application does this impact?

- `createOrderOption`
- `updateOrderOption`
- `deleteOrderOption`

# Testing

### Reproduction steps

- **Environment for testing:** n/a
- **Collection to test with:** n/a

1. Create an order option per the documentation
2. Update an order option per the documentation
3. Delete an order option per the documentation

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
