### PR TITLE
ECHOACCESS-158: Add cursor to related collections

### DIFF
--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -481,6 +481,8 @@ interface Relationship {
 type RelatedCollectionsList {
   "The number of related collections available."
   count: Int
+  "Cursor that points to the/a specific position in a list of requested records."
+  cursor: String
   "The list of related collections."
   items: [RelatedCollection]
 }


### PR DESCRIPTION
# Overview

### What is the feature?

This small change is needed in SIT in order to create pagination in Access

### What is the Solution?

Adding a cursor to Related Collections

### What areas of the application does this impact?

Collection.graphql

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: local one

1. call cursor on Collection >> Related Collections


### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ x] I have added automated tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
