### PR TITLE
GQL-48: Add provider id to order options

### DIFF
--- a/src/types/orderOption.graphql
+++ b/src/types/orderOption.graphql
@@ -20,6 +20,9 @@ type OrderOption {
   "The native ID to set on the order option."
   nativeId: String
 
+  "The provider ID to set on the order option."
+  providerId: String
+
   "The revision date for the order option."
   revisionDate: String
 


### PR DESCRIPTION
# Overview

### What is the feature?

Add provider id to order options

### What is the Solution?

Added providerId to the query

### What areas of the application does this impact?

orderOption queries

# Testing

### Reproduction steps

- **Environment for testing:** N/A
- **Collection to test with:** N/A

1. Query for a providerId on an order option and confirm it returns as expected

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
