### PR TITLE
GQL-80: Adds content-type header to subscription ingest requests. Fixes undefined request id in error message

### DIFF
--- a/src/cmr/concepts/subscription.js
+++ b/src/cmr/concepts/subscription.js
@@ -116,7 +116,12 @@ export default class Subscription extends Concept {
     // Use the provided native id and provider id
     const { nativeId = uuidv4() } = params
 
-    super.ingest(data, requestedKeys, providedHeaders, {
+    const headers = {
+      ...providedHeaders,
+      'Content-Type': 'application/vnd.nasa.cmr.umm+json'
+    }
+
+    super.ingest(data, requestedKeys, headers, {
       path: `ingest/subscriptions/${encodeURIComponent(nativeId)}`
     })
   }

--- a/src/datasources/__tests__/subscription.test.js
+++ b/src/datasources/__tests__/subscription.test.js
@@ -384,6 +384,7 @@ describe('subscription#ingest', () => {
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
+        .matchHeader('Content-Type', 'application/vnd.nasa.cmr.umm+json')
         .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/, JSON.stringify({
           CollectionConceptId: 'C100000-EDSC',
           EmailAddress: 'test@example.com',
@@ -429,6 +430,7 @@ describe('subscription#ingest', () => {
         .defaultReplyHeaders({
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
+        .matchHeader('Content-Type', 'application/vnd.nasa.cmr.umm+json')
         .put(/ingest\/subscriptions\/test-guid/, JSON.stringify({
           CollectionConceptId: 'C100000-EDSC',
           EmailAddress: 'test@example.com',
@@ -516,6 +518,7 @@ describe('subscription#ingest', () => {
   test('catches errors received from ingestCmr', async () => {
     nock(/example-cmr/)
       .put(/ingest\/subscriptions\/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed/)
+      .matchHeader('Content-Type', 'application/vnd.nasa.cmr.umm+json')
       .reply(500, {
         errors: ['HTTP Error']
       }, {

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -269,7 +269,8 @@ export default startServerAndCreateLambdaHandler(
         collectionLoader: new DataLoader(getCollectionsById, {
           cacheKeyFn: (obj) => obj.conceptId
         }),
-        headers: requestHeaders
+        headers: requestHeaders,
+        requestId: newRequestId
       }
     },
     middleware: [

--- a/src/types/subscription.graphql
+++ b/src/types/subscription.graphql
@@ -175,4 +175,6 @@ type SubscriptionMutationResponse {
   conceptId: String
   "The revision of the subscription."
   revisionId: String
+  "The native id of the subscription."
+  nativeId: String
 }


### PR DESCRIPTION
# Overview

### What is the feature?

CMR GraphQL was unable to create or edit subscriptions. CMR was returning an invalid content type error.

### What is the Solution?

Include the correct `Content-Type` header on subscription ingest requests.

I also fixed the issue where our error message did not include the `requestId`

### What areas of the application does this impact?

Subscription mutations

# Testing

### Reproduction steps

Create mutation:
```
mutation CreateSubscription($params: CreateSubscriptionInput) {
  createSubscription(
    params: $params
  ) {
    conceptId
    revisionId
    nativeId
  }
}
```
Variables:
```
{
  "params": {
    "name": "Example Subscription",
    "query": "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78",
    "subscriberId": "YOUR USERNAME",
    "type": "collection"
  }
}
```

Also remember to include an EDL token with the request.

Update mutation:
Be sure to copy the `nativeId` out of the response from the create mutation
```
mutation UpdateSubscription($params: UpdateSubscriptionInput) {
  updateSubscription(params: $params) {
    conceptId
    revisionId
  }
}
```
Variables:
```
{
  "params": {
    "nativeId": "NATIVEID FROM CREATE MUTATION",
    "name": "Example Subscription 2",
    "query": "polygon=-18,-78,-13,-74,-16,-73,-22,-77,-18,-78",
    "subscriberId": "YOUR USERNAME",
    "type": "collection"
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
