### PR TITLE
GQL-60: As a CMR GraphQL operator, I want to query new UMM-C v1.18.1 in the search response

### DIFF
--- a/serverless-configs/env.yml
+++ b/serverless-configs/env.yml
@@ -27,7 +27,7 @@ default_env: &default_env
     lambdaTimeout: ${env:LAMBDA_TIMEOUT, '30'}
 
     # Pinned UMM versions
-    ummCollectionVersion: '1.18.0'
+    ummCollectionVersion: '1.18.1'
     ummGranuleVersion: '1.6.5'
     ummOrderOptionVersion: '1.0.0'
     ummServiceVersion: '1.5.3'


### PR DESCRIPTION
# Overview

### What is the feature?

Update umm-c version from 1.18.0 to 1.18.1

New changes to umm 1.18.1 are: 
- UMM-C schema added "minimum": 0 for Size in GetDataType.
- UMM-C schema added "minimum": 0 for AverageFileSize, TotalCollectionFileSize in FileArchiveInformationType and FileDistributionInformationType.

### What is the Solution?

There were no new fields added and these changes do not need any GraphQL schema change. Updates the ummCollectionVersion in env.yml


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X]  My changes generate no new warnings
