### PR TITLE
MMT-3433: Adds support for collections query within order options

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -140,12 +140,16 @@ export default class Concept {
    * @param {Object} item The item returned from the CMR json endpoint
    */
   setEssentialJsonValues(id, item) {
-    const { association_details: associationDetails } = item
+    const { associations, association_details: associationDetails } = item
 
     const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
 
     if (associationDetails) {
       this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
+    }
+
+    if (associations) {
+      this.setItemValue(id, 'associations', associations)
     }
   }
 
@@ -154,7 +158,20 @@ export default class Concept {
    * @param {String} id Concept ID to set a value for within the result set
    * @param {Object} item The item returned from the CMR json endpoint
    */
-  setEssentialUmmValues() {}
+  setEssentialUmmValues(id, item) {
+    const { meta } = item
+    const { associations, 'association-details': associationDetails } = meta
+
+    const formattedAssociationDetails = camelcaseKeys(associationDetails, { deep: true })
+
+    if (associationDetails) {
+      this.setItemValue(id, 'associationDetails', formattedAssociationDetails)
+    }
+
+    if (associations) {
+      this.setItemValue(id, 'associations', associations)
+    }
+  }
 
   /**
    * Get the total number of records available for a given search across all endpoints. Also

--- a/src/cmr/concepts/orderOption.js
+++ b/src/cmr/concepts/orderOption.js
@@ -1,3 +1,4 @@
+import camelcaseKeys from 'camelcase-keys'
 import Concept from './concept'
 
 export default class OrderOption extends Concept {
@@ -51,8 +52,12 @@ export default class OrderOption extends Concept {
     const { env } = process
     const { ummOrderOptionVersion } = env
 
+    const casedKeys = camelcaseKeys(params, {
+      pascalCase: true
+    })
+
     return {
-      ...params,
+      ...casedKeys,
       MetadataSpecification: {
         URL: `https://cdn.earthdata.nasa.gov/generics/order-option/v${ummOrderOptionVersion}`,
         Name: 'Order Option',

--- a/src/cmr/concepts/provider.js
+++ b/src/cmr/concepts/provider.js
@@ -32,6 +32,7 @@ export default class Provider extends Concept {
       jsonKeys.forEach((jsonKey) => {
         const cmrKey = kebabCase(jsonKey)
         const { [cmrKey]: keyValue } = normalizedItem
+
         // Snake case the key requested and any children of that key
         this.setItemValue(providerId, jsonKey, keyValue)
       })

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -453,34 +453,6 @@ describe('OrderOption', () => {
               }]
             })
 
-          // nock(/example-cmr/)
-          //   .defaultReplyHeaders({
-          //     'CMR-Took': 7,
-          //     'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          //   })
-          //   .get('/search/collections.json?concept_id[]=C100000-EDSC&page_size=20')
-          //   .reply(200, {
-          //     feed: {
-          //       entry: [{
-          //         id: 'C100000-EDSC'
-          //       }]
-          //     }
-          //   })
-
-          // nock(/example-cmr/)
-          //   .defaultReplyHeaders({
-          //     'CMR-Took': 7,
-          //     'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          //   })
-          //   .get('/search/collections.json?concept_id[]=C100001-EDSC&page_size=20')
-          //   .reply(200, {
-          //     feed: {
-          //       entry: [{
-          //         id: 'C100001-EDSC'
-          //       }]
-          //     }
-          //   })
-
           const response = await server.executeOperation({
             variables: {},
             query: `{

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -180,7 +180,7 @@ describe('OrderOption', () => {
               'CMR-Took': 0,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get('/search/order-options.json?concept_id[]=OO100000-EDSC')
+            .get('/search/order-options.json?concept_id=OO100000-EDSC')
             .reply(200, {
               items: []
             })
@@ -205,33 +205,84 @@ describe('OrderOption', () => {
         })
       })
     })
+  })
 
-    describe('Mutation', () => {
-      describe('createOrderOption', () => {
-        test('calls the ingest endpoint to create an order option', async () => {
+  describe('OrderOption', () => {
+    describe('collections', () => {
+      describe('when no keys are requested from the order option', () => {
+        test('returns collections when querying a published record', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .put('/ingest/providers/TEST/order-options/test-native-id-2')
+            .get(/order-options\.json/)
             .reply(200, {
-              'concept-id': 'OO12341234-TEST',
-              'revision-id': 1
+              items: [{
+                concept_id: 'OO100000-EDSC',
+                associations: {
+                  collections: ['C100000-EDSC']
+                },
+                associationDetails: {
+                  collections: [{
+                    concept_id: 'C100000-EDSC',
+                    data: {}
+                  }]
+                }
+              }, {
+                concept_id: 'OO100001-EDSC',
+                associations: {
+                  collections: ['C100001-EDSC']
+                },
+                associationDetails: {
+                  collections: [{
+                    concept_id: 'C100001-EDSC',
+                    data: {}
+                  }]
+                }
+              }]
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.json?concept_id[]=C100000-EDSC&page_size=20')
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100000-EDSC'
+                }]
+              }
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.json?concept_id[]=C100001-EDSC&page_size=20')
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100001-EDSC'
+                }]
+              }
             })
 
           const response = await server.executeOperation({
-            variables: {
-              description: 'This is a description',
-              name: 'This is another new name',
-              providerId: 'TEST',
-              nativeId: 'test-native-id-2',
-              form: 'This is the form'
-            },
-            query: `mutation CreateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String) {
-              createOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
-                conceptId
-                revisionId
+            variables: {},
+            query: `{
+              orderOptions {
+                items {
+                  conceptId
+                  collections {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
               }
             }`
           }, {
@@ -241,39 +292,111 @@ describe('OrderOption', () => {
           const { data } = response.body.singleResult
 
           expect(data).toEqual({
-            createOrderOption: {
-              conceptId: 'OO12341234-TEST',
-              revisionId: '1'
+            orderOptions: {
+              items: [{
+                conceptId: 'OO100000-EDSC',
+                collections: {
+                  items: [{
+                    conceptId: 'C100000-EDSC'
+                  }]
+                }
+              }, {
+                conceptId: 'OO100001-EDSC',
+                collections: {
+                  items: [{
+                    conceptId: 'C100001-EDSC'
+                  }]
+                }
+              }]
             }
           })
         })
       })
 
-      describe('updateOrderOption', () => {
-        test('calls the ingest endpoint to update an order option', async () => {
+      describe('when only umm keys are requested from the order option', () => {
+        test('returns collections when querying a published record', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .put('/ingest/providers/TEST/order-options/test-native-id-2')
+            .get(/order-options\.umm_json/)
             .reply(200, {
-              'concept-id': 'OO12341234-TEST',
-              'revision-id': 2
+              items: [{
+                meta: {
+                  'concept-id': 'OO100000-EDSC',
+                  associations: {
+                    collections: ['C100000-EDSC']
+                  },
+                  'association-details': {
+                    collections: [{
+                      concept_id: 'C100000-EDSC',
+                      data: {}
+                    }]
+                  }
+                },
+                umm: {
+                  Form: '<Form />'
+                }
+              }, {
+                meta: {
+                  'concept-id': 'OO100001-EDSC',
+                  associations: {
+                    collections: ['C100001-EDSC']
+                  },
+                  'association-details': {
+                    collections: [{
+                      concept_id: 'C100001-EDSC',
+                      data: {}
+                    }]
+                  }
+                },
+                umm: {
+                  Form: '<Form />'
+                }
+              }]
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.json?concept_id[]=C100000-EDSC&page_size=20')
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100000-EDSC'
+                }]
+              }
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.json?concept_id[]=C100001-EDSC&page_size=20')
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100001-EDSC'
+                }]
+              }
             })
 
           const response = await server.executeOperation({
-            variables: {
-              description: 'This is a description',
-              name: 'This is another new name',
-              providerId: 'TEST',
-              nativeId: 'test-native-id-2',
-              form: 'This is the form'
-            },
-            query: `mutation UpdateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String!) {
-              updateOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
-                conceptId
-                revisionId
+            variables: {},
+            query: `{
+              orderOptions {
+                items {
+                  form
+                  collections {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
               }
             }`
           }, {
@@ -283,36 +406,93 @@ describe('OrderOption', () => {
           const { data } = response.body.singleResult
 
           expect(data).toEqual({
-            updateOrderOption: {
-              conceptId: 'OO12341234-TEST',
-              revisionId: '2'
+            orderOptions: {
+              items: [{
+                form: '<Form />',
+                collections: {
+                  items: [{
+                    conceptId: 'C100000-EDSC'
+                  }]
+                }
+              }, {
+                form: '<Form />',
+                collections: {
+                  items: [{
+                    conceptId: 'C100001-EDSC'
+                  }]
+                }
+              }]
             }
           })
         })
       })
 
-      describe('deleteOrderOption', () => {
-        test('calls the ingest endpoint to delete an order option', async () => {
+      describe('when no associations are present', () => {
+        test('returns collections an empty result', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .delete('/ingest/providers/TEST/order-options/test-native-id-2')
+            .get(/order-options\.umm_json/)
             .reply(200, {
-              'concept-id': 'OO12341234-TEST',
-              'revision-id': 2
+              items: [{
+                meta: {
+                  'concept-id': 'OO100000-EDSC'
+                },
+                umm: {
+                  Form: '<Form />'
+                }
+              }, {
+                meta: {
+                  'concept-id': 'OO100001-EDSC'
+                },
+                umm: {
+                  Form: '<Form />'
+                }
+              }]
             })
 
+          // nock(/example-cmr/)
+          //   .defaultReplyHeaders({
+          //     'CMR-Took': 7,
+          //     'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          //   })
+          //   .get('/search/collections.json?concept_id[]=C100000-EDSC&page_size=20')
+          //   .reply(200, {
+          //     feed: {
+          //       entry: [{
+          //         id: 'C100000-EDSC'
+          //       }]
+          //     }
+          //   })
+
+          // nock(/example-cmr/)
+          //   .defaultReplyHeaders({
+          //     'CMR-Took': 7,
+          //     'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          //   })
+          //   .get('/search/collections.json?concept_id[]=C100001-EDSC&page_size=20')
+          //   .reply(200, {
+          //     feed: {
+          //       entry: [{
+          //         id: 'C100001-EDSC'
+          //       }]
+          //     }
+          //   })
+
           const response = await server.executeOperation({
-            variables: {
-              providerId: 'TEST',
-              nativeId: 'test-native-id-2'
-            },
-            query: `mutation DeleteOrderOption($nativeId: String!, $providerId: String!) {
-              deleteOrderOption(nativeId: $nativeId, providerId: $providerId) {
-                conceptId
-                revisionId
+            variables: {},
+            query: `{
+              orderOptions {
+                items {
+                  form
+                  collections {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
               }
             }`
           }, {
@@ -322,11 +502,145 @@ describe('OrderOption', () => {
           const { data } = response.body.singleResult
 
           expect(data).toEqual({
-            deleteOrderOption: {
-              conceptId: 'OO12341234-TEST',
-              revisionId: '2'
+            orderOptions: {
+              items: [{
+                form: '<Form />',
+                collections: {
+                  items: null
+                }
+              }, {
+                form: '<Form />',
+                collections: {
+                  items: null
+                }
+              }]
             }
           })
+        })
+      })
+    })
+  })
+
+  describe('Mutation', () => {
+    describe('createOrderOption', () => {
+      test('calls the ingest endpoint to create an order option', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .put('/ingest/providers/TEST/order-options/test-native-id-2')
+          .reply(200, {
+            'concept-id': 'OO12341234-TEST',
+            'revision-id': 1
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            description: 'This is a description',
+            name: 'This is another new name',
+            providerId: 'TEST',
+            nativeId: 'test-native-id-2',
+            form: 'This is the form'
+          },
+          query: `mutation CreateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String) {
+            createOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
+              conceptId
+              revisionId
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          createOrderOption: {
+            conceptId: 'OO12341234-TEST',
+            revisionId: '1'
+          }
+        })
+      })
+    })
+
+    describe('updateOrderOption', () => {
+      test('calls the ingest endpoint to update an order option', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .put('/ingest/providers/TEST/order-options/test-native-id-2')
+          .reply(200, {
+            'concept-id': 'OO12341234-TEST',
+            'revision-id': 2
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            description: 'This is a description',
+            name: 'This is another new name',
+            providerId: 'TEST',
+            nativeId: 'test-native-id-2',
+            form: 'This is the form'
+          },
+          query: `mutation UpdateOrderOption($description: String!, $name: String!, $providerId: String!, $form: String!, $nativeId: String!) {
+            updateOrderOption(description: $description, name: $name, providerId: $providerId, form: $form, nativeId: $nativeId) {
+              conceptId
+              revisionId
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          updateOrderOption: {
+            conceptId: 'OO12341234-TEST',
+            revisionId: '2'
+          }
+        })
+      })
+    })
+
+    describe('deleteOrderOption', () => {
+      test('calls the ingest endpoint to delete an order option', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .delete('/ingest/providers/TEST/order-options/test-native-id-2')
+          .reply(200, {
+            'concept-id': 'OO12341234-TEST',
+            'revision-id': 2
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            providerId: 'TEST',
+            nativeId: 'test-native-id-2'
+          },
+          query: `mutation DeleteOrderOption($nativeId: String!, $providerId: String!) {
+            deleteOrderOption(nativeId: $nativeId, providerId: $providerId) {
+              conceptId
+              revisionId
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          deleteOrderOption: {
+            conceptId: 'OO12341234-TEST',
+            revisionId: '2'
+          }
         })
       })
     })

--- a/src/resolvers/orderOption.js
+++ b/src/resolvers/orderOption.js
@@ -23,6 +23,34 @@ export default {
     }
   },
 
+  OrderOption: {
+    collections: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      // Pull out parent collection id to provide to the granules endpoint because cmr requires it
+      const {
+        associations = {}
+      } = source
+
+      const { collections = [] } = associations
+
+      // If there are no associations to collections for this order option
+      if (!collections.length) {
+        return {
+          count: 0,
+          items: null
+        }
+      }
+
+      const requestedParams = handlePagingParams({
+        conceptId: collections,
+        ...args
+      })
+
+      return dataSources.collectionSourceFetch(requestedParams, context, parseResolveInfo(info))
+    }
+  },
+
   Mutation: {
     createOrderOption: async (source, args, context, info) => {
       const { dataSources } = context

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -82,6 +82,7 @@ export default {
       if (isDraftConceptId(conceptId, 'service')) return null
 
       const { collections = [] } = associationDetails
+
       // If there are no associations to collections for this service
       if (!collections.length) {
         return {
@@ -92,7 +93,7 @@ export default {
 
       let filteredCollections = collections
 
-      // Order-options on the payload may be in under context of a specific collection to service association if a parent col was provided
+      // Order-options on the payload may be the under context of a specific collection to service association if a parent col was provided
       if (parentCollectionConceptId) {
         filteredCollections = collections.filter(
           (assoc) => assoc.conceptId.includes(parentCollectionConceptId)

--- a/src/types/orderOption.graphql
+++ b/src/types/orderOption.graphql
@@ -23,11 +23,19 @@ type OrderOption {
   "The revision date for the order option."
   revisionDate: String
 
+  "The revision id for the order option."
+  revisionId: String
+
   "There are two levels of order options, provider and system. Only administrators may add system level options and only providers may add provider level options."
   scope: OrderOptionScopeType
 
   "The sort key is used to indicate the preferred display order among other definitions."
   sortKey: String
+
+  collections (
+    "Collections query parameters"
+    params: CollectionsInput
+  ): CollectionList
 }
 
 type OrderOptionList {


### PR DESCRIPTION
# Overview

### What is the feature?

Adds support for collections query within order options

### What is the Solution?

Added a resolver for collections that allows them to be queried from within an order option.

### What areas of the application does this impact?

Order option queries.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
