### PR TITLE
GQL-75: Encodes native id before sending it to CMR.

### DIFF
--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -454,7 +454,7 @@ export default class Concept {
       data: preparedParameters,
       headers: preparedHeaders,
       options: {
-        path: `ingest/providers/${providerId}/${this.getConceptType()}/${nativeId}`,
+        path: `ingest/providers/${providerId}/${this.getConceptType()}/${encodeURIComponent(nativeId)}`,
         ...options
       }
     })

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -271,7 +271,7 @@ export default class Draft extends Concept {
       data: prepDataForCmr,
       headers: permittedHeaders,
       options: {
-        path: `ingest/publish/${draftConceptId}/${nativeId}`
+        path: `ingest/publish/${draftConceptId}/${encodeURIComponent(nativeId)}`
       }
     })
   }

--- a/src/cmr/concepts/subscription.js
+++ b/src/cmr/concepts/subscription.js
@@ -117,7 +117,7 @@ export default class Subscription extends Concept {
     const { nativeId = uuidv4() } = params
 
     super.ingest(data, requestedKeys, providedHeaders, {
-      path: `ingest/subscriptions/${nativeId}`
+      path: `ingest/subscriptions/${encodeURIComponent(nativeId)}`
     })
   }
 
@@ -134,6 +134,6 @@ export default class Subscription extends Concept {
 
     const { nativeId } = params
 
-    super.delete(data, requestedKeys, providedHeaders, { path: `ingest/subscriptions/${nativeId}` })
+    super.delete(data, requestedKeys, providedHeaders, { path: `ingest/subscriptions/${encodeURIComponent(nativeId)}` })
   }
 }

--- a/src/datasources/__tests__/draft.test.js
+++ b/src/datasources/__tests__/draft.test.js
@@ -633,6 +633,36 @@ describe('draft#publish', () => {
     })
   })
 
