### PR TITLE
GQL-86: User cannot retrieve C2142771958-LPCLOUD in MMT production

### DIFF
--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -708,108 +708,108 @@ describe('Collection', () => {
             collection: null
           })
         })
+      })
 
-        describe('when retrieving revisions that contain tombstones', () => {
-          test('includes them in the results', async () => {
-            nock(/example-cmr/)
-              .defaultReplyHeaders({
-                'CMR-Hits': 1,
-                'CMR-Took': 7,
-                'CMR-Request-Id': 'abcd-1234-efgh-5678'
-              })
-              .get(/collections\.json/)
-              .reply(200, {
-                feed: {
-                  entry: [{
-                    id: 'C100001-EDSC'
-                  }],
-                  facets: {}
+      describe('when retrieving revisions that contain tombstones', () => {
+        test('includes them in the results', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 1,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/collections\.json/)
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100001-EDSC'
+                }],
+                facets: {}
+              }
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 3,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.umm_json?all_revisions=true&concept_id=C100001-EDSC')
+            .reply(200, {
+              items: [{
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '3',
+                  deleted: false
+                },
+                umm: {
+                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
                 }
-              })
+              }, {
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '2',
+                  deleted: true
+                }
+              }, {
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '1',
+                  deleted: false
+                },
+                umm: {
+                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+                }
+              }]
+            })
 
-            nock(/example-cmr/)
-              .defaultReplyHeaders({
-                'CMR-Hits': 3,
-                'CMR-Took': 7,
-                'CMR-Request-Id': 'abcd-1234-efgh-5678'
-              })
-              .get('/search/collections.umm_json?all_revisions=true&concept_id=C100001-EDSC')
-              .reply(200, {
-                items: [{
-                  meta: {
-                    'concept-id': 'C100001-EDSC',
-                    'revision-id': '3',
-                    deleted: false
-                  },
-                  umm: {
-                    Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
-                  }
-                }, {
-                  meta: {
-                    'concept-id': 'C100001-EDSC',
-                    'revision-id': '2',
-                    deleted: true
-                  }
-                }, {
-                  meta: {
-                    'concept-id': 'C100001-EDSC',
-                    'revision-id': '1',
-                    deleted: false
-                  },
-                  umm: {
-                    Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
-                  }
-                }]
-              })
-
-            const response = await server.executeOperation({
-              variables: {},
-              query: `{
-                collections {
-                  count
-                  facets
-                  items {
-                    conceptId
-                    revisions {
-                      count
-                      items {
-                        revisionId
-                      }
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              collections {
+                count
+                facets
+                items {
+                  conceptId
+                  revisions {
+                    count
+                    items {
+                      revisionId
                     }
                   }
                 }
-              }`
-            }, {
-              contextValue
-            })
-
-            const { data, errors } = response.body.singleResult
-
-            expect(errors).toBeUndefined()
-
-            expect(data).toEqual({
-              collections: {
-                count: 1,
-                facets: {},
-                items: [{
-                  conceptId: 'C100001-EDSC',
-                  revisions: {
-                    count: 3,
-                    items: [
-                      {
-                        revisionId: '3'
-                      },
-                      {
-                        revisionId: '2'
-                      },
-                      {
-                        revisionId: '1'
-                      }
-                    ]
-                  }
-                }]
               }
-            })
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            collections: {
+              count: 1,
+              facets: {},
+              items: [{
+                conceptId: 'C100001-EDSC',
+                revisions: {
+                  count: 3,
+                  items: [
+                    {
+                      revisionId: '3'
+                    },
+                    {
+                      revisionId: '2'
+                    },
+                    {
+                      revisionId: '1'
+                    }
+                  ]
+                }
+              }]
+            }
           })
         })
       })
