### PR TITLE
MMT-3702: Adjust MMT Variable to Collection associations to use updated GraphQL operation

### DIFF
--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -1330,58 +1330,6 @@ describe('Draft', () => {
             }
           })
         })
-
-        test('returns an error when collection concept id not provided', async () => {
-          nock(/example-cmr/, {
-            reqheaders: {
-              accept: 'application/json',
-              'client-id': 'eed-test-graphql',
-              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
-              'cmr-request-id': 'abcd-1234-efgh-5678'
-            }
-          })
-            .defaultReplyHeaders({
-              'CMR-Took': 7,
-              'CMR-Request-Id': 'abcd-1234-efgh-5678'
-            })
-            .put(/ingest\/publish\/TD100000-EDSC\/tool-1/)
-            .reply(201, {
-              'concept-id': 'T100000-EDSC',
-              'revision-id': '1'
-            })
-
-          const response = await server.executeOperation({
-            variables: {
-              draftConceptId: 'TD100000-EDSC',
-              nativeId: 'tool-1',
-              ummVersion: '1.0.0',
-              collectionConceptId: 'C100000-EDSC'
-            },
-            query: `mutation PublishDraft(
-                    $draftConceptId: String!
-                    $nativeId: String!
-                    $ummVersion: String!
-                    $collectionConceptId: String
-                  ) {
-                    publishDraft(
-                      draftConceptId: $draftConceptId
-                      nativeId: $nativeId
-                      ummVersion: $ummVersion
-                      collectionConceptId: $collectionConceptId
-                    ) {
-                      conceptId
-                      revisionId
-                      warnings
-                      existingErrors
-                    }
-                  }`
-          }, {
-            contextValue
-          })
-          const { errors } = response.body.singleResult
-          const { message } = errors[0]
-          expect(message).toEqual('Invalid Argument, collectionConceptId. Collection Concept ID is only required when publishing a Variable Draft.')
-        })
       })
     })
   })
@@ -1784,20 +1732,17 @@ describe('Draft', () => {
             variables: {
               draftConceptId: 'VD100000-EDSC',
               nativeId: 'variable-1',
-              ummVersion: '1.0.0',
-              collectionConceptId: 'C100000-EDSC'
+              ummVersion: '1.0.0'
             },
             query: `mutation PublishDraft(
               $draftConceptId: String!
               $nativeId: String!
               $ummVersion: String!
-              $collectionConceptId: String
             ) {
               publishDraft(
                 draftConceptId: $draftConceptId
                 nativeId: $nativeId
                 ummVersion: $ummVersion
-                collectionConceptId: $collectionConceptId
               ) {
                 conceptId
                 revisionId
@@ -1819,55 +1764,6 @@ describe('Draft', () => {
               existingErrors: null
             }
           })
-        })
-
-        test('returns an error when collection concept id not provided', async () => {
-          nock(/example-cmr/, {
-            reqheaders: {
-              accept: 'application/json',
-              'client-id': 'eed-test-graphql',
-              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
-              'cmr-request-id': 'abcd-1234-efgh-5678'
-            }
-          })
-            .defaultReplyHeaders({
-              'CMR-Took': 7,
-              'CMR-Request-Id': 'abcd-1234-efgh-5678'
-            })
-            .put(/ingest\/publish\/VD100000-EDSC\/variable-1/)
-            .reply(201, {
-              'concept-id': 'V100000-EDSC',
-              'revision-id': '1'
-            })
-
-          const response = await server.executeOperation({
-            variables: {
-              draftConceptId: 'VD100000-EDSC',
-              nativeId: 'variable-1',
-              ummVersion: '1.0.0'
-            },
-            query: `mutation PublishDraft(
-                    $draftConceptId: String!
-                    $nativeId: String!
-                    $ummVersion: String!
-                  ) {
-                    publishDraft(
-                      draftConceptId: $draftConceptId
-                      nativeId: $nativeId
-                      ummVersion: $ummVersion
-                    ) {
-                      conceptId
-                      revisionId
-                      warnings
-                      existingErrors
-                    }
-                  }`
-          }, {
-            contextValue
-          })
-          const { errors } = response.body.singleResult
-          const { message } = errors[0]
-          expect(message).toEqual('collectionConceptId required. When publishing a Variable Draft, an associated Collection Concept Id is required')
         })
       })
     })

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -28,17 +28,6 @@ export default {
     },
     publishDraft: async (source, args, context, info) => {
       const { dataSources } = context
-      const { draftConceptId, collectionConceptId } = args
-
-      // Checks if collectionConceptId is present when publishing a Variable Draft
-      if (isDraftConceptId(draftConceptId, 'variable') && !collectionConceptId) {
-        throw new Error('collectionConceptId required. When publishing a Variable Draft, an associated Collection Concept Id is required')
-      }
-
-      // Checks if collectionConcept is present when publishing a non Variable draft
-      if (!isDraftConceptId(draftConceptId, 'variable') && collectionConceptId) {
-        throw new Error('Invalid Argument, collectionConceptId. Collection Concept ID is only required when publishing a Variable Draft.')
-      }
 
       const result = await dataSources.draftSourcePublish(
         args,

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -93,8 +93,6 @@ type Mutation {
     nativeId: String!
     "UMM Version of the record being published."
     ummVersion: String!
-    "Associated Collection concept-id "
-    collectionConceptId: String
   ): PublishDraftMutationResponse
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

CMR removed the requirement for a variable draft to have a collection concept-id associated when publish a variable record. This PR is removing the check for collectionConceptId for variable draft


# Testing

### Reproduction steps


1. Create a Variable draft
2. Publish the variable draft without specifying a collection concept id

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
