### PR TITLE
MMT-3526: Updates the permitted_group parameter sent to CMR

### DIFF
--- a/src/cmr/concepts/acl.js
+++ b/src/cmr/concepts/acl.js
@@ -20,6 +20,16 @@ export default class Acl extends Concept {
   }
 
   /**
+   * Returns an array of keys that should not be indexed when sent to CMR
+   */
+  getNonIndexedKeys() {
+    return uniq([
+      ...super.getNonIndexedKeys(),
+      'permitted_group'
+    ])
+  }
+
+  /**
    * Parse and return the array of data from the nested response body
    * @param {Object} jsonResponse HTTP response from the CMR endpoint
    */

--- a/src/cmr/concepts/acl.js
+++ b/src/cmr/concepts/acl.js
@@ -1,7 +1,7 @@
 import pick from 'lodash/pick'
 import snakeCase from 'lodash/snakeCase'
-
 import snakecaseKeys from 'snakecase-keys'
+import uniq from 'lodash/uniq'
 
 import { accessControlRequest } from '../../utils/accessControlRequest'
 import { mergeParams } from '../../utils/mergeParams'

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -1,5 +1,5 @@
 import camelcaseKeys from 'camelcase-keys'
-import { uniq } from 'lodash'
+import uniq from 'lodash/uniq'
 
 import Concept from './concept'
 

--- a/src/cmr/concepts/collectionDraftProposal.js
+++ b/src/cmr/concepts/collectionDraftProposal.js
@@ -1,5 +1,6 @@
 import camelcaseKeys from 'camelcase-keys'
-import { get, pick } from 'lodash'
+import get from 'lodash/get'
+import pick from 'lodash/pick'
 import snakecaseKeys from 'snakecase-keys'
 
 import { draftMmtQuery } from '../../utils/draftMmtQuery'

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -2,11 +2,9 @@ import camelcaseKeys from 'camelcase-keys'
 import dasherize from 'dasherize'
 import snakeCaseKeys from 'snakecase-keys'
 
-import {
-  snakeCase,
-  get,
-  pick
-} from 'lodash'
+import get from 'lodash/get'
+import pick from 'lodash/pick'
+import snakeCase from 'lodash/snakeCase'
 
 import { v4 as uuidv4 } from 'uuid'
 

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -51,6 +51,7 @@ export default class Concept {
       conceptIds: 'conceptId',
       dataCenters: 'dataCenter',
       providerIds: 'providerId',
+      permittedGroups: 'permittedGroup',
       shortNames: 'shortName'
     }
   }

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -1,6 +1,7 @@
 import camelcaseKeys from 'camelcase-keys'
 
-import { pick, uniq } from 'lodash'
+import pick from 'lodash/pick'
+import uniq from 'lodash/uniq'
 
 import { pickIgnoringCase } from '../../utils/pickIgnoringCase'
 import { mergeParams } from '../../utils/mergeParams'

--- a/src/cmr/concepts/draftConcept.js
+++ b/src/cmr/concepts/draftConcept.js
@@ -1,5 +1,6 @@
 import camelcaseKeys from 'camelcase-keys'
-import { get, pick } from 'lodash'
+import get from 'lodash/get'
+import pick from 'lodash/pick'
 import snakecaseKeys from 'snakecase-keys'
 
 import { mergeParams } from '../../utils/mergeParams'

--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -1,4 +1,5 @@
-import { uniq } from 'lodash'
+import uniq from 'lodash/uniq'
+
 import Concept from './concept'
 
 export default class Granule extends Concept {

--- a/src/cmr/concepts/provider.js
+++ b/src/cmr/concepts/provider.js
@@ -1,7 +1,10 @@
+import kebabCase from 'lodash/kebabCase'
+import pick from 'lodash/pick'
 import snakecaseKeys from 'snakecase-keys'
-import { kebabCase, pick } from 'lodash'
+
 import { mergeParams } from '../../utils/mergeParams'
 import { providersQuery } from '../../utils/providersQuery'
+
 import Concept from './concept'
 
 export default class Provider extends Concept {

--- a/src/cmr/concepts/subscription.js
+++ b/src/cmr/concepts/subscription.js
@@ -1,6 +1,8 @@
-import { v4 as uuidv4 } from 'uuid'
 import camelcaseKeys from 'camelcase-keys'
-import { uniq } from 'lodash'
+import uniq from 'lodash/uniq'
+
+import { v4 as uuidv4 } from 'uuid'
+
 import { mergeParams } from '../../utils/mergeParams'
 
 import Concept from './concept'

--- a/src/cmr/concepts/tagDefinition.js
+++ b/src/cmr/concepts/tagDefinition.js
@@ -1,7 +1,9 @@
-import { pick } from 'lodash'
+import pick from 'lodash/pick'
 import snakecaseKeys from 'snakecase-keys'
+
 import { mergeParams } from '../../utils/mergeParams'
 import { tagDefinitionQuery } from '../../utils/tagDefinitionQuery'
+
 import Concept from './concept'
 
 export default class TagDefinition extends Concept {

--- a/src/datasources/graphDb.js
+++ b/src/datasources/graphDb.js
@@ -1,8 +1,6 @@
-import {
-  chunk,
-  fromPairs,
-  isObject
-} from 'lodash'
+import chunk from 'lodash/chunk'
+import fromPairs from 'lodash/fromPairs'
+import isObject from 'lodash/isObject'
 
 import { cmrGraphDb } from '../utils/cmrGraphDb'
 import { getUserPermittedGroups } from '../utils/getUserPermittedGroups'

--- a/src/datasources/graphDbDuplicateCollections.js
+++ b/src/datasources/graphDbDuplicateCollections.js
@@ -1,4 +1,5 @@
-import { chunk, isObject } from 'lodash'
+import chunk from 'lodash/chunk'
+import isObject from 'lodash/isObject'
 
 import { cmrGraphDb } from '../utils/cmrGraphDb'
 import { getUserPermittedGroups } from '../utils/getUserPermittedGroups'

--- a/src/types/acl.graphql
+++ b/src/types/acl.graphql
@@ -69,8 +69,11 @@ input AclsInput {
   "User is an URS user name corresponding to a member of a group that has access to an Acl."
   permittedUser: String
 
+  "Group that is permitted via this Acl."
+  permittedGroup: String
+
   "List of groups that are permitted via this Acl."
-  permittedGroup: [String]
+  permittedGroups: [String]
 
   "Provider that owns the Acl"
   provider: String

--- a/src/utils/mmtQuery.js
+++ b/src/utils/mmtQuery.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { snakeCase } from 'lodash'
+import snakeCase from 'lodash/snakeCase'
 
 import snakeCaseKeys from 'snakecase-keys'
 

--- a/src/utils/pickIgnoringCase.js
+++ b/src/utils/pickIgnoringCase.js
@@ -1,4 +1,4 @@
-import { pick } from 'lodash'
+import pick from 'lodash/pick'
 
 import { downcaseKeys } from './downcaseKeys'
 


### PR DESCRIPTION
Added permitted_group to configuration array that prevents the index of array values from being added on its way to CMR.