### PR TITLE
GQL-89: Honor the linkTypes param when it is nested within GranulesInput params

### DIFF
--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -2,6 +2,8 @@ import uniq from 'lodash/uniq'
 
 import Concept from './concept'
 
+import { mergeParams } from '../../utils/mergeParams'
+
 export default class Granule extends Concept {
   /**
    * Instantiates a Granule object
@@ -134,7 +136,7 @@ export default class Granule extends Concept {
     // eslint-disable-next-line no-param-reassign
     item.concept_id = conceptId
 
-    const { linkTypes = [] } = this.params
+    const { linkTypes = [] } = mergeParams(this.params)
 
     // If linkTypes parameter was included and links field was requested, filter the links based on linkTypes
     if (linkTypes.length && links.length) {

--- a/src/datasources/__tests__/granule.test.js
+++ b/src/datasources/__tests__/granule.test.js
@@ -343,8 +343,10 @@ describe('granule', () => {
 
       const response = await granuleDatasource(
         {
-          collectionConceptId: 'C100000-EDSC',
-          linkTypes: ['data', 's3']
+          params: {
+            collectionConceptId: 'C100000-EDSC',
+            linkTypes: ['data', 's3']
+          }
         },
         {
           headers: {


### PR DESCRIPTION
# Overview

### What is the feature?

The query EDSC uses to retrieve granule download links is not taking into account the `linkTypes` param that is being provided because it is nested within the `params` object.

### What is the Solution?

Used the `mergeParams` util to ensure we see the `linkTypes` param regardless of where it is supplied.

### What areas of the application does this impact?

Granule queries with the `linkTypes` param

# Testing

Query
```
query GetGranuleLinks($params: GranulesInput) {
  granules(params: $params) {
    cursor
    items {
      links
    }
  }
} 
```

Variables
```
{
  "params": {
    "exclude": {},
    "options": {},
    "conceptId": [],
    "twoDCoordinateSystem": {},
    "limit": 50,
    "linkTypes": [
      "data",
      "s3",
      "browse"
    ],
    "collectionConceptId": "C2276336440-LARC_ASDC"
  }
} 
```

Ensure that only the correct link types are returned (data, s3 and browse)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
