### PR TITLE
GQL-69: GraphQL granules call returns random results

### DIFF
--- a/serverless-configs/env.yml
+++ b/serverless-configs/env.yml
@@ -26,6 +26,10 @@ default_env: &default_env
     # Timeout for lambda
     lambdaTimeout: ${env:LAMBDA_TIMEOUT, '30'}
 
+    # Refetch variables
+    maxRetries:  ${env:MAX_RETRIES, '1'}
+    retryDelay: ${env:RETRY_DELAY, '1000'}
+
     # Pinned UMM versions
     ummCollectionVersion: '1.18.1'
     ummGranuleVersion: '1.6.5'

--- a/src/cmr/concepts/__tests__/concept.test.js
+++ b/src/cmr/concepts/__tests__/concept.test.js
@@ -30,22 +30,6 @@ describe('collection', () => {
           expect(concept.getItemCount()).toEqual(84)
         })
       })
-
-      describe('both json and umm keys but count is different', () => {
-        test('throws an error', () => {
-          const concept = new Concept('concept', {}, {
-            jsonKeys: ['jsonKey'],
-            ummKeys: ['ummKey']
-          })
-
-          concept.setJsonItemCount(84)
-          concept.setUmmItemCount(32617)
-
-          expect(() => {
-            concept.getItemCount()
-          }).toThrow('Inconsistent data prevented GraphQL from correctly parsing results (JSON Hits: 84, UMM Hits: 32617)')
-        })
-      })
     })
   })
 })

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -208,9 +208,12 @@ export default class Concept {
    */
   async fetchWithRetry(missingIds, keys, fetchFunction, parseFunction, retryCount = 0) {
     const {
-      maxRetries,
-      retryDelay
+      maxRetries: maxRetriesEnv,
+      retryDelay: retryDelayEnv
     } = process.env
+
+    const maxRetries = parseInt(maxRetriesEnv, 10)
+    const retryDelay = parseInt(retryDelayEnv, 10)
 
     const response = await fetchFunction(missingIds, keys)
     const fetchedItems = parseFunction(response)

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -207,8 +207,10 @@ export default class Concept {
    * @param {Integer} retryCount - Current retry attempt count
    */
   async fetchWithRetry(missingIds, keys, fetchFunction, parseFunction, retryCount = 0) {
-    const MAX_RETRIES = 1
-    const RETRY_DELAY = 1000
+    const {
+      maxRetries,
+      retryDelay
+    } = process.env
 
     const response = await fetchFunction(missingIds, keys)
     const fetchedItems = parseFunction(response)
@@ -217,10 +219,10 @@ export default class Concept {
       return { fetchedItems }
     }
 
-    if (retryCount < MAX_RETRIES) {
+    if (retryCount < maxRetries) {
       console.log(`Retry ${retryCount + 1}: ${missingIds} were missing. Retrying...`)
 
-      await new Promise((resolve) => { setTimeout(resolve, RETRY_DELAY) })
+      await new Promise((resolve) => { setTimeout(resolve, retryDelay) })
 
       return this.fetchWithRetry(missingIds, keys, fetchFunction, parseFunction, retryCount + 1)
     }

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -378,8 +378,8 @@ describe('granule', () => {
 
   describe('with json and umm keys', () => {
     beforeEach(() => {
-      process.env.maxRetries = 1
-      process.env.retryDelay = 1000
+      process.env.maxRetries = '1'
+      process.env.retryDelay = '1000'
 
       // Overwrite default requestInfo
       requestInfo = {

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -473,6 +473,654 @@ describe('granule', () => {
         }]
       })
     })
+
+    describe('when JSON and UMM hit counts differ, but returned items match', () => {
+      test('return the parsed granule results', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 85,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'G100000-EDSC',
+                browse_flag: true
+              }]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'G100000-EDSC'
+              },
+              umm: {
+                GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+              }
+            }]
+          })
+
+        const response = await granuleDatasource({
+          params: {
+            concept_id: 'G100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: null,
+          items: [{
+            conceptId: 'G100000-EDSC',
+            browseFlag: true,
+            granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+          }]
+        })
+      })
+    })
+
+    describe('when JSON and UMM hit counts differ and umm item count differ', () => {
+      test('should fetch missing UMM data and return combined results with correct counts', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100001-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100002-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'G100000-EDSC'
+              },
+              umm: {
+                GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+              }
+            }]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100002-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+                }
+              }
+            ]
+          })
+
+        const response = await granuleDatasource({
+          params: {
+            concept_id: 'G100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 3,
+          cursor: null,
+          items: [
+            {
+              conceptId: 'G100000-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+            },
+            {
+              conceptId: 'G100001-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+            },
+            {
+              conceptId: 'G100002-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+            }
+          ]
+        })
+      })
+    })
+
+    describe('when JSON and UMM hit counts differ and json item count differ', () => {
+      test('should fetch missing JSON data and return combined results with correct count', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100000-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100002-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+                }
+              }
+
+            ]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100001-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100002-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        const response = await granuleDatasource({
+          params: {
+            concept_id: 'G100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+        // Console.log('🚀 ~ expect ~ response:', response)
+
+        expect(response).toEqual({
+          count: 3,
+          cursor: null,
+          items: [
+            {
+              conceptId: 'G100000-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+            },
+            {
+              conceptId: 'G100001-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+            },
+            {
+              conceptId: 'G100002-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+            }
+          ]
+        })
+      })
+    })
+
+    describe('when first retry does not get all of missing umm concepts', () => {
+      test('should fetch missing concepts again and return combined result', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100001-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100002-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'G100000-EDSC'
+              },
+              umm: {
+                GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+              }
+            }]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              }
+            ]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100002-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+                }
+              }
+            ]
+          })
+
+        const response = await granuleDatasource({
+          params: {
+            concept_id: 'G100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 3,
+          cursor: null,
+          items: [
+            {
+              conceptId: 'G100000-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+            },
+            {
+              conceptId: 'G100001-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+            },
+            {
+              conceptId: 'G100002-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+            }
+          ]
+        })
+      })
+    })
+
+    describe('when first retry does not get all of missing json concepts', () => {
+      test('should fetch missing concepts again and return combined result', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100000-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100002-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+                }
+              }
+
+            ]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100001-EDSC',
+                  browse_flag: true
+                },
+                {
+                  id: 'G100002-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        const response = await granuleDatasource({
+          params: {
+            concept_id: 'G100000-EDSC'
+          }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 3,
+          cursor: null,
+          items: [
+            {
+              conceptId: 'G100000-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+            },
+            {
+              conceptId: 'G100001-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+            },
+            {
+              conceptId: 'G100002-EDSC',
+              browseFlag: true,
+              granuleUr: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+            }
+          ]
+        })
+      })
+    })
+
+    describe('when JSON and UMM hit counts differ and max retry attempts are reached', () => {
+      test('throws an error after max retries', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 3,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.umm_json/)
+          .reply(200, {
+            items: [
+              {
+                meta: {
+                  'concept-id': 'G100000-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.020.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100001-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.021.nc4'
+                }
+              },
+              {
+                meta: {
+                  'concept-id': 'G100002-EDSC'
+                },
+                umm: {
+                  GranuleUR: 'GLDAS_CLSM025_D.2.0:GLDAS_CLSM025_D.A19480101.022.nc4'
+                }
+              }
+
+            ]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100000-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/granules\.json/)
+          .reply(200, {
+            feed: {
+              entry: [
+                {
+                  id: 'G100001-EDSC',
+                  browse_flag: true
+                }
+              ]
+            }
+          })
+
+        await expect(granuleDatasource({
+          params: { concept_id: 'G100000-EDSC' }
+        }, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)).rejects.toThrow('Inconsistent data prevented GraphQL from correctly parsing results')
+      })
+    })
   })
 
   describe('with only umm keys', () => {

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -378,6 +378,9 @@ describe('granule', () => {
 
   describe('with json and umm keys', () => {
     beforeEach(() => {
+      process.env.maxRetries = 1
+      process.env.retryDelay = 1000
+
       // Overwrite default requestInfo
       requestInfo = {
         name: 'granules',

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -731,7 +731,6 @@ describe('granule', () => {
             'CMR-Request-Id': 'abcd-1234-efgh-5678'
           }
         }, requestInfo)
-        // Console.log('🚀 ~ expect ~ response:', response)
 
         expect(response).toEqual({
           count: 3,

--- a/src/datasources/granule.js
+++ b/src/datasources/granule.js
@@ -17,6 +17,7 @@ export default async (params, context, parsedInfo) => {
   // Parse the response from CMR
   await granule.parse(requestInfo)
 
-  // Return a formatted JSON response
+  await granule.validateResponse(requestInfo)
+
   return granule.getFormattedResponse()
 }

--- a/src/datasources/granule.js
+++ b/src/datasources/granule.js
@@ -17,7 +17,9 @@ export default async (params, context, parsedInfo) => {
   // Parse the response from CMR
   await granule.parse(requestInfo)
 
+  // Validates consistency between JSON and UMM data, if present
   await granule.validateResponse(requestInfo)
 
+  // Return a formatted JSON response
   return granule.getFormattedResponse()
 }


### PR DESCRIPTION
# Overview

### What is the feature?

In CMR STAC we are calling a `Granule` query which has collections fields. In order to complete this request, GraphQL calls `.umm_json` and `.json` endpoint in CMR. Depending on the usage of CMR, something we are seeing an error: `Inconsistent data prevented GraphQL from correctly parsing results (JSON Hits: 151344631, UMM Hits: 151344630)`.

### What is the Solution?
If CMR Hits are different, we are now comparing the formats that were returned.
1. If the CMR Hits are the same, return the result.
2. If the CMR Hits are different but the list of items from both response are the same, return the result.
3. If the CMR Hits are different and the list of items from both response are not the same, figure out which endpoint the conceptId is missing and try to refetch. 
    - If the missing concept is found, add the missing concept to the result.
    - If the missing concept is still not found then display the error.

### What areas of the application does this impact?
Queries that request both json and umm data.

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
