### PR TITLE
GQL-43: Adds revisionDate, createdAt and productionDate granule parameters. Adds revisionDate granule field

### DIFF
--- a/src/cmr/concepts/granule.js
+++ b/src/cmr/concepts/granule.js
@@ -30,6 +30,7 @@ export default class Granule extends Concept {
       'circle',
       'cloud_cover',
       'collection_concept_id',
+      'created_at',
       'cycle',
       'day_night_flag',
       'entry_id',
@@ -43,12 +44,15 @@ export default class Granule extends Concept {
       'passes',
       'point',
       'polygon',
+      'production_date',
       'provider',
       'readable_granule_name',
+      'revision_date',
       'short_name',
       'sort_key',
       'temporal',
-      'two_d_coordinate_system'
+      'two_d_coordinate_system',
+      'updated_since'
     ]
   }
 
@@ -64,6 +68,7 @@ export default class Granule extends Concept {
       'circle',
       'cloud_cover',
       'collection_concept_id',
+      'created_at',
       'cycle',
       'day_night_flag',
       'entry_id',
@@ -77,12 +82,15 @@ export default class Granule extends Concept {
       'passes',
       'point',
       'polygon',
+      'production_date',
       'provider',
       'readable_granule_name',
+      'revision_date',
       'short_name',
       'sort_key',
       'temporal',
-      'two_d_coordinate_system'
+      'two_d_coordinate_system',
+      'updated_since'
     ]
   }
 
@@ -97,13 +105,16 @@ export default class Granule extends Concept {
       'circle',
       'collection_concept_id',
       'concept_id',
+      'created_at',
       'entry_id',
       'exclude',
       'line',
       'point',
       'polygon',
+      'production_date',
       'provider',
       'readable_granule_name',
+      'revision_date',
       'short_name',
       'sort_key'
     ])

--- a/src/resolvers/__tests__/granule.test.js
+++ b/src/resolvers/__tests__/granule.test.js
@@ -68,7 +68,8 @@ describe('Granule', () => {
           items: [{
             meta: {
               'concept-id': 'G100000-EDSC',
-              'native-id': 'test-guid'
+              'native-id': 'test-guid',
+              'revision-date': '2016-04-04T20:00:00.000Z'
             },
             umm: {
               AdditionalAttributes: [{
@@ -117,6 +118,7 @@ describe('Granule', () => {
               producerGranuleId
               providerDates
               relatedUrls
+              revisionDate
               spatialExtent
               temporalExtent
               timeEnd
@@ -162,6 +164,7 @@ describe('Granule', () => {
             producerGranuleId: 'ornare-cursus-ultricies-nibh',
             providerDates: {},
             relatedUrls: [],
+            revisionDate: '2016-04-04T20:00:00.000Z',
             spatialExtent: {},
             temporalExtent: {},
             timeEnd: '2016-04-04T08:00:00.000Z',

--- a/src/types/granule.graphql
+++ b/src/types/granule.graphql
@@ -51,6 +51,8 @@ type Granule {
   providerDates: JSON
   "This element describes any data/service related URLs that include project home pages, services, related data archives/servers, metadata extensions, direct links to online software packages, web mapping services, links to images, or other data."
   relatedUrls: JSON
+  "Date which the Granule was last updated."
+  revisionDate: String
   "This class contains attributes which describe the spatial extent of a granule. Spatial Extent includes any or all of Granule Localities, Horizontal Spatial Domain, and Vertical Spatial Domain."
   spatialExtent: JSON
   "This class contains attributes which describe the temporal extent of a granule. Temporal Extent includes either a Range Date Time, or a Single Date Time."
@@ -91,6 +93,8 @@ input GranulesInput {
   collectionConceptIds: [String]
   "The unique concept id assigned to the granule."
   conceptId: [String]
+  "Find granules which were created within the ranges of datetimes. The datetime has to be in yyyy-MM-ddTHH:mm:ssZ format. The default is inclusive on the range boundaries."
+  createdAt: [String]
   "Cursor that points to the/a specific position in a list of requested records."
   cursor: String
   "Search by cycle which is part of the track information of a granule."
@@ -121,6 +125,8 @@ input GranulesInput {
   orbitNumber: JSON
   "Search by passes which is part of the track information of a granule."
   passes: JSON
+  "Find granules which have production date within the ranges of datetimes. The datetime has to be in yyyy-MM-ddTHH:mm:ssZ format. The default is inclusive on the range boundaries."
+  productionDate: [String]
   "Search using a point involves using a pair of values representing the point coordinates as parameters. The first value is the longitude and second value is the latitude."
   point: [String]
   "Polygon points are provided in counter-clockwise order. The last point should match the first point to close the polygon. The values are listed comma separated in longitude latitude order, i.e. lon1, lat1, lon2, lat2, lon3, lat3, and so on."
@@ -131,12 +137,16 @@ input GranulesInput {
   readableGranuleName: [String]
   "Find granules matching any of the 'short_name' param values. The 'short_name' here refers to the short name of the collections corresponding to the granules being searched for."
   shortName: [String]
+  "Find granules which have revision date within the ranges of datetimes. The datetime has to be in yyyy-MM-ddTHH:mm:ssZ format. The default is inclusive on the range boundaries."
+  revisionDate: [String]
   "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
   sortKey: [String]
   "The temporal datetime has to be in yyyy-MM-ddTHH:mm:ssZ format."
   temporal: String
   "The 2D coordinate system associated with the collection"
   twoDCoordinateSystem: JSON
+  "Find granules which have revision date starting at or after 'updated_since' param value."
+  updatedSince: String
 }
 
 input GranuleInput {

--- a/src/utils/umm/granuleKeyMap.json
+++ b/src/utils/umm/granuleKeyMap.json
@@ -14,6 +14,7 @@
     "orbitCalculatedSpatialDomains": "umm.OrbitCalculatedSpatialDomains",
     "providerDates": "umm.ProviderDates",
     "relatedUrls": "umm.RelatedUrls",
+    "revisionDate": "meta.revision-date",
     "spatialExtent": "umm.SpatialExtent",
     "temporalExtent": "umm.TemporalExtent"
   }


### PR DESCRIPTION
# Overview

### What is the feature?

Adds revisionDate, createdAt and productionDate granule parameters. 
Adds revisionDate granule field

### What areas of the application does this impact?

Granule queries

# Testing

Add/remove the different variables to test each parameter

Query
```
query Granules($params: GranulesInput) {
  granules(params: $params) {
    count
    items {
      conceptId
      timeEnd
      timeStart
      revisionDate
    }
  }
}
```

Variables
```
{
  "params": {
    "provider": "ASF",
    "createdAt": "2020-01-01,2020-01-02",
    // "productionDate": "2020-01-01,2020-01-02",
    // "revisionDate": "2020-01-01,2020-01-02",
    // "temporal": "2020-01-01,2020-01-02",
    // "updatedSince": "2020-01-01"
  }
}
```

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
