### PR TITLE
MMT-3645: Return [] over null when no results are found

### DIFF
--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -1009,12 +1009,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 services: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 services: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -1071,12 +1071,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 services: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 services: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -1580,12 +1580,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 tools: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 tools: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -1642,12 +1642,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 tools: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 tools: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -1860,12 +1860,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 variables: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 variables: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -1922,12 +1922,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 variables: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 variables: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -2140,12 +2140,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 dataQualitySummaries: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 dataQualitySummaries: {
-                  items: null
+                  items: []
                 }
               }]
             }
@@ -2202,12 +2202,12 @@ describe('Collection', () => {
               items: [{
                 conceptId: 'C100000-EDSC',
                 dataQualitySummaries: {
-                  items: null
+                  items: []
                 }
               }, {
                 conceptId: 'C100001-EDSC',
                 dataQualitySummaries: {
-                  items: null
+                  items: []
                 }
               }]
             }

--- a/src/resolvers/__tests__/orderOption.test.js
+++ b/src/resolvers/__tests__/orderOption.test.js
@@ -478,12 +478,12 @@ describe('OrderOption', () => {
               items: [{
                 form: '<Form />',
                 collections: {
-                  items: null
+                  items: []
                 }
               }, {
                 form: '<Form />',
                 collections: {
-                  items: null
+                  items: []
                 }
               }]
             }

--- a/src/resolvers/__tests__/service.test.js
+++ b/src/resolvers/__tests__/service.test.js
@@ -558,12 +558,12 @@ describe('Service', () => {
           items: [{
             conceptId: 'S100000-EDSC',
             variables: {
-              items: null
+              items: []
             }
           }, {
             conceptId: 'S100001-EDSC',
             variables: {
-              items: null
+              items: []
             }
           }]
         }
@@ -1059,7 +1059,7 @@ describe('Service', () => {
                       {
                         conceptId: 'S100000-EDSC',
                         orderOptions: {
-                          items: null
+                          items: []
                         }
                       }
                     ]
@@ -1144,7 +1144,7 @@ describe('Service', () => {
                       {
                         conceptId: 'S100000-EDSC',
                         orderOptions: {
-                          items: null
+                          items: []
                         }
                       }
                     ]
@@ -1237,7 +1237,7 @@ describe('Service', () => {
                       {
                         conceptId: 'S100000-EDSC',
                         orderOptions: {
-                          items: null
+                          items: []
                         }
                       }
                     ]
@@ -1301,7 +1301,7 @@ describe('Service', () => {
                 {
                   conceptId: 'C100000-EDSC',
                   services: {
-                    items: null
+                    items: []
                   }
                 }
               ]
@@ -1505,7 +1505,7 @@ describe('Service', () => {
             items: [{
               conceptId: 'S100000-EDSC',
               orderOptions: {
-                items: null
+                items: []
               }
             }]
           }

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -159,7 +159,7 @@ export default {
       if (!dataQualitySummaryConceptIds.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 
@@ -198,7 +198,7 @@ export default {
       if (!services.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 
@@ -267,7 +267,7 @@ export default {
       if (!tools.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 
@@ -295,7 +295,7 @@ export default {
       if (!variables.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 

--- a/src/resolvers/orderOption.js
+++ b/src/resolvers/orderOption.js
@@ -38,7 +38,7 @@ export default {
       if (!collections.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 

--- a/src/resolvers/service.js
+++ b/src/resolvers/service.js
@@ -102,7 +102,7 @@ export default {
       if (!collections.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 
@@ -129,7 +129,7 @@ export default {
       if (!orderOptionConceptIds.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 
@@ -159,7 +159,7 @@ export default {
       if (!variables.length) {
         return {
           count: 0,
-          items: null
+          items: []
         }
       }
 


### PR DESCRIPTION
Replaces default responses for search results with empty arrays, instead of `null`. 