@@ -1791,7 +1791,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get('/search/tools.json?concept_id[]=T100000-EDSC&concept_id[]=T100001-EDSC&page_size=2')
+            .get('/search/tools.json?concept_id[]=T100000-EDSC&concept_id[]=T100001-EDSC&page_size=20')
             .reply(200, {
               items: [{
                 concept_id: 'T100000-EDSC'
@@ -1805,7 +1805,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get('/search/tools.json?concept_id[]=T100002-EDSC&concept_id[]=T100003-EDSC&page_size=2')
+            .get('/search/tools.json?concept_id[]=T100002-EDSC&concept_id[]=T100003-EDSC&page_size=20')
             .reply(200, {
               items: [{
                 concept_id: 'T100002-EDSC'
@@ -2071,7 +2071,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get('/search/variables.json?concept_id[]=V100000-EDSC&concept_id[]=V100001-EDSC&page_size=2')
+            .get('/search/variables.json?concept_id[]=V100000-EDSC&concept_id[]=V100001-EDSC&page_size=20')
             .reply(200, {
               items: [{
                 concept_id: 'V100000-EDSC'
@@ -2085,7 +2085,7 @@ describe('Collection', () => {
               'CMR-Took': 7,
               'CMR-Request-Id': 'abcd-1234-efgh-5678'
             })
-            .get('/search/variables.json?concept_id[]=V100002-EDSC&concept_id[]=V100003-EDSC&page_size=2')
+            .get('/search/variables.json?concept_id[]=V100002-EDSC&concept_id[]=V100003-EDSC&page_size=20')
             .reply(200, {
               items: [{
                 concept_id: 'V100002-EDSC'
@@ -2136,6 +2136,132 @@ describe('Collection', () => {
                 }
               }]
             }
+          })
+        })
+
+        describe('when variable associations count is greater than defaultPageSize', () => {
+          test('returns first 20 results', async () => {
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get(/collections\.json/)
+              .reply(200, {
+                feed: {
+                  entry: [{
+                    id: 'C100000-EDSC',
+                    association_details: {
+                      variables: [
+                        { concept_id: 'V100000-EDSC' },
+                        { concept_id: 'V100001-EDSC' },
+                        { concept_id: 'V100002-EDSC' },
+                        { concept_id: 'V100003-EDSC' },
+                        { concept_id: 'V100004-EDSC' },
+                        { concept_id: 'V100005-EDSC' },
+                        { concept_id: 'V100006-EDSC' },
+                        { concept_id: 'V100007-EDSC' },
+                        { concept_id: 'V100008-EDSC' },
+                        { concept_id: 'V100009-EDSC' },
+                        { concept_id: 'V100010-EDSC' },
+                        { concept_id: 'V100011-EDSC' },
+                        { concept_id: 'V100012-EDSC' },
+                        { concept_id: 'V100013-EDSC' },
+                        { concept_id: 'V100014-EDSC' },
+                        { concept_id: 'V100015-EDSC' },
+                        { concept_id: 'V100016-EDSC' },
+                        { concept_id: 'V100017-EDSC' },
+                        { concept_id: 'V100018-EDSC' },
+                        { concept_id: 'V100019-EDSC' },
+                        { concept_id: 'V100020-EDSC' }
+                      ]
+                    }
+                  }]
+                }
+              })
+
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get('/search/variables.json?concept_id[]=V100000-EDSC&concept_id[]=V100001-EDSC&concept_id[]=V100002-EDSC&concept_id[]=V100003-EDSC&concept_id[]=V100004-EDSC&concept_id[]=V100005-EDSC&concept_id[]=V100006-EDSC&concept_id[]=V100007-EDSC&concept_id[]=V100008-EDSC&concept_id[]=V100009-EDSC&concept_id[]=V100010-EDSC&concept_id[]=V100011-EDSC&concept_id[]=V100012-EDSC&concept_id[]=V100013-EDSC&concept_id[]=V100014-EDSC&concept_id[]=V100015-EDSC&concept_id[]=V100016-EDSC&concept_id[]=V100017-EDSC&concept_id[]=V100018-EDSC&concept_id[]=V100019-EDSC&concept_id[]=V100020-EDSC&page_size=20')
+              .reply(200, {
+                items: [
+                  { concept_id: 'V100000-EDSC' },
+                  { concept_id: 'V100001-EDSC' },
+                  { concept_id: 'V100002-EDSC' },
+                  { concept_id: 'V100003-EDSC' },
+                  { concept_id: 'V100004-EDSC' },
+                  { concept_id: 'V100005-EDSC' },
+                  { concept_id: 'V100006-EDSC' },
+                  { concept_id: 'V100007-EDSC' },
+                  { concept_id: 'V100008-EDSC' },
+                  { concept_id: 'V100009-EDSC' },
+                  { concept_id: 'V100010-EDSC' },
+                  { concept_id: 'V100011-EDSC' },
+                  { concept_id: 'V100012-EDSC' },
+                  { concept_id: 'V100013-EDSC' },
+                  { concept_id: 'V100014-EDSC' },
+                  { concept_id: 'V100015-EDSC' },
+                  { concept_id: 'V100016-EDSC' },
+                  { concept_id: 'V100017-EDSC' },
+                  { concept_id: 'V100018-EDSC' },
+                  { concept_id: 'V100019-EDSC' }
+                ]
+              })
+
+            const response = await server.executeOperation({
+              variables: {},
+              query: `{
+                collections {
+                  items {
+                    conceptId
+                    variables {
+                      items {
+                        conceptId
+                      }
+                    }
+                  }
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              collections: {
+                items: [{
+                  conceptId: 'C100000-EDSC',
+                  variables: {
+                    items: [
+                      { conceptId: 'V100000-EDSC' },
+                      { conceptId: 'V100001-EDSC' },
+                      { conceptId: 'V100002-EDSC' },
+                      { conceptId: 'V100003-EDSC' },
+                      { conceptId: 'V100004-EDSC' },
+                      { conceptId: 'V100005-EDSC' },
+                      { conceptId: 'V100006-EDSC' },
+                      { conceptId: 'V100007-EDSC' },
+                      { conceptId: 'V100008-EDSC' },
+                      { conceptId: 'V100009-EDSC' },
+                      { conceptId: 'V100010-EDSC' },
+                      { conceptId: 'V100011-EDSC' },
+                      { conceptId: 'V100012-EDSC' },
+                      { conceptId: 'V100013-EDSC' },
+                      { conceptId: 'V100014-EDSC' },
+                      { conceptId: 'V100015-EDSC' },
+                      { conceptId: 'V100016-EDSC' },
+                      { conceptId: 'V100017-EDSC' },
+                      { conceptId: 'V100018-EDSC' },
+                      { conceptId: 'V100019-EDSC' }
+                    ]
+                  }
+                }]
+              }
+            })
           })
         })
       })

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -273,7 +273,7 @@ export default {
 
       return dataSources.toolSourceFetch({
         conceptId: toolConceptIds,
-        ...handlePagingParams(args, tools.length)
+        ...handlePagingParams(args)
       }, context, parseResolveInfo(info))
     },
     variables: async (source, args, context, info) => {
@@ -301,7 +301,7 @@ export default {
 
       return dataSources.variableSourceFetch({
         conceptId: variableConceptIds,
-        ...handlePagingParams(args, variables.length)
+        ...handlePagingParams(args)
       }, context, parseResolveInfo(info))
     }
   },


### PR DESCRIPTION
# Overview

### What is the feature?

Initial issue was User cannot retrieve C2142771958-LPCLOUD in MMT production. Users were unable to do this because there were over 2000 variable associations. This could also be an issue for services and tools. 

### What is the Solution?

Edit the resolver to pass handlePagingParams nothing as opposed to variables.length. This defaults the page size to 20, users of a client will need to paginate through results if there is ever a front end that requires it. MMT does not allow users to view associated variables or tools from a Collection so there should not be a need to change MMT at this time. I did the same for tools but not for services. Services CAN be viewed from collections but it does not appear that is very common for a collection to have more than 3 services. 

### What areas of the application does this impact?

Collection resolver

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: C1200462006-CMR_ONLY

1. Query for associated variables with the above collection. On main you'll receive the error below whereas on the branch you'll get back the first 20 results.  
2. There does not appear to be a collection with more than 3 or 4 associated tools which makes this a little tricky. This collection C1200376270-MMT_2 has a four. You can query tools on that collection and then edit line 276 in Collection.js/resolvers to ...handlePagingParams(args, 3), you'll notice a result comes back with only 3 results but the count is still 4. This demonstrates that the change doesn't break it. 

### Attachments
Issue on main
<img width="1331" alt="Screenshot 2024-11-19 at 1 07 42 PM" src="https://github.com/user-attachments/assets/4625860a-15bc-4311-a53d-826fc1a77540">

Fixed on branch
<img width="1311" alt="Screenshot 2024-11-19 at 1 09 19 PM" src="https://github.com/user-attachments/assets/8a21a14f-ce8b-4a85-9f14-2f4782f20a5f">



# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
