### PR TITLE
MMT-3695: Implements revisions resolver

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -286,20 +286,20 @@ export default class Concept {
    */
   getPermittedJsonSearchParams() {
     return [
-      'concept_id',
-      'offset',
-      'page_size',
-      'sort_key',
-      'permitted_user',
       'all_revisions',
       'concept_id',
+      'concept_id',
       'include_full_acl',
+      'offset',
       'offset',
       'originator_id',
       'page_num',
       'page_size',
+      'page_size',
+      'permitted_user',
       'permitted_user',
       'provider_id',
+      'sort_key',
       'sort_key',
       'tag_key',
       'target'

--- a/src/cmr/concepts/draftConcept.js
+++ b/src/cmr/concepts/draftConcept.js
@@ -102,9 +102,7 @@ export default class DraftConcept extends Concept {
 
     const { ummKeys } = this.requestInfo
 
-    const ummHeaders = {
-      ...this.headers
-    }
+    const ummHeaders = this.headers
 
     // Construct the promise that will request data from the umm endpoint
     promises.push(

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -17,10 +17,12 @@ export const CONCEPT_TYPES = [
 ]
 
 /**
- * List of supported pseudo fields, these fields aren't a real CMR concept, but are still supported by separate queries
+ * List of supported pseudo fields, these fields aren't a real CMR concept, but are still supported by separate queries.
+ * Adding the field to this list will keep it out of being added to `jsonKeys` and triggering a CMR json endpoint call.
  */
 export const PSEUDO_FIELDS = [
-  'maxItemsPerOrder'
+  'maxItemsPerOrder',
+  'revisions'
 ]
 
 /**

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -387,7 +387,9 @@ describe('Collection', () => {
         contextValue
       })
 
-      const { data } = response.body.singleResult
+      const { data, errors } = response.body.singleResult
+
+      expect(errors).toBeUndefined()
 
       expect(data).toEqual({
         collections: {

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -127,6 +127,7 @@ describe('Collection', () => {
             meta: {
               'concept-id': 'C100000-EDSC',
               'native-id': 'test-guid',
+              'revision-id': '2',
               'association-details': {
                 variables: [
                   {
@@ -263,6 +264,35 @@ describe('Collection', () => {
           }]
         })
 
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 2,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/collections.umm_json?all_revisions=true&concept_id=C100000-EDSC')
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'C100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '2'
+            },
+            umm: {
+              Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }, {
+            meta: {
+              'concept-id': 'C100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '1'
+            },
+            umm: {
+              Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }]
+        })
+
       const response = await server.executeOperation({
         variables: {},
         query: `{
@@ -328,6 +358,12 @@ describe('Collection', () => {
               purpose
               quality
               relatedUrls
+              revisions {
+                count
+                items {
+                  revisionId
+                }
+              }
               scienceKeywords
               shortName
               spatialExtent
@@ -507,6 +543,17 @@ describe('Collection', () => {
             purpose: 'Mock Purpose',
             quality: 'Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.',
             relatedUrls: [],
+            revisions: {
+              count: 2,
+              items: [
+                {
+                  revisionId: '2'
+                },
+                {
+                  revisionId: '1'
+                }
+              ]
+            },
             scienceKeywords: [],
             shortName: 'LOREM-QUAM',
             spatialExtent: {

--- a/src/resolvers/__tests__/tool.test.js
+++ b/src/resolvers/__tests__/tool.test.js
@@ -70,6 +70,35 @@ describe('Tool', () => {
           }]
         })
 
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 2,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/tools.umm_json?all_revisions=true&concept_id=T100000-EDSC')
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'T100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '2'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }, {
+            meta: {
+              'concept-id': 'T100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '1'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }]
+        })
+
       const response = await server.executeOperation({
         variables: {},
         query: `{
@@ -92,6 +121,12 @@ describe('Tool', () => {
               potentialAction
               quality
               relatedUrls
+              revisions {
+                count
+                items {
+                  revisionId
+                }
+              }
               searchAction
               supportedBrowsers
               supportedInputFormats
@@ -111,7 +146,9 @@ describe('Tool', () => {
         contextValue
       })
 
-      const { data } = response.body.singleResult
+      const { data, errors } = response.body.singleResult
+
+      expect(errors).toBeUndefined()
 
       expect(data).toEqual({
         tools: {
@@ -139,6 +176,17 @@ describe('Tool', () => {
             potentialAction: {},
             quality: {},
             relatedUrls: [],
+            revisions: {
+              count: 2,
+              items: [
+                {
+                  revisionId: '2'
+                },
+                {
+                  revisionId: '1'
+                }
+              ]
+            },
             searchAction: {},
             supportedBrowsers: [],
             supportedInputFormats: [],

--- a/src/resolvers/__tests__/variable.test.js
+++ b/src/resolvers/__tests__/variable.test.js
@@ -74,6 +74,35 @@ describe('Variable', () => {
           }]
         })
 
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 2,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/variables.umm_json?all_revisions=true&concept_id=V100000-EDSC')
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'V100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '2'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }, {
+            meta: {
+              'concept-id': 'V100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '1'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }]
+        })
+
       const response = await server.executeOperation({
         variables: {},
         query: `{
@@ -95,6 +124,12 @@ describe('Variable', () => {
               nativeId
               offset
               relatedUrls
+              revisions {
+                count
+                items {
+                  revisionId
+                }
+              }
               scale
               scienceKeywords
               sets
@@ -110,7 +145,9 @@ describe('Variable', () => {
         contextValue
       })
 
-      const { data } = response.body.singleResult
+      const { data, errors } = response.body.singleResult
+
+      expect(errors).toBeUndefined()
 
       expect(data).toEqual({
         variables: {
@@ -137,6 +174,17 @@ describe('Variable', () => {
             nativeId: 'test-guid',
             offset: 1.234,
             relatedUrls: [],
+            revisions: {
+              count: 2,
+              items: [
+                {
+                  revisionId: '2'
+                },
+                {
+                  revisionId: '1'
+                }
+              ]
+            },
             scale: 1.234,
             scienceKeywords: [],
             sets: [],

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -48,6 +48,21 @@ export default {
   },
 
   Collection: {
+    revisions: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const { conceptId } = source
+
+      return dataSources.collectionSourceFetch(
+        {
+          conceptId,
+          allRevisions: true
+        },
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
     granules: async (source, args, context, info) => {
       const { dataSources } = context
 
@@ -223,14 +238,8 @@ export default {
         return null
       }
 
-      const tagKeys = []
-
-      Object.keys(tags).map((key) => (
-        tagKeys.push(key)
-      ))
-
       const requestedParams = handlePagingParams({
-        tagKey: tagKeys
+        tagKey: Object.keys(tags)
       })
 
       return dataSources.tagDefinitionSource(

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -48,6 +48,21 @@ export default {
   },
 
   Service: {
+    revisions: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const { conceptId } = source
+
+      return dataSources.serviceSourceFetch(
+        {
+          conceptId,
+          allRevisions: true
+        },
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
     collections: async (source, args, context, info) => {
       const { dataSources } = context
 

--- a/src/resolvers/tool.js
+++ b/src/resolvers/tool.js
@@ -40,6 +40,21 @@ export default {
   },
 
   Tool: {
+    revisions: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const { conceptId } = source
+
+      return dataSources.toolSourceFetch(
+        {
+          conceptId,
+          allRevisions: true
+        },
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
     collections: async (source, args, context, info) => {
       const { dataSources } = context
 

--- a/src/resolvers/variable.js
+++ b/src/resolvers/variable.js
@@ -70,6 +70,21 @@ export default {
   },
 
   Variable: {
+    revisions: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const { conceptId } = source
+
+      return dataSources.variableSourceFetch(
+        {
+          conceptId,
+          allRevisions: true
+        },
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
     collections: async (source, args, context, info) => {
       const { dataSources } = context
 

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -245,15 +245,22 @@ type Collection {
   "The Version of the collection."
   version: String
 
+  "All revisions of this Collection."
+  revisions: CollectionRevisionList
+
   relatedCollections (
     "Related Collections query parameters"
     params: RelatedCollectionsInput
+
     "The size of the range GraphDB searches on. Defaults to 5"
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "The beginning of the range GraphDB searches on"
     offset: Int @deprecated(reason: "Use `params.offset`")
+
     "Filter the RelatedURL relationships by the Type property."
     relatedUrlType: [String] @deprecated(reason: "Use `params.relatedUrlType`")
+
     "Filter the RelatedURL relationships by the subtype property."
     relatedUrlSubtype: [String] @deprecated(reason: "Use `params.relatedUrlSubtype`")
   ): RelatedCollectionsList
@@ -416,10 +423,13 @@ type Collection {
 type DuplicateCollection {
   "The unique concept id assigned to the collection."
   id: String
+
   "The DOI that identifies the collection."
   doi: String
+
   "The short name associated with the collection."
   shortName: String
+
   "The title of the collection described by the metadata."
   title: String
 }
@@ -427,6 +437,7 @@ type DuplicateCollection {
 type DuplicateCollectionList {
   "The number of duplicate collections available."
   count: Int
+
   "The list of duplicate collections."
   items: [DuplicateCollection]
 }
@@ -508,6 +519,14 @@ type GraphDbPlatformInstrument implements Relationship {
 
   "The name of the instrument."
   instrument: String
+}
+
+type CollectionRevisionList {
+  "The number of hits for a given search."
+  count: Int
+
+  "The list of collection search results."
+  items: [Collection]
 }
 
 type CollectionList {
@@ -657,7 +676,7 @@ input CollectionsInput {
   "The name of the providers associated with the collections."
   providers: [String]
 
-  "The revision id of the collection"
+  "The revision date of the collection"
   revisionDate: String
 
   "Science Keywords associated with the collection, in facet form."
@@ -701,9 +720,6 @@ input CollectionsInput {
 
   "UMM Variable concept id."
   variableConceptId: String
-
-  "Returns all revisions when set to true."
-  allRevisions: Boolean
 }
 
 input CollectionInput {

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -1,74 +1,113 @@
 type Service {
   "Information about any constraints for accessing the service, software, or tool."
   accessConstraints: String
+
   "Words or phrases to further describe the service, software, or tool."
   ancillaryKeywords: [String]
+
   "The list of concepts and any data on the relationship between this service and other permitted concepts"
   associationDetails: JSON
+  
   "The unique concept id assigned to the service."
   conceptId: String!
+
   "This is the contact groups of the service."
   contactGroups: JSON
+
   "This is the contact persons of the service."
   contactPersons: JSON
+
   "A brief description of the service."
   description: String
+
   "This element describes the latest date when the service was most recently pushed to production for support and maintenance."
   lastUpdatedDate: String
+
   "The long name of the service, software, or tool."
   longName: String
+
   "The maximum number of items permitted in a single order. Only for services that are type ECHO ORDERS."
   maxItemsPerOrder: Int
+
   "The name of the service, software, or tool."
   name: String
+
   "The native id to set on the service."
   nativeId: String!
+
   "This class describes the signature of the operational metadata provided by the service."
   operationMetadata: JSON
+
   "Provider ID of the service."
   providerId: String
+
   "Date which the Service was last updated."
   revisionDate: String
+
   "The revision id of the Service."
   revisionId: String
+
   "Web addresses used to get supported documentation or other related information link to the service."
   relatedUrls: JSON
+
   "Allows for the specification of Earth Science Service keywords that are representative of the service, software, or tool being described. The controlled vocabulary for Service Keywords is maintained in the Keyword Management System (KMS)."
   serviceKeywords: JSON
+
   "This element contains important information about the Unique Resource Locator for the service."
   serviceOptions: JSON
+
   "The service provider, or organization, or institution responsible for developing, archiving, and/or distributing the service, software, or tool."
   serviceOrganizations: JSON
+
   "List of input projection names supported by the service."
   supportedInputProjections: JSON
+
   "List of output projection names supported by the service."
   supportedOutputProjections: JSON
+
   "List of format name combinations which explicitly state which re-formatting options are available."
   supportedReformattings: JSON
+
   "Information about the quality of the service, software, or tool, or any quality assurance procedures followed in development."
   serviceQuality: JSON
+
   "The type of the service."
   type: String
+
   "Raw UMM Metadata of the Service Record."
   ummMetadata: JSON
+
   "Represents the Internet site where you can directly access the back-end service."
   url: JSON
+
   "Information on how the item (service, software, or tool) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness."
   useConstraints: JSON
+
   "Id of the user who modified/published record"
   userId: String
+
   "The edition or version of the service."
   version: String
+
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
+
+  "Previous revisions of this Collection"
+  previousRevisions: [Collection]
+
+  "All revisions of this Service."
+  revisions: ServiceRevisionList
 
   collections (
     "Collections query parameters"
     params: CollectionsInput
+
     "The unique concept id assigned to the service."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "The number of collections requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
   ): CollectionList
@@ -84,11 +123,21 @@ type Service {
   ): VariableList
 }
 
+type ServiceRevisionList {
+  "The number of hits for a given search."
+  count: Int
+
+  "The list of service search results."
+  items: [Service]
+}
+
 type ServiceList {
   "The number of hits for a given search."
   count: Int
+
   "Cursor that points to the a specific position in a list of requested records."
   cursor: String
+
   "The list of service search results."
   items: [Service]
 }
@@ -96,22 +145,27 @@ type ServiceList {
 input ServicesInput {
   "The unique concept id assigned to the service."
   conceptId: [String]
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "Keyword search value."
   keyword: String
+
   "The number of services requested by the user."
   limit: Int
+
   "Zero based offset of individual results."
   offset: Int
+
   "The name of the provider associated with the service."
   provider: String
+
   "The type of the service."
   type: String
+
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: String
-  "Returns all revisions when set to true"
-  allRevisions: Boolean
 }
 
 input ServiceInput {
@@ -123,16 +177,22 @@ type Query {
   services (
     "Services query parameters"
     params: ServicesInput
+
     "The unique concept id assigned to the service."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "Cursor that points to the a specific position in a list of requested records."
     cursor: String @deprecated(reason: "Use `params.cursor`")
+
     "The number of servies requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
+
     "The type of the service."
     type: String @deprecated(reason: "Use `params.type`")
+
     "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
     sortKey: [String] @deprecated(reason: "Use `params.sortKey`")
   ): ServiceList!
@@ -140,6 +200,7 @@ type Query {
   service (
     "Service query parameters"
     params: ServiceInput
+
     "The unique concept id assigned to the service."
     conceptId: String @deprecated(reason: "Use `params.conceptId`")
   ): Service

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -1,90 +1,139 @@
 type Tool {
   "Information about any constraints for accessing the downloadable tool or web user interface."
   accessConstraints: String
+
   "Words or phrases to further describe the downloadable tool or web user interface."
   ancillaryKeywords: JSON
+
   "The list of concepts and any data on the relationship between this tool and other permitted concepts"
   associationDetails: JSON
+
   "The unique concept id assigned to the tool."
   conceptId: String!
+
   "Group(s) to contact at an organization to get information about the web user interface or downloadable tool, including how the group may be contacted."
   contactGroups: JSON
+
   "This is the contact persons of the downloadable tool or web user interface."
   contactPersons: JSON
+
   "A brief description of the web user interface or downloadable tool. Note: This field allows lightweight markup language with plain text formatting syntax. Line breaks within the text are preserved."
   description: String
+
   "The Digital Object Identifier (DOI) of the web user interface or downloadable tool."
   doi: String
+
   "The native id of a tool."
   nativeId: String
+
   "This element describes the latest date when the tool was most recently pushed to production for support and maintenance. "
   lastUpdatedDate: String
+
   "The long name of the downloadable tool or web user interface."
   longName: String
+
   "Requires the client, or user, to add in schema information into every tool record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema."
   metadataSpecification: JSON
+
   "The name of the downloadable tool or web user interface."
   name: String
+
   "The tool provider, or organization, or institution responsible for developing, archiving, and/or distributing the web user interface, software, or tool."
   organizations: JSON
+
   "This element contains information about a smart handoff from one web user interface to another."
   potentialAction: JSON
+
   "Provider ID of the Tool."
   providerId: String
+
   "Information about the quality of the downloadable tool or web user interface. This would include information about any quality assurance procedures followed in development. Note: This field allows lightweight markup language with plain text formatting syntax. Line breaks within the text are preserved."
   quality: JSON
+
   "A URL associated with the web user interface or downloadable tool, e.g., the home page for the tool provider which is responsible for the tool."
   relatedUrls: JSON
+
   "Date which the Tool was last updated."
   revisionDate: String
+
   "The revision id of the Tool."
   revisionId: String
+
   "This element contains information about a smart handoff from one web user interface to another."
   searchAction: JSON
+
   "The browser(s) and associated version supported by the web user interface."
   supportedBrowsers: JSON
+
   "The project element describes the list of input format names supported by the web user interface or downloadable tool."
   supportedInputFormats: JSON
+
   "The operating system(s) and associated version supported by the downloadable tool."
   supportedOperatingSystems: JSON
+
   "The project element describes the list of output format names supported by the web user interface or downloadable tool."
   supportedOutputFormats: JSON
+
   "The programming language(s) and associated version supported by the downloadable tool."
   supportedSoftwareLanguages: JSON
+
   "Allows for the specification of Earth Science keywords that are representative of the service, software, or tool being described. The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS)."
   toolKeywords: JSON
+
   "The type of the downloadable tool or web user interface."
   type: String
+
   "Raw UMM Metadata of the Tool Record."
   ummMetadata: JSON
+
   "The URL where you can directly access the web user interface or downloadable tool."
   url: JSON
+
   "Information on how the item (downloadable tool or web user interface) may or may not be used after access is granted. This includes any special restrictions, legal prerequisites, terms and conditions, and/or limitations on using the item. Providers may request acknowledgement of the item from users and claim no responsibility for quality and completeness."
   useConstraints: JSON
+
   "Id of the user who modified/published record"
   userId: String
+
   "The edition or version of the web user interface software, or tool. A value of 'NOT PROVIDED' may be used if the version is not available or unknown."
   version: String
+
   "This field provides users with information on what changes were included in the most recent version."
   versionDescription: String
+
+  "All revisions of this Tool."
+  revisions: ToolRevisionList
 
   collections (
     "Collections query parameters"
     params: CollectionsInput
+
     "The unique concept id assigned to the service."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "The number of collections requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
   ): CollectionList
 }
 
+type ToolRevisionList {
+  "The number of hits for a given search."
+  count: Int
+
+  "The list of tool search results."
+  items: [Tool]
+}
+
 type ToolList {
   "The number of hits for a given search."
   count: Int
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "The list of service search results."
   items: [Tool]
 }
@@ -92,20 +141,24 @@ type ToolList {
 input ToolsInput {
   "The unique concept id assigned to the tool."
   conceptId: [String]
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "Keyword search value."
   keyword: String
+
   "The number of tools requested by the user."
   limit: Int
+
   "Zero based offset of individual results."
   offset: Int
+
   "The name of the provider associated with the tool."
   provider: String
+
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: String
-  "Returns all revisions when set to true"
-  allRevisions: Boolean
 }
 
 input ToolInput {
@@ -117,14 +170,19 @@ type Query {
   tools (
     "Tools query parameters"
     params: ToolsInput
+
     "The unique concept id assigned to the tool."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "Cursor that points to the a specific position in a list of requested records."
     cursor: String @deprecated(reason: "Use `params.cursor`")
+
     "The number of servies requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
+
     "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
     sortKey: [String] @deprecated(reason: "Use `params.sortKey`")
   ): ToolList!
@@ -159,6 +217,7 @@ type Mutation {
 type ToolMutationResponse {
   "The unique concept id assigned to the tool."
   conceptId: String!
+
   "The revision of the tool."
   revisionId: String!
 }

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -1,80 +1,124 @@
 type Variable {
   "Any additional identifiers of a variable."
   additionalIdentifiers: JSON
+
   "The list of concepts and any data on the relationship between this variable and other permitted concepts"
   associationDetails: JSON
+
   "The unique concept id assigned to the variable."
   conceptId: String!
+
   "Specify data type of a variable. These types can be either: uint8, uint16, etc."
   dataType: String
+
   "The definition of the variable."
   definition: String
+
   "A variable consists of one or more dimensions. An example of a dimension name is 'XDim'. An example of a dimension size is '1200'. Variables are rarely one dimensional."
   dimensions: JSON
+
   "The fill value of the variable in the data file. It is generally a value which falls outside the valid range. For example, if the valid range is '0, 360', the fill value may be '-1'. The fill value type is data provider-defined. For example, 'Out of Valid Range'."
   fillValues: JSON
+
   "This element describes the x and y dimension ranges for this variable. Typically these values are 2 latitude and longitude ranges, but they don't necessarily have to be."
   indexRanges: JSON
+
   "Describes a store (zarr) where a variable has been separated from its original data files and saved as its own entity."
   instanceInformation: JSON
+
   "The expanded or long name related to the variable Name."
   longName: String
+
   "The measurement information of a variable."
   measurementIdentifiers: JSON
+
   "The name of a variable."
   name: String
+
   "The native id of a variable."
   nativeId: String
+
   "The offset is the value which is either added to or subtracted from all values in the stored data field in order to obtain the original values. May be used together with Scale. An example of an offset is '0.49'."
   offset: Float
+
   "Provider ID of the Variable."
   providerId: String
+
   "A described URL associated with the a web resource, or interface. e.g., the home page for the variable provider."
   relatedUrls: JSON
+
   "Date which the Variable was last updated."
   revisionDate: String
+
   "The revision id of the Variable."
   revisionId: String
+
   "The sampling information of a variable."
   samplingIdentifiers: JSON
+
   "The scale is the numerical factor by which all values in the stored data field are multiplied in order to obtain the original values. May be used together with Offset. An example of a scale factor is '0.002'."
   scale: Float
+
   "Controlled Science Keywords describing the collection. The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS)."
   scienceKeywords: JSON
+
   "The set information of a variable. The variable is grouped within a set. The set is defined by the name, type, size and index. For example, Name: 'Data_Fields', Type: 'General', Size: '15', Index: '7' for the case of the variable named 'LST_Day_1km'."
   sets: JSON
+
   "This is the more formal or scientific name, .e.g., the CF Standard Name."
   standardName: String
+
   "Raw UMM Metadata of the Variable Record."
   ummMetadata: JSON
+
   "The units associated with a variable."
   units: String
+
   "Id of the user who modified/published record"
   userId: String
+
   "Valid ranges of variable data values."
   validRanges: JSON
+
   "Specifies the sub type of a variable."
   variableSubType: String
+
   "Specify basic type of a variable."
   variableType: String
+  
+  "All revisions of this Variable."
+  revisions: VariableRevisionList
 
   collections (
     "Collections query parameters"
     params: CollectionsInput
+
     "The unique concept id assigned to the service."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "The number of collections requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
   ): CollectionList
 }
 
+type VariableRevisionList {
+  "The number of hits for a given search."
+  count: Int
+
+  "The list of variable search results."
+  items: [Variable]
+}
+
 type VariableList {
   "The number of hits for a given search."
   count: Int
+
   "Cursor that points to the a specific position in a list of requested records."
   cursor: String
+
   "The list of variable search results."
   items: [Variable]
 }
@@ -82,22 +126,27 @@ type VariableList {
 input VariablesInput {
   "The unique concept id assigned to the variable."
   conceptId: [String]
+
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
+
   "Keyword search value."
   keyword: String
+
   "The number of variables requested by the user."
   limit: Int
+
   "The name of a variable."
   name: String
+
   "Zero based offset of individual results."
   offset: Int
+
   "The name of the provider associated with the variable."
   provider: String
+
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: String
-  "Returns all revisions when set to true"
-  allRevisions: Boolean
 }
 
 input VariableInput {
@@ -109,16 +158,22 @@ type Query {
   variables (
     "Variables query parameters"
     params: VariablesInput
+
     "The unique concept id assigned to the variable."
     conceptId: [String] @deprecated(reason: "Use `params.conceptId`")
+
     "Cursor that points to the a specific position in a list of requested records."
     cursor: String @deprecated(reason: "Use `params.cursor`")
+
     "The number of variables requested by the user."
     limit: Int @deprecated(reason: "Use `params.limit`")
+
     "The name of a variable."
     name: String @deprecated(reason: "Use `params.name`")
+
     "Zero based offset of individual results."
     offset: Int @deprecated(reason: "Use `params.offset`")
+
     "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
     sortKey: [String] @deprecated(reason: "Use `params.sortKey`")
   ): VariableList!
@@ -126,6 +181,7 @@ type Query {
   variable (
     "Variable query parameters"
     params: VariableInput
+
     "The unique concept id assigned to the variable."
     conceptId: String @deprecated(reason: "Use `params.conceptId`")
   ): Variable
@@ -135,6 +191,7 @@ type Mutation {
   publishGeneratedVariables (
     "The collection concept Id."
     conceptId: String!
+
   ): VariableList
 
   restoreVariableRevision (

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -39,6 +39,10 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
       formattedConceptName = conceptName.toLowerCase()
     }
 
+    if (name === 'revisions') {
+      formattedConceptName = `${conceptName}Revision`
+    }
+
     isList = true
     const {
       [`${upperFirst(formattedConceptName)}List`]: conceptListKeysRequested
@@ -123,10 +127,11 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
     if (
       (
         requestedFields.includes('granules')
-        || requestedFields.includes('subscriptions')
-        || requestedFields.includes('relatedCollections')
         || requestedFields.includes('duplicateCollections')
         || requestedFields.includes('generateVariableDrafts')
+        || requestedFields.includes('relatedCollections')
+        || requestedFields.includes('revisions')
+        || requestedFields.includes('subscriptions')
       )
        && !requestedFields.includes('conceptId')) {
       requestedFields.push('conceptId')


### PR DESCRIPTION
# Overview

### What is the feature?

Adds a `revisions` return field for Collection, Service, Tool and Variable types.

### What areas of the application does this impact?

Collection, Service, Tool and Variable types have a new field, `revisions` which will return all of the revisions of each concept

# Testing

### Reproduction steps

Query for Collections, Services, Tools and Variables, include the `revisions` field and ensure all revisions (there is a CMR max of 10) are returned

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
