### PR TITLE
GQL-73: Update GraphQL to the new UMM-C version for the Web Unitification Round 2 changes.

### DIFF
--- a/serverless-configs/env.yml
+++ b/serverless-configs/env.yml
@@ -31,7 +31,7 @@ default_env: &default_env
     retryDelay: ${env:RETRY_DELAY, '1000'}
 
     # Pinned UMM versions
-    ummCollectionVersion: '1.18.1'
+    ummCollectionVersion: '1.18.2'
     ummGranuleVersion: '1.6.5'
     ummOrderOptionVersion: '1.0.0'
     ummServiceVersion: '1.5.3'


### PR DESCRIPTION
# Overview

### What is the feature?
Update UMM-C from 1.18.1 to 1.18.2

[CMR-10173](https://bugs.earthdata.nasa.gov/browse/CMR-10173), UMM-C schema added PREPRINT, INREVIEW, and SUPERSEDED enums to CollectionProgress
[CMR-10173](https://bugs.earthdata.nasa.gov/browse/CMR-10173), UMM-C schema removed NOT APPLICABLE enum in CollectionProgress
[CMR-10173](https://bugs.earthdata.nasa.gov/browse/CMR-10173), UMM-C schema added IsPreviousVersionOf and IsNewVersionOf enums to AssociatedDOIs/Type

### What is the Solution?

There were no new fields added and these changes do not need any GraphQL schema change. Updates the ummCollectionVersion in env.yml to 1.18.2

### What areas of the application does this impact?

env.yml

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. double check all tests pass and environment still works as expected
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
