### PR TITLE
GQL-85: Cannot view collection when a revision doesn't have UMM

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -334,7 +334,7 @@ export default class Collection extends Concept {
    * @param {Object} item The item returned from the CMR umm endpoint
    */
   normalizeUmmItem(item) {
-    const { umm } = item
+    const { umm = {} } = item
 
     const { ArchiveAndDistributionInformation: archiveAndDistributionInformation = {} } = umm
 

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -712,8 +712,8 @@ describe('Collection', () => {
     })
 
     describe('collection', () => {
-      describe('when calling revisions returns a revision tombstone', () => {
-        test('returns results', async () => {
+      describe('when retrieving revisions that contain tombstones', () => {
+        test('includes them in the results', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Hits': 1,

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -267,7 +267,7 @@ describe('Collection', () => {
 
       nock(/example-cmr/)
         .defaultReplyHeaders({
-          'CMR-Hits': 2,
+          'CMR-Hits': 3,
           'CMR-Took': 7,
           'CMR-Request-Id': 'abcd-1234-efgh-5678'
         })
@@ -277,7 +277,8 @@ describe('Collection', () => {
             meta: {
               'concept-id': 'C100000-EDSC',
               'native-id': 'test-guid',
-              'revision-id': '2'
+              'revision-id': '3',
+              deleted: false
             },
             umm: {
               Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
@@ -286,7 +287,15 @@ describe('Collection', () => {
             meta: {
               'concept-id': 'C100000-EDSC',
               'native-id': 'test-guid',
-              'revision-id': '1'
+              'revision-id': '2',
+              deleted: true
+            }
+          }, {
+            meta: {
+              'concept-id': 'C100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '1',
+              deleted: false
             },
             umm: {
               Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
@@ -549,8 +558,11 @@ describe('Collection', () => {
             quality: 'Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.',
             relatedUrls: [],
             revisions: {
-              count: 2,
+              count: 3,
               items: [
+                {
+                  revisionId: '3'
+                },
                 {
                   revisionId: '2'
                 },

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -708,110 +708,108 @@ describe('Collection', () => {
             collection: null
           })
         })
-      })
-    })
 
-    describe('collection', () => {
-      describe('when retrieving revisions that contain tombstones', () => {
-        test('includes them in the results', async () => {
-          nock(/example-cmr/)
-            .defaultReplyHeaders({
-              'CMR-Hits': 1,
-              'CMR-Took': 7,
-              'CMR-Request-Id': 'abcd-1234-efgh-5678'
-            })
-            .get(/collections\.json/)
-            .reply(200, {
-              feed: {
-                entry: [{
-                  id: 'C100001-EDSC'
-                }],
-                facets: {}
-              }
-            })
+        describe('when retrieving revisions that contain tombstones', () => {
+          test('includes them in the results', async () => {
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get(/collections\.json/)
+              .reply(200, {
+                feed: {
+                  entry: [{
+                    id: 'C100001-EDSC'
+                  }],
+                  facets: {}
+                }
+              })
 
-          nock(/example-cmr/)
-            .defaultReplyHeaders({
-              'CMR-Hits': 3,
-              'CMR-Took': 7,
-              'CMR-Request-Id': 'abcd-1234-efgh-5678'
-            })
-            .get('/search/collections.umm_json?all_revisions=true&concept_id=C100001-EDSC')
-            .reply(200, {
-              items: [{
-                meta: {
-                  'concept-id': 'C100001-EDSC',
-                  'revision-id': '3',
-                  deleted: false
-                },
-                umm: {
-                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
-                }
-              }, {
-                meta: {
-                  'concept-id': 'C100001-EDSC',
-                  'revision-id': '2',
-                  deleted: true
-                }
-              }, {
-                meta: {
-                  'concept-id': 'C100001-EDSC',
-                  'revision-id': '1',
-                  deleted: false
-                },
-                umm: {
-                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
-                }
-              }]
-            })
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 3,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get('/search/collections.umm_json?all_revisions=true&concept_id=C100001-EDSC')
+              .reply(200, {
+                items: [{
+                  meta: {
+                    'concept-id': 'C100001-EDSC',
+                    'revision-id': '3',
+                    deleted: false
+                  },
+                  umm: {
+                    Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+                  }
+                }, {
+                  meta: {
+                    'concept-id': 'C100001-EDSC',
+                    'revision-id': '2',
+                    deleted: true
+                  }
+                }, {
+                  meta: {
+                    'concept-id': 'C100001-EDSC',
+                    'revision-id': '1',
+                    deleted: false
+                  },
+                  umm: {
+                    Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+                  }
+                }]
+              })
 
-          const response = await server.executeOperation({
-            variables: {},
-            query: `{
-              collections {
-                count
-                facets
-                items {
-                  conceptId
-                  revisions {
-                    count
-                    items {
-                      revisionId
+            const response = await server.executeOperation({
+              variables: {},
+              query: `{
+                collections {
+                  count
+                  facets
+                  items {
+                    conceptId
+                    revisions {
+                      count
+                      items {
+                        revisionId
+                      }
                     }
                   }
                 }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data, errors } = response.body.singleResult
+
+            expect(errors).toBeUndefined()
+
+            expect(data).toEqual({
+              collections: {
+                count: 1,
+                facets: {},
+                items: [{
+                  conceptId: 'C100001-EDSC',
+                  revisions: {
+                    count: 3,
+                    items: [
+                      {
+                        revisionId: '3'
+                      },
+                      {
+                        revisionId: '2'
+                      },
+                      {
+                        revisionId: '1'
+                      }
+                    ]
+                  }
+                }]
               }
-            }`
-          }, {
-            contextValue
-          })
-
-          const { data, errors } = response.body.singleResult
-
-          expect(errors).toBeUndefined()
-
-          expect(data).toEqual({
-            collections: {
-              count: 1,
-              facets: {},
-              items: [{
-                conceptId: 'C100001-EDSC',
-                revisions: {
-                  count: 3,
-                  items: [
-                    {
-                      revisionId: '3'
-                    },
-                    {
-                      revisionId: '2'
-                    },
-                    {
-                      revisionId: '1'
-                    }
-                  ]
-                }
-              }]
-            }
+            })
           })
         })
       })


### PR DESCRIPTION
# Overview

### What is the feature?

Users are unable to view C1000000321-SEDAC in production. It comes back with a "TypeError: Cannot read properties of undefined (reading 'ArchiveAndDistributionInformation')"

### What is the Solution?

This happens we getCollection calls revisions and tries to read the umm of each revision. In the case of deleted revisions, there is no umm. So I created a default for the umm of a revision. 

### What areas of the application does this impact?

collection.js under concepts

# Testing

### Reproduction steps

- **Environment for testing: UAT
- **Collection to test with: 
https://mmt.uat.earthdata.nasa.gov/collections/C1265136920-OB_CLOUD
https://mmt.uat.earthdata.nasa.gov/collections/C1265136919-OB_CLOUD
https://mmt.uat.earthdata.nasa.gov/collections/C1265136924-OB_CLOUD
https://mmt.uat.earthdata.nasa.gov/collections/C1265136917-OB_CLOUD

1. Point cmr-graphql to UAT
2. Use reference picture below to set up a graphql query. Test it on main to see TypeError, then test on branch to see that it returns. 

### Attachments
On main
<img width="1243" alt="Screenshot 2024-11-13 at 1 18 35 PM" src="https://github.com/user-attachments/assets/8148fd39-cf3f-4ea6-a4c5-d3c15fea4a6a">

On branch
<img width="1252" alt="Screenshot 2024-11-13 at 1 19 08 PM" src="https://github.com/user-attachments/assets/51b07a57-1c80-419b-b265-fd04afee3344">


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
