### PR TITLE
GQL-42: Fixes bug with launchpad tokens

### DIFF
--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -196,12 +196,11 @@ export default startServerAndCreateLambdaHandler(
           }
         } else {
           // Get the edlUsername from the launchpad endpoint
-          const [, launchpadToken] = bearerToken.split(' ')
-
           let edlUsername
+
           // If we don't have a token, don't try to call EDL
-          if (launchpadToken) {
-            edlUsername = await fetchLaunchpadEdlUid(launchpadToken, edlClientToken)
+          if (bearerToken) {
+            edlUsername = await fetchLaunchpadEdlUid(bearerToken, edlClientToken)
           }
 
           if (edlUsername) {

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -195,13 +195,8 @@ export default startServerAndCreateLambdaHandler(
             context.edlUsername = edlUsername
           }
         } else {
-          // Get the edlUsername from the launchpad endpoint
-          let edlUsername
-
-          // If we don't have a token, don't try to call EDL
-          if (bearerToken) {
-            edlUsername = await fetchLaunchpadEdlUid(bearerToken, edlClientToken)
-          }
+          // Get the edlUsername from the Launchpad endpoint
+          const edlUsername = await fetchLaunchpadEdlUid(bearerToken, edlClientToken)
 
           if (edlUsername) {
             context.edlUsername = edlUsername

--- a/src/permissions/__tests__/permissions.test.js
+++ b/src/permissions/__tests__/permissions.test.js
@@ -6,7 +6,8 @@ import permissions from '../index'
 
 import { canReadSystemGroups } from '../acls/canReadSystemGroups'
 import { canCreateSystemGroups } from '../acls/canCreateSystemGroups'
-import { isLocalMMTAdmin } from '../rules/isLocalMMTAdmin'
+
+import { isLocalMMT } from '../rules/isLocalMMT'
 
 vi.mock('graphql-shield', async () => {
   const original = await vi.importActual('graphql-shield')
@@ -23,25 +24,25 @@ describe('permissions', () => {
     expect(shield.mock.calls[0][0]).toEqual({
       Query: {
         group: race(
-          isLocalMMTAdmin,
+          isLocalMMT,
           canReadSystemGroups
         ),
         groups: race(
-          isLocalMMTAdmin,
+          isLocalMMT,
           canReadSystemGroups
         )
       },
       Mutation: {
         createGroup: race(
-          isLocalMMTAdmin,
+          isLocalMMT,
           canCreateSystemGroups
         ),
         deleteGroup: race(
-          isLocalMMTAdmin,
+          isLocalMMT,
           canCreateSystemGroups
         ),
         updateGroup: race(
-          isLocalMMTAdmin,
+          isLocalMMT,
           canCreateSystemGroups
         )
       }

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -6,33 +6,34 @@ import {
 
 import { canReadSystemGroups } from './acls/canReadSystemGroups'
 import { canCreateSystemGroups } from './acls/canCreateSystemGroups'
-import { isLocalMMTAdmin } from './rules/isLocalMMTAdmin'
+
+import { isLocalMMT } from './rules/isLocalMMT'
 
 const permissions = shield(
   {
     Query: {
       // The `race` rule allows you to chain the rules so that execution stops once one of them returns.
-      // So if the `isLocalMMTAdmin` rule passes, don't bother checking the permissions of the user
+      // So if the `isLocalMMT` rule passes, don't bother checking the permissions of the user
       group: race(
-        isLocalMMTAdmin,
+        isLocalMMT,
         canReadSystemGroups
       ),
       groups: race(
-        isLocalMMTAdmin,
+        isLocalMMT,
         canReadSystemGroups
       )
     },
     Mutation: {
       createGroup: race(
-        isLocalMMTAdmin,
+        isLocalMMT,
         canCreateSystemGroups
       ),
       deleteGroup: race(
-        isLocalMMTAdmin,
+        isLocalMMT,
         canCreateSystemGroups
       ),
       updateGroup: race(
-        isLocalMMTAdmin,
+        isLocalMMT,
         canCreateSystemGroups
       )
     }

--- a/src/permissions/rules/__tests__/isLocalMMT.test.js
+++ b/src/permissions/rules/__tests__/isLocalMMT.test.js
@@ -1,6 +1,6 @@
-import { isLocalMMTAdmin } from '../isLocalMMTAdmin'
+import { isLocalMMT } from '../isLocalMMT'
 
-describe('isLocalMMTAdmin', () => {
+describe('isLocalMMT', () => {
   const OLD_ENV = process.env
 
   beforeEach(() => {
@@ -14,7 +14,7 @@ describe('isLocalMMTAdmin', () => {
   test('returns true if the request is offline and has the admin token', async () => {
     process.env.IS_OFFLINE = true
 
-    const result = await isLocalMMTAdmin.resolve(
+    const result = await isLocalMMT.resolve(
       null,
       {},
       {
@@ -30,7 +30,7 @@ describe('isLocalMMTAdmin', () => {
   test('returns false if the request is offline but a real token is passed', async () => {
     process.env.IS_OFFLINE = true
 
-    const result = await isLocalMMTAdmin.resolve(
+    const result = await isLocalMMT.resolve(
       null,
       {},
       {
@@ -46,7 +46,7 @@ describe('isLocalMMTAdmin', () => {
   test('returns false if the request is not offline', async () => {
     process.env.IS_OFFLINE = false
 
-    const result = await isLocalMMTAdmin.resolve(
+    const result = await isLocalMMT.resolve(
       null,
       {},
       {

--- a/src/permissions/rules/isLocalMMT.js
+++ b/src/permissions/rules/isLocalMMT.js
@@ -1,19 +1,18 @@
 import { rule } from 'graphql-shield'
 
 import { downcaseKeys } from '../../utils/downcaseKeys'
+import { isOfflineMMT } from '../../utils/isOfflineMMT'
 
 /**
  * Check to see if the request is made while running in dev mode (IS_OFFLINE),
- * and is coming from the MMT's local admin (token ABC-1).
+ * and is coming from the local MMT (token ABC-1).
  */
-export const isLocalMMTAdmin = rule()(async (parent, params, context) => {
+export const isLocalMMT = rule()(async (parent, params, context) => {
   const { headers } = context
 
   const {
     authorization: token
   } = downcaseKeys(headers)
 
-  if (process.env.IS_OFFLINE && token === 'ABC-1') return true
-
-  return false
+  return isOfflineMMT(token)
 })

--- a/src/utils/__tests__/fetchLaunchpadEdlUid.test.js
+++ b/src/utils/__tests__/fetchLaunchpadEdlUid.test.js
@@ -2,13 +2,20 @@ import nock from 'nock'
 
 import fetchLaunchpadEdlUid from '../fetchLaunchpadEdlUid'
 
-beforeEach(() => {
-  process.env = {
-    ursRootUrl: 'https://example-urs.com'
-  }
-})
-
 describe('fetchLaunchpadEdlUid', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...OLD_ENV,
+      ursRootUrl: 'https://example-urs.com'
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
   test('returns uid', async () => {
     nock(/example-urs/, 'token=mock-launchpad-token')
       .post(/api\/nams\/edl_user_uid/)
@@ -20,6 +27,13 @@ describe('fetchLaunchpadEdlUid', () => {
     const token = await fetchLaunchpadEdlUid('mock-launchpad-token', 'mock-client-token')
 
     expect(token).toEqual('mock-uid')
+  })
+
+  test('returns null for the local MMT', async () => {
+    process.env.IS_OFFLINE = true
+    const token = await fetchLaunchpadEdlUid('ABC-1', 'mock-client-token')
+
+    expect(token).toBeNull()
   })
 
   test('returns undefined when the response from EDL is an error', async () => {

--- a/src/utils/__tests__/isOfflineMMT.test.js
+++ b/src/utils/__tests__/isOfflineMMT.test.js
@@ -1,0 +1,43 @@
+import { isOfflineMMT } from '../isOfflineMMT'
+
+describe('isOfflineMMT', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...OLD_ENV,
+      ursRootUrl: 'https://example-urs.com'
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('when running offline with the local MMT token', () => {
+    test('returns true', async () => {
+      process.env.IS_OFFLINE = true
+      const token = await isOfflineMMT('ABC-1')
+
+      expect(token).toEqual(true)
+    })
+  })
+
+  describe('when running online with the local MMT token', () => {
+    test('returns false', async () => {
+      process.env.IS_OFFLINE = false
+      const token = await isOfflineMMT('ABC-1')
+
+      expect(token).toEqual(false)
+    })
+  })
+
+  describe('when running online a regular token', () => {
+    test('returns false', async () => {
+      process.env.IS_OFFLINE = false
+      const token = await isOfflineMMT('mock-token')
+
+      expect(token).toEqual(false)
+    })
+  })
+})

--- a/src/utils/fetchLaunchpadEdlUid.js
+++ b/src/utils/fetchLaunchpadEdlUid.js
@@ -1,5 +1,7 @@
 import axios from 'axios'
 
+import { isOfflineMMT } from './isOfflineMMT'
+
 /**
  * Uses the EDL API to retrieve the user's EDL UID given their launchpad token.
  * @param {String} launchpadToken User's launchpad token
@@ -8,6 +10,9 @@ import axios from 'axios'
  */
 const fetchLaunchpadEdlUid = async (launchpadToken, clientToken) => {
   const { ursRootUrl } = process.env
+
+  // If the token is the local MMT, don't call launchpad
+  if (isOfflineMMT(launchpadToken)) return null
 
   const url = `${ursRootUrl}/api/nams/edl_user_uid`
   const authorizationHeader = `Bearer ${clientToken}`

--- a/src/utils/isOfflineMMT.js
+++ b/src/utils/isOfflineMMT.js
@@ -1,0 +1,6 @@
+/**
+ * Returns true if the app is running in offline mode and the token is 'ABC-1'
+ * @param {String} token User token to check
+ * @returns Boolean
+ */
+export const isOfflineMMT = (token) => process.env.IS_OFFLINE && token === 'ABC-1'


### PR DESCRIPTION
# Overview

### What is the feature?

Launchpad tokens don't use the `Bearer ` prefix, my previous PR assumed they did. This PR removes that logic

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
