### PR TITLE
GQL-61: As a user, I can read and update provider level group permissions

### DIFF
--- a/src/permissions/__tests__/permissions.test.js
+++ b/src/permissions/__tests__/permissions.test.js
@@ -4,8 +4,9 @@ import { race, shield } from 'graphql-shield'
 // eslint-disable-next-line no-unused-vars
 import permissions from '../index'
 
-import { canReadSystemGroups } from '../acls/canReadSystemGroups'
+import { canCreateProviderGroups } from '../acls/canCreateProviderGroups'
 import { canCreateSystemGroups } from '../acls/canCreateSystemGroups'
+import { canReadSystemGroups } from '../acls/canReadSystemGroups'
 
 import { isLocalMMT } from '../rules/isLocalMMT'
 
@@ -35,7 +36,8 @@ describe('permissions', () => {
       Mutation: {
         createGroup: race(
           isLocalMMT,
-          canCreateSystemGroups
+          canCreateProviderGroups,
+          canCreateSystemGroups,
         ),
         deleteGroup: race(
           isLocalMMT,
@@ -43,7 +45,8 @@ describe('permissions', () => {
         ),
         updateGroup: race(
           isLocalMMT,
-          canCreateSystemGroups
+          canCreateProviderGroups,
+          canCreateSystemGroups,
         )
       }
     })

--- a/src/permissions/acls/__tests__/canCreateProviderGroups.test.js
+++ b/src/permissions/acls/__tests__/canCreateProviderGroups.test.js
@@ -1,0 +1,53 @@
+import { canCreateProviderGroups } from '../canCreateProviderGroups'
+
+import * as hasPermission from '../../../utils/hasPermission'
+import { forbiddenError } from '../../../utils/forbiddenError'
+
+describe('canCreateProviderGroups', () => {
+  test('when a tag is provided and the user has access to provider permission', async () => {
+    vi.spyOn(hasPermission, 'hasPermission').mockResolvedValue(true)
+
+    const result = await canCreateProviderGroups.resolve(
+      null,
+      {
+        tag: 'MOCK-PROVIDER'
+      },
+      {
+        edlUsername: 'test-user'
+      }
+    )
+
+    expect(result).toEqual(true)
+  })
+
+  test('throws a ForbiddenError if the user does not have permission', async () => {
+    vi.spyOn(hasPermission, 'hasPermission').mockResolvedValue(false)
+
+    const result = await canCreateProviderGroups.resolve(
+      null,
+      {
+        tag: 'MOCK-PROVIDER'
+      },
+      {
+        edlUsername: 'test-user'
+      }
+    )
+
+    expect(result).toEqual(forbiddenError('Not authorized to perform [create] on provider object [GROUP]'))
+  })
+
+  test('when a tag is not provided and the user does not have permission', async () => {
+    vi.spyOn(hasPermission, 'hasPermission').mockResolvedValue(false)
+
+    const result = await canCreateProviderGroups.resolve(
+      null,
+      {
+        tag: 'CMR'
+      },
+      {
+        edlUsername: 'test-user'
+      }
+    )
+    expect(result).toEqual(false)
+  })
+})

--- a/src/permissions/acls/__tests__/canCreateSystemGroups.test.js
+++ b/src/permissions/acls/__tests__/canCreateSystemGroups.test.js
@@ -23,12 +23,29 @@ describe('canCreateSystemGroups', () => {
 
     const result = await canCreateSystemGroups.resolve(
       null,
-      {},
+      {
+        tag: 'CMR'
+      },
       {
         edlUsername: 'test-user'
       }
     )
 
     expect(result).toEqual(forbiddenError('Not authorized to perform [create] on system object [GROUP]'))
+  })
+
+  test('returns true if the tag is CMR and the user has system permission', async () => {
+    vi.spyOn(hasPermission, 'hasPermission').mockResolvedValue(true)
+
+    const result = await canCreateSystemGroups.resolve(
+      null,
+      {
+        tag: 'CMR'
+      },
+      {
+        edlUsername: 'test-user'
+      }
+    )
+    expect(result).toEqual(true)
   })
 })