+  test('handles native ids with special characters', async () => {
+    nock(/example/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .put(/ingest\/publish\/CD100000-EDSC\/mock-native%2Fid/)
+      .reply(201, {
+        'concept-id': 'C100000-EDSC',
+        'revision-id': '1'
+      })
+
+    // Native id includes a / so ensure it gets encoded before sending to CMR.
+    const response = await draftSourcePublish({
+      draftConceptId: 'CD100000-EDSC',
+      nativeId: 'mock-native/id',
+      providerId: 'EDSC',
+      ummVersion: '1.0.0'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'C100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
   test('catches errors received from ingestCmr', async () => {
     nock(/example/)
       .put(/ingest\/publish\/CD100000-EDSC\/mock-native-id/, JSON.stringify({}))

--- a/src/datasources/__tests__/draft.test.js
+++ b/src/datasources/__tests__/draft.test.js
@@ -439,6 +439,57 @@ describe('draft#ingest', () => {
     })
   })
 
+  test('handles native ids with special characters', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .put(/ingest\/providers\/EDSC\/tool-drafts\/test-guid%2Ftest-slash/, JSON.stringify({
+        Name: 'mock name',
+        URL: {
+          URLContentType: 'DistributionURL',
+          Type: 'GOTO WEB TOOL',
+          Description: 'Landing Page',
+          URLValue: 'https://example.com/'
+        },
+        MetadataSpecification: {
+          URL: 'https://cdn.earthdata.nasa.gov/umm/tool/v1.0.0',
+          Name: 'UMM-T',
+          Version: '1.0.0'
+        }
+      }))
+      .reply(201, {
+        'concept-id': 'TD100000-EDSC',
+        'revision-id': '1'
+      })
+
+    const response = await draftSourceIngest({
+      conceptType: 'Tool',
+      metadata: {
+        Name: 'mock name',
+        URL: {
+          URLContentType: 'DistributionURL',
+          Type: 'GOTO WEB TOOL',
+          Description: 'Landing Page',
+          URLValue: 'https://example.com/'
+        }
+      },
+      nativeId: 'test-guid/test-slash',
+      providerId: 'EDSC',
+      ummVersion: '1.0.0'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'TD100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
   test('catches errors received from ingestCmr', async () => {
     nock(/example-cmr/)
       .put(/ingest\/providers\/EDSC\/tool-drafts\/test-guid/)
@@ -522,6 +573,34 @@ describe('draft#delete', () => {
     const response = await draftSourceDelete({
       conceptType: 'Tool',
       nativeId: 'test-guid',
+      providerId: 'EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'TD100000-EDSC',
+      revisionId: '1'
+    })
+  })
+
+  test('handles native ids with special characters', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .delete(/ingest\/providers\/EDSC\/tool-drafts\/test-guid%2Ftest-slash/)
+      .reply(201, {
+        'concept-id': 'TD100000-EDSC',
+        'revision-id': '1'
+      })
+
+    const response = await draftSourceDelete({
+      conceptType: 'Tool',
+      nativeId: 'test-guid/test-slash',
       providerId: 'EDSC'
     }, {
       headers: {
@@ -638,7 +717,7 @@ describe('draft#publish', () => {
       .defaultReplyHeaders({
         'CMR-Request-Id': 'abcd-1234-efgh-5678'
       })
-      .put(/ingest\/publish\/CD100000-EDSC\/mock-native%2Fid/)
+      .put(/ingest\/publish\/CD100000-EDSC\/mock-native-id%2Ftest-slash/)
       .reply(201, {
         'concept-id': 'C100000-EDSC',
         'revision-id': '1'
@@ -647,7 +726,7 @@ describe('draft#publish', () => {
     // Native id includes a / so ensure it gets encoded before sending to CMR.
     const response = await draftSourcePublish({
       draftConceptId: 'CD100000-EDSC',
-      nativeId: 'mock-native/id',
+      nativeId: 'mock-native-id/test-slash',
       providerId: 'EDSC',
       ummVersion: '1.0.0'
     }, {

--- a/src/utils/cmrDelete.js
+++ b/src/utils/cmrDelete.js
@@ -32,7 +32,7 @@ export const cmrDelete = async ({
 
   // Default options
   const {
-    path = `ingest/providers/${providerId}/${conceptType}/${nativeId}`
+    path = `ingest/providers/${providerId}/${conceptType}/${encodeURIComponent(nativeId)}`
   } = options
 
   // Merge default headers into the provided headers and then pick out only permitted values


### PR DESCRIPTION
# Overview

### What is the feature?

LPDAAC ran into an issue in MMT in production and couldn't publish their draft record.
https://mmt.earthdata.nasa.gov/drafts/collections/CD3244307783-LPCLOUD
After some initial investigation it was determined that the native id was not fully URL encoded: The Original Native ID is:
"native-id" : "VIIRS/NPP BRDF/Albedo Model Parameters Daily L3 Global 1km SIN Grid V002"
The CMR request has it as: 
VIIRS/NPP%20BRDF/Albedo%20Model%20Parameters%20Daily%20L3%20Global%201km%20SIN%20Grid%20V002
The non encoded slashes / are adding to the invalid URL:
/ingest/publish/CD3244307783-LPCLOUD/VIIRS/NPP%20BRDF/Albedo%20Model%20Parameters%20Daily%20L3%20Global%201km%20SIN%20Grid%20V002
So the CMR can't find the correct API endpoint.

### What is the Solution?

I looked through all the files where `{nativeId}` was being used in a URL and now encoding the native id.

### What areas of the application does this impact?

Publish endpoint
Delete endpoint
Ingest endpoint
Ingest and delete on subscription 

# Testing

1.   Ingest a record into CMR where its native ids have /'s
2.  Try to publish it
3. Try deleting the record also

Note, it was not just /'s, one record had "Last of the Wild Project, Version 2, 2005 (LWP-2): Global Human Influence Index (HII) Dataset (IGHP)" as the native id which also didn't work when trying to publish.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
