### PR TITLE
GQL-85: Cannot view collection metadata C1000000321-SEDAC in MMT "All Collections"

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -332,7 +332,7 @@ export default class Collection extends Concept {
    * @param {Object} item The item returned from the CMR umm endpoint
    */
   normalizeUmmItem(item) {
-    const { umm } = item
+    const { umm = {} } = item
 
     const { ArchiveAndDistributionInformation: archiveAndDistributionInformation = {} } = umm
 

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -46,7 +46,13 @@ export default {
       )
     }
   },
+  CollectionRevisionListItem: {
+    __resolveType: (source) => {
+      const { deleted } = source
 
+      return deleted ? 'TombstonedCollectionMetadata' : 'Collection'
+    }
+  },
   Collection: {
     revisions: async (source, args, context, info) => {
       const { dataSources } = context

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -71,6 +71,9 @@ type Collection {
   "The Data Maturity element is used to inform users on where the collection is in a collection's life cycle."
   dataMaturity: String
 
+  "True if revision has been deleted"
+  deleted: Boolean
+
   "This element allows end users to get direct access to data products that are stored in the Amazon Web Service (AWS) S3 buckets. The sub elements include S3 credentials end point and a documentation URL as well as bucket prefix names and an AWS region."
   directDistributionInformation: JSON
 

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -527,12 +527,43 @@ type GraphDbPlatformInstrument implements Relationship {
   instrument: String
 }
 
+type TombstonedCollectionMetadata {
+  "The concept id of the draft."
+  conceptId: String!
+
+  "The concept type of the draft."
+  conceptType: String
+
+  "True if revision has been deleted"
+  deleted: Boolean
+
+  "The data format of the collection"
+  format: String
+
+  "The native id of the draft."
+  nativeId: String
+
+  "Provider ID of the draft."
+  providerId: String
+
+  "The revision id of the draft."
+  revisionId: String
+
+  "Date which the draft was last updated."
+  revisionDate: String
+
+  "Id of the user who modified/published record"
+  userId: String
+}
+
+union CollectionRevisionListItem = Collection | TombstonedCollectionMetadata
+
 type CollectionRevisionList {
   "The number of hits for a given search."
   count: Int
 
   "The list of collection search results."
-  items: [Collection]
+  items: [CollectionRevisionListItem]
 }
 
 type CollectionList {

--- a/src/types/service.graphql
+++ b/src/types/service.graphql
@@ -17,6 +17,9 @@ type Service {
   "This is the contact persons of the service."
   contactPersons: JSON
 
+  "True if revision has been deleted"
+  deleted: Boolean
+
   "A brief description of the service."
   description: String
 

--- a/src/types/tool.graphql
+++ b/src/types/tool.graphql
@@ -17,6 +17,9 @@ type Tool {
   "This is the contact persons of the downloadable tool or web user interface."
   contactPersons: JSON
 
+  "True if revision has been deleted"
+  deleted: Boolean
+
   "A brief description of the web user interface or downloadable tool. Note: This field allows lightweight markup language with plain text formatting syntax. Line breaks within the text are preserved."
   description: String
 

--- a/src/types/variable.graphql
+++ b/src/types/variable.graphql
@@ -14,6 +14,9 @@ type Variable {
   "The definition of the variable."
   definition: String
 
+  "True if revision has been deleted"
+  deleted: Boolean
+
   "A variable consists of one or more dimensions. An example of a dimension name is 'XDim'. An example of a dimension size is '1200'. Variables are rarely one dimensional."
   dimensions: JSON
 

--- a/src/utils/umm/collectionKeyMap.json
+++ b/src/utils/umm/collectionKeyMap.json
@@ -29,6 +29,7 @@
     "dataDates": "umm.DataDates",
     "dataLanguage": "umm.DataLanguage",
     "dataMaturity": "umm.DataMaturity",
+    "deleted": "meta.deleted",
     "directDistributionInformation": "umm.DirectDistributionInformation",
     "directoryNames": "umm.DirectoryNames",
     "doi": "umm.DOI",

--- a/src/utils/umm/serviceKeyMap.json
+++ b/src/utils/umm/serviceKeyMap.json
@@ -12,6 +12,7 @@
     "conceptId": "meta.concept-id",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",
+    "deleted": "meta.deleted",
     "description": "umm.Description",
     "lastUpdatedDate": "umm.LastUpdatedDate",
     "longName": "umm.LongName",

--- a/src/utils/umm/toolKeyMap.json
+++ b/src/utils/umm/toolKeyMap.json
@@ -11,6 +11,7 @@
     "conceptId": "meta.concept-id",
     "contactGroups": "umm.ContactGroups",
     "contactPersons": "umm.ContactPersons",
+    "deleted": "meta.deleted",
     "description": "umm.Description",
     "doi": "umm.DOI",
     "lastUpdatedDate": "umm.LastUpdatedDate",

--- a/src/utils/umm/variableKeyMap.json
+++ b/src/utils/umm/variableKeyMap.json
@@ -10,6 +10,7 @@
     "conceptId": "meta.concept-id",
     "dataType": "umm.DataType",
     "definition": "umm.Definition",
+    "deleted": "meta.deleted",
     "dimensions": "umm.Dimensions",
     "fillValues": "umm.FillValues",
     "indexRanges": "umm.IndexRanges",


### PR DESCRIPTION
# Overview

### What is the feature?

Can't view some collections when umm on revisions isn't available. 

### What is the Solution?

umm isn't available when a revision has been deleted as the only thing returned in these cases is the 'tombstone' which contains just the metadata. Collection.js in concepts is different from variable, tool, and service in that the component has a function called normalizeUmmItem which needs umm in order to function. A change within this function is needed to get the code to work as expected. Adding tombstoneMetadata is not actually required to get the code to work but may be needed to inform other clients that the data that is being returned is not, in fact, a collection. 

Adjusted the normalizeUmmItem function in collection.js to account for this. Adjusted the .graphql's so that they were passing 'deleted' metadata up to client. 

### What areas of the application does this impact?

concept.graphql and collection.js concept

# Testing

### Reproduction steps

- **Environment for testing: UAT
- **Collection to test with: See below

1. run cmr-graphql in UAT mode on branch GQL-85
2. grab your uat token from the headers in mmt.uat.earthdata.nasa.gov
3. open localhost:3013 and use the screen shots below to test collection: C1271740212-OB_CLDSIT 

### Attachments
Collection on GQL-85
![Screenshot 2024-11-08 at 9 00 25 AM](https://github.com/user-attachments/assets/0039c578-d672-4235-b8c8-bc28c25a524d)

Collection on Main
![Screenshot 2024-11-08 at 9 03 09 AM](https://github.com/user-attachments/assets/2814242d-3374-4929-8154-3a13c8643b81)

You CAN run graphQL in Prod mode to see the problem Collection in action but I've included a screenshot here so you don't have to:
<img width="1698" alt="Screenshot 2024-11-12 at 9 08 39 AM" src="https://github.com/user-attachments/assets/317b4395-1102-4588-bbc8-11e0ff1bbf80">



# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
