### PR TITLE
GQL-42: Implements paging for groups query

### DIFF
--- a/src/datasources/__tests__/group.test.js
+++ b/src/datasources/__tests__/group.test.js
@@ -83,8 +83,10 @@ describe('group', () => {
         })
 
         const params = {
-          tags: ['MMT'],
-          wildcardTags: true
+          params: {
+            tags: ['MMT'],
+            wildcardTags: true
+          }
         }
         const context = {
           headers: {}
@@ -128,8 +130,10 @@ describe('group', () => {
         })
 
         const params = {
-          tags: ['MMT_2'],
-          wildcardTags: false
+          params: {
+            tags: ['MMT_2'],
+            wildcardTags: false
+          }
         }
         const context = {
           headers: {}
@@ -169,7 +173,9 @@ describe('group', () => {
         })
 
         const params = {
-          tags: ['MMT_2']
+          params: {
+            tags: ['MMT_2']
+          }
         }
         const context = {
           headers: {}
@@ -182,6 +188,57 @@ describe('group', () => {
           items: [{
             groupId: 'mock-group-1',
             id: 'mock-group-1',
+            tag: 'MMT_2'
+          }]
+        })
+
+        expect(edlRequestMock).toHaveBeenCalledTimes(1)
+        expect(edlRequestMock).toHaveBeenCalledWith({
+          context,
+          method: 'GET',
+          params,
+          pathType: edlPathTypes.SEARCH_GROUPS
+        })
+      })
+    })
+
+    describe('when there are more than 1 page of results', () => {
+      test('returns the user groups limited', async () => {
+        const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
+          data: [{
+            group_id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-2',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-3',
+            tag: 'MMT_2'
+          }]
+        })
+
+        const params = {
+          params: {
+            tags: ['MMT_2'],
+            limit: 2,
+            offset: 0
+          }
+        }
+        const context = {
+          headers: {}
+        }
+
+        const result = await searchGroup(params, context)
+
+        expect(result).toEqual({
+          count: 3,
+          items: [{
+            groupId: 'mock-group-1',
+            id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            groupId: 'mock-group-2',
+            id: 'mock-group-2',
             tag: 'MMT_2'
           }]
         })

--- a/src/datasources/__tests__/group.test.js
+++ b/src/datasources/__tests__/group.test.js
@@ -253,6 +253,55 @@ describe('group', () => {
       })
     })
 
+    describe('when excludeTags is provided', () => {
+      test('returns the user groups', async () => {
+        const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockResolvedValue({
+          data: [{
+            group_id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-2',
+            tag: 'MMT_2'
+          }, {
+            group_id: 'mock-group-3',
+            tag: 'MMT_1'
+          }]
+        })
+
+        const params = {
+          params: {
+            excludeTags: ['MMT_1']
+          }
+        }
+        const context = {
+          headers: {}
+        }
+
+        const result = await searchGroup(params, context)
+
+        expect(result).toEqual({
+          count: 2,
+          items: [{
+            groupId: 'mock-group-1',
+            id: 'mock-group-1',
+            tag: 'MMT_2'
+          }, {
+            groupId: 'mock-group-2',
+            id: 'mock-group-2',
+            tag: 'MMT_2'
+          }]
+        })
+
+        expect(edlRequestMock).toHaveBeenCalledTimes(1)
+        expect(edlRequestMock).toHaveBeenCalledWith({
+          context,
+          method: 'GET',
+          params,
+          pathType: edlPathTypes.SEARCH_GROUPS
+        })
+      })
+    })
+
     describe('when the request errors', () => {
       test('calls parseError', async () => {
         const edlRequestMock = vi.spyOn(edlRequest, 'edlRequest').mockImplementation(async () => {

--- a/src/datasources/group.js
+++ b/src/datasources/group.js
@@ -53,6 +53,7 @@ export const searchGroup = async (params, context, requestInfo) => {
 
     const { params: searchParams } = params
     const {
+      excludeTags,
       limit = 20,
       offset = 0,
       tags,
@@ -67,6 +68,11 @@ export const searchGroup = async (params, context, requestInfo) => {
     // If `wildcardTags` is falsey, narrow the results to exact matches of the `tags` parameter (if it exists).
     if (tags && !wildcardTags) {
       filteredData = camelcasedData.filter((group) => tags.includes(group.tag))
+    }
+
+    // If the `excludeTags` parameter is included, only return groups that do not match the values provided
+    if (excludeTags) {
+      filteredData = filteredData.filter((group) => !excludeTags.includes(group.tag))
     }
 
     // Fake paging until EDL supports paging parameters

--- a/src/types/group.graphql
+++ b/src/types/group.graphql
@@ -47,6 +47,12 @@ input GroupsInput {
 
   "Setting to `true` will have the `tags` parameter act as a wildcard search, returning groups where the tag contains the provided tag. Setting to `false` will have the `tags` parameter be an exact search. Defaults to `false`."
   wildcardTags: Boolean
+
+  "The number of groups requested by the user."
+  limit: Int
+
+  "Zero based offset of individual results."
+  offset: Int
 }
 
 input GroupInput {

--- a/src/types/group.graphql
+++ b/src/types/group.graphql
@@ -48,6 +48,9 @@ input GroupsInput {
   "Setting to `true` will have the `tags` parameter act as a wildcard search, returning groups where the tag contains the provided tag. Setting to `false` will have the `tags` parameter be an exact search. Defaults to `false`."
   wildcardTags: Boolean
 
+  "Parameter used to exclude groups that exactly match the provided tags."
+  excludeTags: [String]
+
   "The number of groups requested by the user."
   limit: Int
 


### PR DESCRIPTION
# Overview

### What is the feature?

Implements paging for groups query by adding `limit` and `offset`. Defaults `limit` to `20` and `offset` to `0`

### What areas of the application does this impact?

`groups` query

# Testing

Perform `groups` query that will return many results, like `name: ""`. Ensure you see full groups count but only 20 results. 
Perform same query and provide `limit` and `offset` parameters

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
