### PR TITLE
GQL-52: Allow querying for Acls from within a group

### DIFF
--- a/src/resolvers/__tests__/acl.test.js
+++ b/src/resolvers/__tests__/acl.test.js
@@ -592,6 +592,64 @@ describe('Acl', () => {
           })
         })
       })
+
+      describe('when the acl does not have catalogItemIdentity', () => {
+        test('returns null for collections', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 1,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/access-control\/acls/)
+            .reply(200, {
+              items: [
+                {
+                  acl: {}
+                }
+              ]
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `
+                  query GetAcls($params: AclsInput) {
+                    acls(params: $params) {
+                      items {
+                        catalogItemIdentity {
+                          granuleApplicable
+                          collectionApplicable
+                        }
+                        collections {
+                          count
+                        }
+                      }
+                    }
+                  }`
+
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            acls: {
+              items: [
+                {
+                  catalogItemIdentity: {
+                    collectionApplicable: null,
+                    granuleApplicable: null
+                  },
+                  collections: null
+                }
+              ]
+            }
+          })
+        })
+      })
     })
 
     describe('acls', () => {

--- a/src/resolvers/acl.js
+++ b/src/resolvers/acl.js
@@ -137,7 +137,7 @@ export default {
     },
 
     catalogItemIdentity: async (source) => {
-      const { catalogItemIdentity } = source
+      const { catalogItemIdentity = {} } = source
 
       const camelcasedData = camelcaseKeys(catalogItemIdentity, { deep: true })
 

--- a/src/resolvers/group.js
+++ b/src/resolvers/group.js
@@ -1,5 +1,6 @@
 import { parseResolveInfo } from 'graphql-parse-resolve-info'
 import { parseRequestedFields } from '../utils/parseRequestedFields'
+import { handlePagingParams } from '../utils/handlePagingParams'
 
 export default {
   Query: {
@@ -79,6 +80,23 @@ export default {
         context,
         requestInfo
       )
+    },
+
+    acls: async (source, args, context, info) => {
+      const { groupId } = source
+
+      const { dataSources } = context
+
+      const a = await dataSources.aclSourceFetch(
+        handlePagingParams({
+          ...args,
+          permittedGroup: groupId
+        }),
+        context,
+        parseResolveInfo(info)
+      )
+
+      return a
     }
   }
 }

--- a/src/resolvers/group.js
+++ b/src/resolvers/group.js
@@ -87,7 +87,7 @@ export default {
 
       const { dataSources } = context
 
-      const a = await dataSources.aclSourceFetch(
+      return dataSources.aclSourceFetch(
         handlePagingParams({
           ...args,
           permittedGroup: groupId
@@ -95,8 +95,6 @@ export default {
         context,
         parseResolveInfo(info)
       )
-
-      return a
     }
   }
 }

--- a/src/types/acl.graphql
+++ b/src/types/acl.graphql
@@ -36,7 +36,6 @@ type Acl {
     "Collections query parameters"
     params: CollectionsInput
   ) : CollectionList
-
 }
 
 type CatalogItemIdentity {
@@ -129,7 +128,7 @@ input AclsInput {
   "Type of the object being controlled."
   identityType: IdentityType
 
-  "The size of the range GraphDB searches on. Defaults to 20."
+  "The number of Acls to return."
   limit: Int
 
   "Zero based offset of individual results."

--- a/src/types/group.graphql
+++ b/src/types/group.graphql
@@ -25,6 +25,20 @@ type Group {
 
   "List of members of the group."
   members: GroupMemberList
+
+  "List of Acls this group belongs to."
+  acls (
+    "Group acls query parameters."
+    params: GroupAclsInput
+  ): AclList
+}
+
+input GroupAclsInput {
+  "The number of Acls to return."
+  limit: Int
+
+  "Zero based offset of individual results."
+  offset: Int
 }
 
 type GroupList {


### PR DESCRIPTION
# Overview

### What is the feature?

Adds the ability to query for Acls that belong to a group, from within a group query.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
