### PR TITLE
GQL-70: GraphQL granules call returns error during expanded temporal range. 

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -29,6 +29,8 @@ export default class Concept {
   constructor(conceptType, headers = {}, requestInfo = {}, params = {}) {
     // Set properties for data available during instantiation
     this.conceptType = conceptType
+
+    // Make a copy of headers so that new additional headers do not get propogated to any sub query calls
     this.headers = { ...headers }
     this.requestInfo = requestInfo
 

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -29,7 +29,7 @@ export default class Concept {
   constructor(conceptType, headers = {}, requestInfo = {}, params = {}) {
     // Set properties for data available during instantiation
     this.conceptType = conceptType
-    this.headers = headers
+    this.headers = { ...headers }
     this.requestInfo = requestInfo
 
     // Defaults the result set to an empty object


### PR DESCRIPTION
# Overview

### What is the feature?

The headers value gets modified with a search-after header when using a cursor. The search-after header is persisting when calling granule query with a subquery of collection.

### What is the Solution?

Make a copy of the headers value so the original headers value isn't modified.

### What areas of the application does this impact?

graphQL calls for a Granule query with a Collection subquery when passing in a cursor.

# Testing

### Reproduction steps

Run the following query in PROD(need to make sure you pass in a cursor and it returns more than 20 items):

query getGranules($params: GranulesInput) {
    granules(params: $params) {
      count
      cursor
      items {
        title
        conceptId
        collection

{           conceptId           shortName           version           title         }
        cloudCover
        lines
        boxes
        polygons
        points
        links
        timeStart
        timeEnd
        relatedUrls
      }
    }
  }

 

Variables:

{
  "params":

{   "provider": "LPCLOUD",   "entryId": [     "HLSL30_2.0"   ],   "polygon": [     "-120.1,49,-120,49,-120,49.1,-120.5,49.1,-120.1,49"   ],   "temporal": "2013-07-01T00:00:00Z/2013-09-22T23:59:59Z",   "cursor": "eyJqc29uIjoiW1wibHBjbG91ZFwiLDEzNzkxODQ2NjMyMzYsMjI0MTk3NzE5Nl0iLCJ1bW0iOiJbXCJscGNsb3VkXCIsMTM3OTE4NDY2MzIzNiwyMjQxOTc3MTk2XSJ9"   }
}

- **Environment for testing:**
This is in PROD
- **Collection to test with:**
HLSL30_2.0

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
