### PR TITLE
GQL-92: Adds additionalAttributes field to Granule and attribute parameter to GranulesInput

### DIFF
--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -24,6 +24,7 @@ export default class Granule extends Concept {
   getPermittedJsonSearchParams() {
     return [
       ...super.getPermittedJsonSearchParams(),
+      'attribute',
       'bounding_box',
       'browse_only',
       'circle',
@@ -56,6 +57,7 @@ export default class Granule extends Concept {
   getPermittedUmmSearchParams() {
     return [
       ...super.getPermittedUmmSearchParams(),
+      'attribute',
       'bounding_box',
       'browse_only',
       'circle',
@@ -88,6 +90,7 @@ export default class Granule extends Concept {
   getNonIndexedKeys() {
     return uniq([
       ...super.getNonIndexedKeys(),
+      'attribute',
       'bounding_box',
       'circle',
       'collection_concept_id',

--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -45,6 +45,7 @@ export default class Granule extends Concept {
       'polygon',
       'provider',
       'readable_granule_name',
+      'short_name',
       'sort_key',
       'temporal',
       'two_d_coordinate_system'
@@ -78,6 +79,7 @@ export default class Granule extends Concept {
       'polygon',
       'provider',
       'readable_granule_name',
+      'short_name',
       'sort_key',
       'temporal',
       'two_d_coordinate_system'
@@ -102,6 +104,7 @@ export default class Granule extends Concept {
       'polygon',
       'provider',
       'readable_granule_name',
+      'short_name',
       'sort_key'
     ])
   }

--- a/src/resolvers/__tests__/granule.test.js
+++ b/src/resolvers/__tests__/granule.test.js
@@ -71,6 +71,10 @@ describe('Granule', () => {
               'native-id': 'test-guid'
             },
             umm: {
+              AdditionalAttributes: [{
+                Name: 'Mock Attribute Name',
+                Values: ['Mock Attribute Value']
+              }],
               CloudCover: 25.3,
               DataGranule: {},
               GranuleUR: 'parturient-etiam-malesuada',
@@ -90,6 +94,7 @@ describe('Granule', () => {
           granules(params: { collectionConceptId: "C100000-EDSC" }) {
             count
             items {
+              additionalAttributes
               boxes
               browseFlag
               cloudCover
@@ -131,6 +136,10 @@ describe('Granule', () => {
         granules: {
           count: 1,
           items: [{
+            additionalAttributes: [{
+              name: 'Mock Attribute Name',
+              values: ['Mock Attribute Value']
+            }],
             boxes: [],
             browseFlag: false,
             collectionConceptId: 'C100000-EDSC',

--- a/src/types/granule.graphql
+++ b/src/types/granule.graphql
@@ -129,6 +129,8 @@ input GranulesInput {
   provider: [String]
   "Search for granules using the readable_granule_name parameter."
   readableGranuleName: [String]
+  "Search by the short name of the granule."
+  shortName: [String]
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]
   "The temporal datetime has to be in yyyy-MM-ddTHH:mm:ssZ format."

--- a/src/types/granule.graphql
+++ b/src/types/granule.graphql
@@ -1,4 +1,6 @@
 type Granule {
+  "Reference to an additional attribute in the parent collection. The attribute reference may contain a granule specific value that will override the value in the parent collection for this granule. An attribute with the same name must exist in the parent collection."
+  additionalAttributes: JSON
   "A list of boxes representing spatial coverage."
   boxes: [String]
   "Boolean value displaying whether or not a granule has browse imagery."
@@ -73,6 +75,8 @@ type GranuleList {
 }
 
 input GranulesInput {
+  "Find granules by additional attribute. For full syntax reference see CMR documentation. https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-additional-attribute"
+  attribute: [String]
   "Bounding boxes define an area on the earth aligned with longitude and latitude. The Bounding box parameters must be 4 comma-separated numbers: lower left longitude, lower left latitude, upper right longitude, upper right latitude."
   boundingBox: [String]
   "Search by the browse only flag of the granule."

--- a/src/types/granule.graphql
+++ b/src/types/granule.graphql
@@ -129,7 +129,7 @@ input GranulesInput {
   provider: [String]
   "Search for granules using the readable_granule_name parameter."
   readableGranuleName: [String]
-  "Search by the short name of the granule."
+  "Find granules matching any of the 'short_name' param values. The 'short_name' here refers to the short name of the collections corresponding to the granules being searched for."
   shortName: [String]
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]

--- a/src/utils/umm/granuleKeyMap.json
+++ b/src/utils/umm/granuleKeyMap.json
@@ -4,6 +4,7 @@
     "conceptId"
   ],
   "ummKeyMappings": {
+    "additionalAttributes": "umm.AdditionalAttributes",
     "cloudCover": "umm.CloudCover",
     "conceptId": "meta.concept-id",
     "dataGranule": "umm.DataGranule",


### PR DESCRIPTION
# Overview

### What is the feature?

Adds additionalAttributes field to Granule 
Adds attribute parameter to GranulesInput
Adds shortName parameter to GranulesInput

### What areas of the application does this impact?

Granule queries

# Testing

You can try adding/removing the different attribute variables to see different results being returned.

Query
```
query Granules($params: GranulesInput) {
  granules(params: $params) {
    count
    items {
      conceptId
      additionalAttributes
    }
  }
}
```

Variables
```
{
  "params": {
    "provider": "ASF",
    "shortName": "SEASAT_SAR_L1_TIFF",
    "attribute": [
      "string,GRANULE_TYPE,SEASAT_STD_FRAME",
      "float,OFF_NADIR_ANGLE,-1",
      "string,ASCENDING_DESCENDING,ASCENDING"
    ]
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
