### PR TITLE
GQL-79: exposed EntryId

### DIFF
--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -64,6 +64,7 @@ describe('Collection', () => {
               coordinate_system: 'CARTESIAN',
               data_center: 'PORTA',
               dataset_id: 'Condimentum Quam Mattis Cursus Pharetra',
+              entry_id: 'LOREM-QUAM_1.0.0',
               has_formats: true,
               has_granules: true,
               has_spatial_subsetting: true,
@@ -327,6 +328,7 @@ describe('Collection', () => {
               directDistributionInformation
               directoryNames
               doi
+              entryId
               hasFormats
               hasGranules
               hasSpatialSubsetting
@@ -486,6 +488,7 @@ describe('Collection', () => {
                 version: 'A.1'
               }
             },
+            entryId: 'LOREM-QUAM_1.0.0',
             hasFormats: true,
             hasGranules: true,
             hasSpatialSubsetting: true,

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -86,6 +86,9 @@ type Collection {
   "Entry Title"
   entryTitle: String @deprecated(reason: "Use `title`.")
 
+  "Entry Id is the concatenation of short name, an underscore, and version of the corresponding collection"
+  entryId: String
+
   "The File Naming Convention refers to the naming convention of the data set's (Collection's) data files along with a description of the granule file construction."
   fileNamingConvention: JSON
 


### PR DESCRIPTION
# Overview

### What is the feature?

Exposed EntryId to collections graphql requests

### What is the Solution?

Added EntryId to collection.graphql
### What areas of the application does this impact?

graphql-cmr

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. make a new graphql call with the following query
query GetProjectCollections(
  $params: CollectionsInput
) {
  collections(params: $params) {
    items {
      entryId
      shortName
      version
    }
  }
}

2. ensure entryId is returned in the response

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
