### PR TITLE
GQL-42: Retrieve user's EDL UID with launchpad tokens

### DIFF
--- a/src/datasources/__tests__/group.test.js
+++ b/src/datasources/__tests__/group.test.js
@@ -70,35 +70,129 @@ describe('group', () => {
   })
 
   describe('searchGroup', () => {
-    test('returns the user groups', async () => {
-      const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
-        data: [{
-          mock_data: 'Mock Data'
-        }]
+    describe('when wildcardTags is true', () => {
+      test('returns the user groups', async () => {
+        const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
+          data: [{
+            group_id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-2',
+            tag: 'MMT_1'
+          }]
+        })
+
+        const params = {
+          tags: ['MMT'],
+          wildcardTags: true
+        }
+        const context = {
+          headers: {}
+        }
+
+        const result = await searchGroup(params, context)
+
+        expect(result).toEqual({
+          count: 2,
+          items: [{
+            groupId: 'mock-group-1',
+            id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            groupId: 'mock-group-2',
+            id: 'mock-group-2',
+            tag: 'MMT_1'
+          }]
+        })
+
+        expect(edlRequestMock).toHaveBeenCalledTimes(1)
+        expect(edlRequestMock).toHaveBeenCalledWith({
+          context,
+          method: 'GET',
+          params,
+          pathType: edlPathTypes.SEARCH_GROUPS
+        })
       })
+    })
 
-      const params = {
-        tags: ['MMT_2']
-      }
-      const context = {
-        headers: {}
-      }
+    describe('when wildcardTags is false', () => {
+      test('returns the user groups', async () => {
+        const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
+          data: [{
+            group_id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-2',
+            tag: 'MMT_1'
+          }]
+        })
 
-      const result = await searchGroup(params, context)
+        const params = {
+          tags: ['MMT_2'],
+          wildcardTags: false
+        }
+        const context = {
+          headers: {}
+        }
 
-      expect(result).toEqual({
-        count: 1,
-        items: [{
-          mockData: 'Mock Data'
-        }]
+        const result = await searchGroup(params, context)
+
+        expect(result).toEqual({
+          count: 1,
+          items: [{
+            groupId: 'mock-group-1',
+            id: 'mock-group-1',
+            tag: 'MMT_2'
+          }]
+        })
+
+        expect(edlRequestMock).toHaveBeenCalledTimes(1)
+        expect(edlRequestMock).toHaveBeenCalledWith({
+          context,
+          method: 'GET',
+          params,
+          pathType: edlPathTypes.SEARCH_GROUPS
+        })
       })
+    })
 
-      expect(edlRequestMock).toHaveBeenCalledTimes(1)
-      expect(edlRequestMock).toHaveBeenCalledWith({
-        context,
-        method: 'GET',
-        params,
-        pathType: edlPathTypes.SEARCH_GROUPS
+    describe('when wildcardTags is undefined', () => {
+      test('returns the user groups', async () => {
+        const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
+          data: [{
+            group_id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-2',
+            tag: 'MMT_1'
+          }]
+        })
+
+        const params = {
+          tags: ['MMT_2']
+        }
+        const context = {
+          headers: {}
+        }
+
+        const result = await searchGroup(params, context)
+
+        expect(result).toEqual({
+          count: 1,
+          items: [{
+            groupId: 'mock-group-1',
+            id: 'mock-group-1',
+            tag: 'MMT_2'
+          }]
+        })
+
+        expect(edlRequestMock).toHaveBeenCalledTimes(1)
+        expect(edlRequestMock).toHaveBeenCalledWith({
+          context,
+          method: 'GET',
+          params,
+          pathType: edlPathTypes.SEARCH_GROUPS
+        })
       })
     })
 

--- a/src/datasources/group.js
+++ b/src/datasources/group.js
@@ -49,7 +49,22 @@ export const searchGroup = async (params, context, requestInfo) => {
     // Format the returned data to match the schema
     const camelcasedData = camelcaseKeys(result.data, { deep: true })
 
-    const updatedData = camelcasedData.map((group) => renameEdlId(group, 'groupId'))
+    const {
+      tags,
+      wildcardTags
+    } = params
+    let filteredData = camelcasedData
+
+    // EDL does a wildcard-ish search with the `tags` parameter, but that isn't ideal. By default we want
+    // the `tags` parameter to be exact, and the user should opt-in to a wildcard search by setting
+    // `wildcardTags` to `true`.
+    //
+    // If `wildcardTags` is falsey, narrow the results to exact matches of the `tags` parameter (if it exists).
+    if (tags && !wildcardTags) {
+      filteredData = camelcasedData.filter((group) => tags.includes(group.tag))
+    }
+
+    const updatedData = filteredData.map((group) => renameEdlId(group, 'groupId'))
 
     // Include `count` and `items` to match the schema's groupList
     return {

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -197,7 +197,12 @@ export default startServerAndCreateLambdaHandler(
         } else {
           // Get the edlUsername from the launchpad endpoint
           const [, launchpadToken] = bearerToken.split(' ')
-          const edlUsername = await fetchLaunchpadEdlUid(launchpadToken, edlClientToken)
+
+          let edlUsername
+          // If we don't have a token, don't try to call EDL
+          if (launchpadToken) {
+            edlUsername = await fetchLaunchpadEdlUid(launchpadToken, edlClientToken)
+          }
 
           if (edlUsername) {
             context.edlUsername = edlUsername

--- a/src/types/group.graphql
+++ b/src/types/group.graphql
@@ -42,8 +42,11 @@ input GroupsInput {
   "Parameter used to search for groups by user ids. Multiple user ids can be passed as a comma separated string or as an array. A group containing all users passed in will be returned."
   userIds: [String]
 
-  "Parameter used to search for groups by tags. Multiple tags can be passed as a comma separated string or as an array. A group that matches any of the tags passed in will be returned. This is a wildcard search and will return groups where the parameter matches any of the group's tag field."
+  "Parameter used to search for groups by tags. A group that matches any of the tags passed in will be returned. This field supports wildcard searches by setting `wildcardTags` to `true`."
   tags: [String]
+
+  "Setting to `true` will have the `tags` parameter act as a wildcard search, returning groups where the tag contains the provided tag. Setting to `false` will have the `tags` parameter be an exact search. Defaults to `false`."
+  wildcardTags: Boolean
 }
 
 input GroupInput {

--- a/src/utils/__tests__/fetchEdlClientToken.test.js
+++ b/src/utils/__tests__/fetchEdlClientToken.test.js
@@ -10,10 +10,6 @@ beforeEach(() => {
   }
 })
 
-global.fetch = vi.fn(() => Promise.resolve({
-  json: () => Promise.resolve()
-}))
-
 describe('Retrieving EDL Client Token', () => {
   test('returns token', async () => {
     nock(/example-urs/, 'grant_type=client_credentials')

--- a/src/utils/__tests__/fetchLaunchpadEdlUid.test.js
+++ b/src/utils/__tests__/fetchLaunchpadEdlUid.test.js
@@ -1,0 +1,38 @@
+import nock from 'nock'
+
+import fetchLaunchpadEdlUid from '../fetchLaunchpadEdlUid'
+
+beforeEach(() => {
+  process.env = {
+    ursRootUrl: 'https://example-urs.com'
+  }
+})
+
+describe('fetchLaunchpadEdlUid', () => {
+  test('returns uid', async () => {
+    nock(/example-urs/, 'token=mock-launchpad-token')
+      .post(/api\/nams\/edl_user_uid/)
+      .matchHeader('Authorization', 'Bearer mock-client-token')
+      .reply(200, {
+        uid: 'mock-uid'
+      })
+
+    const token = await fetchLaunchpadEdlUid('mock-launchpad-token', 'mock-client-token')
+
+    expect(token).toEqual('mock-uid')
+  })
+
+  test('returns undefined when the response from EDL is an error', async () => {
+    nock(/example-urs/, 'grant_type=client_credentials')
+      .post(/api\/nams\/edl_user_uid/)
+      .matchHeader('Authorization', 'Bearer mock-client-token')
+      .reply(400)
+
+    const token = await fetchLaunchpadEdlUid('mock-launchpad-token', 'mock-client-token')
+      .catch((error) => {
+        expect(error.message).toEqual('Request failed with status code 400')
+      })
+
+    expect(token).toEqual(undefined)
+  })
+})

--- a/src/utils/fetchLaunchpadEdlUid.js
+++ b/src/utils/fetchLaunchpadEdlUid.js
@@ -1,0 +1,28 @@
+import axios from 'axios'
+
+/**
+ * Uses the EDL API to retrieve the user's EDL UID given their launchpad token.
+ * @param {String} launchpadToken User's launchpad token
+ * @param {String} clientToken The EDL Client token
+ * @returns The user's EDL UID
+ */
+const fetchLaunchpadEdlUid = async (launchpadToken, clientToken) => {
+  const { ursRootUrl } = process.env
+
+  const url = `${ursRootUrl}/api/nams/edl_user_uid`
+  const authorizationHeader = `Bearer ${clientToken}`
+
+  const response = await axios.post(url, `token=${launchpadToken}`, {
+    headers: {
+      Authorization: authorizationHeader,
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  })
+
+  const { data } = response
+  const { uid } = data
+
+  return uid
+}
+
+export default fetchLaunchpadEdlUid


### PR DESCRIPTION
# Overview

### What is the feature?

Checking permissions for groups calls requires the user's EDL UID, which we didn't have for launchpad users. This PR adds a call to retrieve the EDL UID when the token provided is a launchpad token.

### What areas of the application does this impact?

Calls made with launchpad tokens, specifically those that need to check user permissions

# Testing

Submit groups queries/mutations using a launchpad token.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
