### PR TITLE
GQL-88: Updates CloudCover type

### DIFF
--- a/src/resolvers/__tests__/granule.test.js
+++ b/src/resolvers/__tests__/granule.test.js
@@ -36,13 +36,13 @@ describe('Granule', () => {
             entry: [{
               boxes: [],
               browse_flag: false,
-              cloud_cover: 25,
+              cloud_cover: '25.3',
               collection_concept_id: 'C100000-EDSC',
               coordinate_system: 'CARTESIAN',
               data_center: 'Tortor Lorem',
               dataset_id: 'Condimentum Ullamcorper Malesuada Sollicitudin',
               day_night_flag: 'BOTH',
-              granule_size: 525.0454,
+              granule_size: '525.0454',
               id: 'G100000-EDSC',
               links: [],
               online_access_flag: true,
@@ -71,7 +71,7 @@ describe('Granule', () => {
               'native-id': 'test-guid'
             },
             umm: {
-              CloudCover: 25,
+              CloudCover: 25.3,
               DataGranule: {},
               GranuleUR: 'parturient-etiam-malesuada',
               MeasuredParameters: {},
@@ -134,7 +134,7 @@ describe('Granule', () => {
             boxes: [],
             browseFlag: false,
             collectionConceptId: 'C100000-EDSC',
-            cloudCover: 25,
+            cloudCover: 25.3,
             conceptId: 'G100000-EDSC',
             coordinateSystem: 'CARTESIAN',
             dataCenter: 'Tortor Lorem',

--- a/src/types/granule.graphql
+++ b/src/types/granule.graphql
@@ -8,7 +8,7 @@ type Granule {
   "The concept id of the parent CMR collection."
   collectionConceptId: String
   "A percentage value indicating how much of the area of a granule (the EOSDIS data unit) has been obscured by clouds. It is worth noting that there are many different measures of cloud cover within the EOSDIS data holdings and that the cloud cover parameter that is represented in the archive is dataset-specific."
-  cloudCover: Int
+  cloudCover: Float
   "The unique concept id assigned to the granule."
   conceptId: String!
   "Coordinate system info of the metadata."


### PR DESCRIPTION
# Overview

### What is the feature?

The CloudCover field in the Granule type is currently an Int, but that value needs to be a Float

### What is the Solution?

Updated the type in the schema. 
CMR granule endpoints return different types. `.json` returns Strings while `.umm_json` returns a Float. I updated the tests to correctly reflect this

### What areas of the application does this impact?

Granule queries with CloudCover

# Testing

This query shows a PROD collection that does have floating point CloudCover values
Query
```
query Collection($params: CollectionInput) {
  collection(params: $params) {
    granules {
      count
      items {
        conceptId
        cloudCover
      }
    }
  }
}
```
Variables
```
{
  "params": {
    "conceptId": "C3020920290-OB_CLOUD"
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

