### PR TITLE
GQL-103: Updating UMM-C shema to 1.18.3

### DIFF
--- a/cdk/graphql/lib/graphql-stack.ts
+++ b/cdk/graphql/lib/graphql-stack.ts
@@ -38,7 +38,7 @@ const environment = {
   stellateAppName: process.env.STELLATE_APP_NAME!,
   stellateKey: process.env.STELLATE_KEY!,
   lambdaTimeout: process.env.LAMBDA_TIMEOUT || '30',
-  ummCollectionVersion: '1.18.2',
+  ummCollectionVersion: '1.18.3',
   ummGranuleVersion: '1.6.5',
   ummOrderOptionVersion: '1.0.0',
   ummServiceVersion: '1.5.3',


### PR DESCRIPTION
# Overview

### What is the feature?

Update UMM-C schema from 1.18.2 to 1.18.3 as seen here: https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/collection/v1.18.3

### What is the Solution?

Changes include:
UMM-C schema added URLMimeType enum "application/geo+json"
UMM-C schema updated 'DOI/PreviousVersion/Version' definition
UMM-C schema corrected spelling for Temporal resolution 'Constant'
UMM-C schema updated media type definition

### What areas of the application does this impact?

This only required a single version bump in GQL without any other changes.  

# Testing

### Reproduction steps

- **Environment for testing: local
- **Collection to test with: local

1. Spin up local graphql and make sure you can ingest a draft with 1.18.3 changes


### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