--- a/src/permissions/acls/__tests__/canReadSystemGroups.test.js
+++ b/src/permissions/acls/__tests__/canReadSystemGroups.test.js
@@ -9,7 +9,11 @@ describe('canReadSystemGroups', () => {
 
     const result = await canReadSystemGroups.resolve(
       null,
-      {},
+      {
+        params: {
+          tags: ['CMR']
+        }
+      },
       {
         edlUsername: 'test-user'
       }
@@ -23,12 +27,30 @@ describe('canReadSystemGroups', () => {
 
     const result = await canReadSystemGroups.resolve(
       null,
-      {},
+      {
+        params: {
+          tags: ['CMR']
+        }
+      },
       {
         edlUsername: 'test-user'
       }
     )
 
     expect(result).toEqual(forbiddenError('Not authorized to perform [read] on system object [GROUP]'))
+  })
+
+  test('returns true if no tags are provided', async () => {
+    vi.spyOn(hasPermission, 'hasPermission').mockResolvedValue(true)
+
+    const result = await canReadSystemGroups.resolve(
+      null,
+      {},
+      {
+        edlUsername: 'test-user'
+      }
+    )
+
+    expect(result).toEqual(true)
   })
 })

--- a/src/permissions/acls/canCreateProviderGroups.js
+++ b/src/permissions/acls/canCreateProviderGroups.js
@@ -1,0 +1,38 @@
+import { rule } from 'graphql-shield'
+
+import { hasPermission } from '../../utils/hasPermission'
+import { forbiddenError } from '../../utils/forbiddenError'
+
+/**
+ * Check to see if the user can create provider groups using
+ * the cmr permissions api. In order to create provider groups, the user must have the `create`
+ * permission on the GROUP provider_object.
+ * @method
+ * @return {(true|ForbiddenError)}
+ */
+export const canCreateProviderGroups = rule()(async (parent, params, context) => {
+  const { edlUsername } = context
+
+  const { tag } = params
+
+  // If tag, perform check to see if the user has access to the given provider.
+  if (tag) {
+    if (
+      await hasPermission(
+        context,
+        {
+          permissions: 'create',
+          permissionOptions: {
+            provider: tag,
+            target: 'GROUP',
+            user_id: edlUsername
+          }
+        }
+      )
+    ) return true
+
+    return forbiddenError('Not authorized to perform [create] on provider object [GROUP]')
+  }
+
+  return true
+})

--- a/src/permissions/acls/canCreateProviderGroups.js
+++ b/src/permissions/acls/canCreateProviderGroups.js
@@ -16,7 +16,7 @@ export const canCreateProviderGroups = rule()(async (parent, params, context) =>
   const { tag } = params
 
   // If tag, perform check to see if the user has access to the given provider.
-  if (tag) {
+  if (tag && tag !== 'CMR') {
     if (
       await hasPermission(
         context,
@@ -34,5 +34,5 @@ export const canCreateProviderGroups = rule()(async (parent, params, context) =>
     return forbiddenError('Not authorized to perform [create] on provider object [GROUP]')
   }
 
-  return true
+  return false
 })

--- a/src/permissions/acls/canCreateSystemGroups.js
+++ b/src/permissions/acls/canCreateSystemGroups.js
@@ -33,5 +33,5 @@ export const canCreateSystemGroups = rule()(async (parent, params, context) => {
     return forbiddenError('Not authorized to perform [create] on system object [GROUP]')
   }
 
-  return false
+  return true
 })

--- a/src/permissions/acls/canCreateSystemGroups.js
+++ b/src/permissions/acls/canCreateSystemGroups.js
@@ -13,18 +13,25 @@ import { forbiddenError } from '../../utils/forbiddenError'
 export const canCreateSystemGroups = rule()(async (parent, params, context) => {
   const { edlUsername } = context
 
-  if (
-    await hasPermission(
-      context,
-      {
-        permissions: 'create',
-        permissionOptions: {
-          user_id: edlUsername,
-          system_object: 'GROUP'
-        }
-      }
-    )
-  ) return true
+  const { tag } = params
 
-  return forbiddenError('Not authorized to perform [create] on system object [GROUP]')
+  // If the tag is CMR, perform check to see if the user has access to system group.
+  if (tag === 'CMR') {
+    if (
+      await hasPermission(
+        context,
+        {
+          permissions: 'create',
+          permissionOptions: {
+            user_id: edlUsername,
+            system_object: 'GROUP'
+          }
+        }
+      )
+    ) return true
+
+    return forbiddenError('Not authorized to perform [create] on system object [GROUP]')
+  }
+
+  return false
 })

--- a/src/permissions/acls/canReadSystemGroups.js
+++ b/src/permissions/acls/canReadSystemGroups.js
@@ -13,7 +13,7 @@ import { forbiddenError } from '../../utils/forbiddenError'
 export const canReadSystemGroups = rule()(async (parent, params, context) => {
   const { edlUsername } = context
 
-  const { params: requestedParams } = params
+  const { params: requestedParams = {} } = params
 
   const { tags } = requestedParams
 

--- a/src/permissions/acls/canReadSystemGroups.js
+++ b/src/permissions/acls/canReadSystemGroups.js
@@ -13,18 +13,29 @@ import { forbiddenError } from '../../utils/forbiddenError'
 export const canReadSystemGroups = rule()(async (parent, params, context) => {
   const { edlUsername } = context
 
-  if (
-    await hasPermission(
-      context,
-      {
-        permissions: 'read',
-        permissionOptions: {
-          user_id: edlUsername,
-          system_object: 'GROUP'
-        }
-      }
-    )
-  ) return true
+  const { params: requestedParams } = params
 
-  return forbiddenError('Not authorized to perform [read] on system object [GROUP]')
+  const { tags } = requestedParams
+
+  const isSystemPermission = tags?.includes('CMR')
+
+  // If the tags includes CMR (SYSTEM) check if the user has access to read system groups
+  if (isSystemPermission) {
+    if (
+      await hasPermission(
+        context,
+        {
+          permissions: 'read',
+          permissionOptions: {
+            user_id: edlUsername,
+            system_object: 'GROUP'
+          }
+        }
+      )
+    ) return true
+
+    return forbiddenError('Not authorized to perform [read] on system object [GROUP]')
+  }
+
+  return true
 })

--- a/src/permissions/index.js
+++ b/src/permissions/index.js
@@ -8,6 +8,7 @@ import { canReadSystemGroups } from './acls/canReadSystemGroups'
 import { canCreateSystemGroups } from './acls/canCreateSystemGroups'
 
 import { isLocalMMT } from './rules/isLocalMMT'
+import { canCreateProviderGroups } from './acls/canCreateProviderGroups'
 
 const permissions = shield(
   {
@@ -26,7 +27,8 @@ const permissions = shield(
     Mutation: {
       createGroup: race(
         isLocalMMT,
-        canCreateSystemGroups
+        canCreateProviderGroups,
+        canCreateSystemGroups,
       ),
       deleteGroup: race(
         isLocalMMT,
@@ -34,7 +36,8 @@ const permissions = shield(
       ),
       updateGroup: race(
         isLocalMMT,
-        canCreateSystemGroups
+        canCreateProviderGroups,
+        canCreateSystemGroups,
       )
     }
   },


### PR DESCRIPTION
# Overview

### What is the feature?

In MMT, a user reported that even they don't have system level permission they should still be able to view their provider level permission.

### What is the Solution?

Updates the rules and checking in shield. 

**Query**

- If params.tag includes CMR, check if the user has system level permission
- Else let them read permission 

**Mutation**

- If params.tag includes CMR, check if the user has system level permission

- If params.tag does not include CMR and includes some other provider, check if the user has create group permission for that provider

- If the user does not have a tag, allow them to update. 

### What areas of the application does this impact?

List impacted areas. SIT/UAT/PROD

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
