### PR TITLE
GQL-99: Adds UMM-Vis

### DIFF
--- a/cdk/graphql/lib/graphql-stack.ts
+++ b/cdk/graphql/lib/graphql-stack.ts
@@ -45,6 +45,7 @@ const environment = {
   ummSubscriptionVersion: '1.1.1',
   ummToolVersion: '1.2.0',
   ummVariableVersion: '1.9.0',
+  ummVisualizationVersion: '1.1.0',
   maximumQueryPathLength: '1500',
   stage: STAGE_NAME
 }

--- a/src/cmr/concepts/__tests__/draft.test.js
+++ b/src/cmr/concepts/__tests__/draft.test.js
@@ -66,6 +66,17 @@ describe('Draft concept', () => {
         })
       })
 
+      describe('when the conceptType is visualization-drafts', () => {
+        test('sets the ingestPath and metadataSpecification correctly', () => {
+          const draft = new Draft('visualization-drafts', {}, {}, {
+            draftConceptId: 'VISD100000-EDSC',
+            providerId: 'EDSC'
+          })
+
+          expect(draft.publishPath).toEqual('publish/VISD100000-EDSC')
+        })
+      })
+
       describe('when the conceptType is not a supported draft', () => {
         test('sets the ingestPath and metadataSpecification correctly', () => {
           const draft = new Draft('bad-drafts', {}, {}, {

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -97,6 +97,7 @@ export default class Collection extends Concept {
       'tool_concept_id',
       'two_d_coordinate_system_name',
       'variable_concept_id',
+      'visualization_concept_id',
       'version'
     ]
   }
@@ -154,6 +155,7 @@ export default class Collection extends Concept {
       'tool_concept_id',
       'two_d_coordinate_system_name',
       'variable_concept_id',
+      'visualization_concept_id',
       'version'
     ]
   }

--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -97,7 +97,6 @@ export default class Collection extends Concept {
       'tool_concept_id',
       'two_d_coordinate_system_name',
       'variable_concept_id',
-      'visualization_concept_id',
       'version'
     ]
   }
@@ -155,7 +154,6 @@ export default class Collection extends Concept {
       'tool_concept_id',
       'two_d_coordinate_system_name',
       'variable_concept_id',
-      'visualization_concept_id',
       'version'
     ]
   }

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -409,6 +409,7 @@ export default class Concept {
       'concept_id',
       'include_full_acl',
       'offset',
+      'options',
       'originator_id',
       'page_size',
       'permitted_user',
@@ -427,6 +428,7 @@ export default class Concept {
       'all_revisions',
       'concept_id',
       'offset',
+      'options',
       'page_size',
       'provider_id',
       'sort_key'

--- a/src/cmr/concepts/concept.js
+++ b/src/cmr/concepts/concept.js
@@ -409,7 +409,6 @@ export default class Concept {
       'concept_id',
       'include_full_acl',
       'offset',
-      'options',
       'originator_id',
       'page_size',
       'permitted_user',
@@ -428,7 +427,6 @@ export default class Concept {
       'all_revisions',
       'concept_id',
       'offset',
-      'options',
       'page_size',
       'provider_id',
       'sort_key'

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -191,14 +191,26 @@ export default class Draft extends Concept {
       ummVersion
     } = specificationData
 
-    return super.mutateIngestParameters({
+    const paramsToIngest = {
       ...params.metadata,
       MetadataSpecification: {
         URL: `https://cdn.earthdata.nasa.gov/umm/${ummType}/v${ummVersion}`,
         Name: ummName,
         Version: ummVersion
       }
-    })
+    }
+
+    if (ummName === 'Visualization') {
+      // ConceptIds is currently required for UMM-Vis, but will be removed in the future.
+      // For now, we will add a dummy value to satisfy the CMR validations.
+      // This will be removed when the field is removed from the schema.
+      paramsToIngest.ConceptIds = [{
+        Type: 'STD',
+        Value: 'C12345-GRAPHQL'
+      }]
+    }
+
+    return super.mutateIngestParameters(paramsToIngest)
   }
 
   /**

--- a/src/cmr/concepts/draft.js
+++ b/src/cmr/concepts/draft.js
@@ -147,7 +147,8 @@ export default class Draft extends Concept {
       ummCollectionVersion,
       ummServiceVersion,
       ummToolVersion,
-      ummVariableVersion
+      ummVariableVersion,
+      ummVisualizationVersion
     } = env
 
     const { conceptType } = params
@@ -168,11 +169,15 @@ export default class Draft extends Concept {
         ummType: 'tool',
         ummVersion: ummToolVersion
       },
-
       'variable-drafts': {
         ummName: 'UMM-Var',
         ummType: 'variable',
         ummVersion: ummVariableVersion
+      },
+      'visualization-drafts': {
+        ummName: 'Visualization',
+        ummType: 'visualization',
+        ummVersion: ummVisualizationVersion
       }
     }
 
@@ -207,7 +212,8 @@ export default class Draft extends Concept {
       ummCollectionVersion,
       ummServiceVersion,
       ummToolVersion,
-      ummVariableVersion
+      ummVariableVersion,
+      ummVisualizationVersion
     } = env
 
     const { conceptType } = this.params
@@ -216,7 +222,8 @@ export default class Draft extends Concept {
       'collection-drafts': ummCollectionVersion,
       'service-drafts': ummServiceVersion,
       'tool-drafts': ummToolVersion,
-      'variable-drafts': ummVariableVersion
+      'variable-drafts': ummVariableVersion,
+      'visualization-drafts': ummVisualizationVersion
     }
 
     const {

--- a/src/cmr/concepts/visualization.js
+++ b/src/cmr/concepts/visualization.js
@@ -1,0 +1,98 @@
+import Concept from './concept'
+
+export default class Visualization extends Concept {
+  /**
+   * Instantiates a Visualization object
+   * @param {Object} headers HTTP headers provided by the query
+   * @param {Object} requestInfo Parsed data pertaining to the Graph query
+   * @param {Object} params GraphQL query parameters
+   */
+  constructor(headers, requestInfo, params) {
+    super('visualizations', headers, requestInfo, params)
+  }
+
+  /**
+   * Returns an array of keys representing supported search params for the json endpoint
+   */
+  getPermittedJsonSearchParams() {
+    return [
+      ...super.getPermittedJsonSearchParams(),
+      'name',
+      'provider',
+      'title'
+    ]
+  }
+
+  /**
+   * Returns an array of keys representing supported search params for the umm endpoint
+   */
+  getPermittedUmmSearchParams() {
+    return [
+      ...super.getPermittedUmmSearchParams(),
+      'name',
+      'provider',
+      'title'
+    ]
+  }
+
+  /**
+   * Parse and return the array of data from the nested response body
+   * @param {Object} jsonResponse HTTP response from the CMR endpoint
+   */
+  parseJsonBody(jsonResponse) {
+    const { data } = jsonResponse
+
+    const { items } = data
+
+    return items
+  }
+
+  /**
+   * Query the CMR UMM API endpoint to retrieve requested data
+   * @param {Object} searchParams Parameters provided by the query
+   * @param {Array} ummKeys Keys requested by the query
+   * @param {Object} headers Headers requested by the query
+   */
+  fetchUmm(searchParams, ummKeys, headers) {
+    const ummHeaders = {
+      ...headers,
+      Accept: `application/vnd.nasa.cmr.umm_results+json; version=${process.env.ummVisualizationVersion}`
+    }
+
+    return super.fetchUmm(searchParams, ummKeys, ummHeaders)
+  }
+
+  /**
+   * Mutate the provided values from the user to meet expectations from CMR
+   * @param {Object} params Parameters provided by the client
+   * @returns The payload to send to CMR
+   */
+  mutateIngestParameters(params) {
+    const { env } = process
+    const { ummVisualizationVersion } = env
+
+    return super.mutateIngestParameters({
+      ...params,
+      MetadataSpecification: {
+        URL: `https://cdn.earthdata.nasa.gov/umm/visualization/v${ummVisualizationVersion}`,
+        Name: 'Visualization',
+        Version: ummVisualizationVersion
+      }
+    })
+  }
+
+  /**
+   * Merge provided and default headers and ensure they are permitted
+   * @param {Object} providedHeaders Headers provided by the client
+   * @returns An object holding acceptable headers and their values
+   */
+  ingestHeaders(providedHeaders) {
+    const { env } = process
+    const { ummVisualizationVersion } = env
+
+    return super.ingestHeaders({
+      ...providedHeaders,
+      'Content-Type': `application/vnd.nasa.cmr.umm+json; version=${ummVisualizationVersion}`
+    })
+  }
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -13,7 +13,8 @@ export const CONCEPT_TYPES = [
   'services',
   'subscriptions',
   'tools',
-  'variables'
+  'variables',
+  'visualizations'
 ]
 
 /**
@@ -32,7 +33,8 @@ export const DRAFT_CONCEPT_ID_PREFIXES = {
   collection: 'CD',
   service: 'SD',
   tool: 'TD',
-  variable: 'VD'
+  variable: 'VD',
+  visualization: 'VISD'
 }
 
 /**

--- a/src/datasources/__tests__/visualization.test.js
+++ b/src/datasources/__tests__/visualization.test.js
@@ -1,0 +1,530 @@
+import nock from 'nock'
+
+import {
+  deleteVisualization as visualizationSourceDelete,
+  restoreVisualizationRevision as visualizationSourceRestoreRevision,
+  fetchVisualizations as visualizationSourceFetch
+} from '../visualization'
+
+let requestInfo
+
+describe('visualization#fetch', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    vi.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'visualizations',
+      alias: 'visualizations',
+      args: {},
+      fieldsByTypeName: {
+        VisualizationList: {
+          items: {
+            name: 'items',
+            alias: 'items',
+            args: {},
+            fieldsByTypeName: {
+              Visualization: {
+                conceptId: {
+                  name: 'conceptId',
+                  alias: 'conceptId',
+                  args: {},
+                  fieldsByTypeName: {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('cursor', () => {
+    beforeEach(() => {
+      // Overwrite default requestInfo
+      requestInfo = {
+        name: 'visualizations',
+        alias: 'visualizations',
+        args: {},
+        fieldsByTypeName: {
+          VisualizationList: {
+            cursor: {
+              name: 'cursor',
+              alias: 'cursor',
+              args: {},
+              fieldsByTypeName: {}
+            },
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Visualization: {
+                  conceptId: {
+                    name: 'conceptId',
+                    alias: 'conceptId',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  visualizationType: {
+                    name: 'visualizationType',
+                    alias: 'visualizationType',
+                    args: {},
+                    fieldsByTypeName: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('returns a cursor', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678',
+          'CMR-Search-After': '["xyz", 789, 999]'
+        })
+        .get(/visualizations\.umm_json/)
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'VIS100000-EDSC'
+            },
+            umm: {
+              VisualizationType: 'tiles'
+            }
+          }]
+        })
+
+      const response = await visualizationSourceFetch({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
+        items: [{
+          conceptId: 'VIS100000-EDSC',
+          visualizationType: 'tiles'
+        }]
+      })
+    })
+
+    describe('when a cursor is requested', () => {
+      test('requests a cursor', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 84,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678',
+            'CMR-Search-After': '["xyz", 789, 999]'
+          })
+          .get(/visualizations\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'VIS100000-EDSC'
+              },
+              umm: {
+                VisualizationType: 'tiles'
+              }
+            }]
+          })
+
+        const response = await visualizationSourceFetch({}, {
+          headers: {
+            'Client-Id': 'eed-test-graphql',
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          }
+        }, requestInfo)
+
+        expect(response).toEqual({
+          count: 84,
+          cursor: 'eyJ1bW0iOiJbXCJ4eXpcIiwgNzg5LCA5OTldIn0=',
+          items: [{
+            conceptId: 'VIS100000-EDSC',
+            visualizationType: 'tiles'
+          }]
+        })
+      })
+    })
+  })
+
+  describe('without params', () => {
+    test('returns the parsed visualization results', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/visualizations\.json/)
+        .reply(200, {
+          items: [{
+            concept_id: 'VIS100000-EDSC'
+          }]
+        })
+
+      const response = await visualizationSourceFetch({}, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          conceptId: 'VIS100000-EDSC'
+        }]
+      })
+    })
+  })
+
+  describe('with params', () => {
+    test('returns the parsed visualization results', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/visualizations.json?concept_id=VIS100000-EDSC')
+        .reply(200, {
+          items: [{
+            concept_id: 'VIS100000-EDSC'
+          }]
+        })
+
+      const response = await visualizationSourceFetch({
+        params: {
+          concept_id: 'VIS100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          conceptId: 'VIS100000-EDSC'
+        }]
+      })
+    })
+  })
+
+  describe('with only umm keys', () => {
+    beforeEach(() => {
+      // Overwrite default requestInfo
+      requestInfo = {
+        name: 'visualizations',
+        alias: 'visualizations',
+        args: {},
+        fieldsByTypeName: {
+          VisualizationList: {
+            items: {
+              name: 'items',
+              alias: 'items',
+              args: {},
+              fieldsByTypeName: {
+                Visualization: {
+                  visualizationType: {
+                    name: 'visualizationType',
+                    alias: 'visualizationType',
+                    args: {},
+                    fieldsByTypeName: {}
+                  },
+                  title: {
+                    name: 'title',
+                    alias: 'title',
+                    args: {},
+                    fieldsByTypeName: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+
+    test('returns the parsed visualization results', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 84,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/visualizations\.umm_json/)
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'VIS100000-EDSC'
+            },
+            umm: {
+              Title: 'Test Visualization',
+              VisualizationType: 'tiles'
+            }
+          }]
+        })
+
+      const response = await visualizationSourceFetch({
+        params: {
+          concept_id: 'VIS100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+
+      expect(response).toEqual({
+        count: 84,
+        cursor: null,
+        items: [{
+          title: 'Test Visualization',
+          visualizationType: 'tiles'
+        }]
+      })
+    })
+  })
+
+  test('catches errors received from queryCmrVisualizations', async () => {
+    nock(/example-cmr/)
+      .get(/visualizations/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      visualizationSourceFetch({
+        params: {
+          conceptId: 'VIS100000-EDSC'
+        }
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})
+
+describe('restoreVisualizationRevision', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    vi.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'visualizationDelete',
+      alias: 'visualizationDelete',
+      args: {
+        conceptId: 'VIS100000-EDSC',
+        revisionId: '1'
+      },
+      fieldsByTypeName: {
+        VisualizationMutationResponse: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          revisionId: {
+            name: 'revisionId',
+            alias: 'revisionId',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  test('returns the CMR results', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .get('/search/visualizations.umm_json?concept_id=VIS100000-EDSC&all_revisions=true')
+      .reply(200, {
+        items: [{
+          meta: {
+            'concept-id': 'VIS100000-EDSC',
+            'native-id': '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+            'revision-id': 1
+          },
+          umm: {
+            LongName: 'Tortor Elit Fusce Quam Risus'
+          }
+        }, {
+          meta: {
+            'concept-id': 'VIS100000-EDSC',
+            'native-id': '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+            'revision-id': 2
+          },
+          umm: {
+            LongName: 'Adipiscing Cras Etiam Venenatis'
+          }
+        }]
+      })
+
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .put('/ingest/providers/EDSC/visualizations/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed')
+      .reply(200, {
+        'concept-id': 'VIS100000-EDSC',
+        'revision-id': '3'
+      })
+
+    const response = await visualizationSourceRestoreRevision({
+      revisionId: '1',
+      conceptId: 'VIS100000-EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'VIS100000-EDSC',
+      revisionId: '3'
+    })
+  })
+})
+
+describe('visualization#delete', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    vi.restoreAllMocks()
+
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+
+    // Default requestInfo
+    requestInfo = {
+      name: 'deleteVisualization',
+      alias: 'deleteVisualization',
+      args: {
+        conceptId: 'VIS100000-EDSC',
+        nativeId: 'test-guid'
+      },
+      fieldsByTypeName: {
+        VisualizationMutationResponse: {
+          conceptId: {
+            name: 'conceptId',
+            alias: 'conceptId',
+            args: {},
+            fieldsByTypeName: {}
+          },
+          revisionId: {
+            name: 'revisionId',
+            alias: 'revisionId',
+            args: {},
+            fieldsByTypeName: {}
+          }
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  test('returns the CMR results', async () => {
+    nock(/example-cmr/)
+      .defaultReplyHeaders({
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      })
+      .delete(/ingest\/providers\/EDSC\/visualizations\/test-guid/)
+      .reply(201, {
+        'concept-id': 'VIS100000-EDSC',
+        'revision-id': '2'
+      })
+
+    const response = await visualizationSourceDelete({
+      nativeId: 'test-guid',
+      providerId: 'EDSC'
+    }, {
+      headers: {
+        'Client-Id': 'eed-test-graphql',
+        'CMR-Request-Id': 'abcd-1234-efgh-5678'
+      }
+    }, requestInfo)
+
+    expect(response).toEqual({
+      conceptId: 'VIS100000-EDSC',
+      revisionId: '2'
+    })
+  })
+
+  test('catches errors received from cmrDelete', async () => {
+    nock(/example-cmr/)
+      .delete(/ingest\/providers\/EDSC\/visualizations\/test-guid/)
+      .reply(500, {
+        errors: ['HTTP Error']
+      }, {
+        'cmr-request-id': 'abcd-1234-efgh-5678'
+      })
+
+    await expect(
+      visualizationSourceDelete({
+        nativeId: 'test-guid',
+        providerId: 'EDSC'
+      }, {
+        headers: {
+          'Client-Id': 'eed-test-graphql',
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        }
+      }, requestInfo)
+    ).rejects.toThrow(Error)
+  })
+})

--- a/src/datasources/visualization.js
+++ b/src/datasources/visualization.js
@@ -1,0 +1,96 @@
+import { cmrQuery } from '../utils/cmrQuery'
+import { findPreviousRevision } from '../utils/findPreviousRevision'
+import { getProviderFromConceptId } from '../utils/getProviderFromConceptId'
+import { parseRequestedFields } from '../utils/parseRequestedFields'
+
+import visualizationKeyMap from '../utils/umm/visualizationKeyMap.json'
+
+import Visualization from '../cmr/concepts/visualization'
+
+export const fetchVisualizations = async (params, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, visualizationKeyMap, 'visualization')
+
+  const visualization = new Visualization(headers, requestInfo, params)
+
+  // Query CMR
+  visualization.fetch(params)
+
+  // Parse the response from CMR
+  await visualization.parse(requestInfo)
+
+  // Return a formatted JSON response
+  return visualization.getFormattedResponse()
+}
+
+export const restoreVisualizationRevision = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, visualizationKeyMap, 'visualization')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const visualization = new Visualization(headers, requestInfo, args)
+
+  const {
+    conceptId,
+    revisionId
+  } = args
+
+  const previousRevisions = await cmrQuery({
+    conceptType: 'visualizations',
+    options: {
+      format: 'umm_json'
+    },
+    params: {
+      conceptId,
+      allRevisions: true
+    }
+  })
+
+  const { data: responseData } = previousRevisions
+
+  // Find the requested revision for the provided concept
+  const previousRevision = findPreviousRevision(responseData, revisionId)
+
+  const { meta, umm } = previousRevision
+
+  const { 'native-id': nativeId } = meta
+
+  // Query CMR
+  visualization.ingest({
+    nativeId,
+    providerId: getProviderFromConceptId(conceptId),
+    ...umm
+  }, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await visualization.parseIngest(requestInfo)
+
+  // Return a formatted JSON response
+  return visualization.getFormattedIngestResponse()
+}
+
+export const deleteVisualization = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, visualizationKeyMap, 'visualization')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const visualization = new Visualization(headers, requestInfo, args)
+
+  // Contact CMR
+  visualization.delete(args, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await visualization.parseDelete(requestInfo)
+
+  // Return a formatted JSON response
+  return visualization.getFormattedDeleteResponse()
+}

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -71,6 +71,12 @@ import {
 } from '../datasources/variable'
 
 import {
+  deleteVisualization as visualizationSourceDelete,
+  fetchVisualizations as visualizationSourceFetch,
+  restoreVisualizationRevision as visualizationSourceRestoreRevision
+} from '../datasources/visualization'
+
+import {
   deleteSubscription as subscriptionSourceDelete,
   fetchSubscription as subscriptionSourceFetch,
   ingestSubscription as subscriptionSourceIngest
@@ -261,9 +267,12 @@ export default startServerAndCreateLambdaHandler(
           toolSourceFetch,
           toolSourceRestoreRevision,
           variableDraftSource,
-          variableSourceRestoreRevision,
           variableSourceDelete,
-          variableSourceFetch
+          variableSourceFetch,
+          variableSourceRestoreRevision,
+          visualizationSourceDelete,
+          visualizationSourceFetch,
+          visualizationSourceRestoreRevision
         },
         edlClientToken,
         collectionLoader: new DataLoader(getCollectionsById, {

--- a/src/resolvers/__tests__/__mocks__/mockServer.js
+++ b/src/resolvers/__tests__/__mocks__/mockServer.js
@@ -54,6 +54,12 @@ import {
 } from '../../../datasources/variable'
 
 import {
+  deleteVisualization as visualizationSourceDelete,
+  fetchVisualizations as visualizationSourceFetch,
+  restoreVisualizationRevision as visualizationSourceRestoreRevision
+} from '../../../datasources/visualization'
+
+import {
   deleteSubscription as subscriptionSourceDelete,
   fetchSubscription as subscriptionSourceFetch,
   ingestSubscription as subscriptionSourceIngest
@@ -136,7 +142,10 @@ export const buildContextValue = (extraContext) => ({
     variableDraftSource,
     variableSourceDelete,
     variableSourceFetch,
-    variableSourceRestoreRevision
+    variableSourceRestoreRevision,
+    visualizationSourceDelete,
+    visualizationSourceFetch,
+    visualizationSourceRestoreRevision
   },
   headers: {
     'Client-Id': 'eed-test-graphql',

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -21,6 +21,7 @@ describe('Draft', () => {
     process.env.ummSubscriptionVersion = '1.0.0'
     process.env.ummToolVersion = '1.0.0'
     process.env.ummVariableVersion = '1.0.0'
+    process.env.ummVisualizationVersion = '1.0.0'
   })
 
   afterEach(() => {
@@ -1769,6 +1770,446 @@ describe('Draft', () => {
     })
   })
 
+  describe('Visualization drafts', () => {
+    describe('Query', () => {
+      test('all draft fields', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 1,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/visualization-drafts\.umm_json/)
+          .reply(200, {
+            hits: 1,
+            items: [{
+              meta: {
+                'concept-id': 'VISD00000-EDSC',
+                'concept-type': 'visualization-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptId: 'VISD00000-EDSC',
+              conceptType: 'Visualization'
+            }
+          },
+          query: `query Draft($params: DraftInput) {
+            draft(params: $params) {
+              conceptId
+              conceptType
+              deleted
+              name
+              nativeId
+              providerId
+              revisionDate
+              revisionId
+              ummMetadata
+              previewMetadata {
+                ... on Visualization {
+                  conceptId
+                  name
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data, errors } = response.body.singleResult
+
+        expect(errors).toBeUndefined()
+
+        expect(data).toEqual({
+          draft: {
+            conceptId: 'VISD00000-EDSC',
+            conceptType: 'visualization-draft',
+            deleted: false,
+            previewMetadata: {
+              conceptId: 'VISD00000-EDSC',
+              name: 'Test Draft'
+            },
+            name: 'Test Draft',
+            nativeId: 'test-guid',
+            providerId: 'EDSC',
+            revisionDate: '2022-05-27T15:18:00.920Z',
+            revisionId: '1',
+            ummMetadata: {
+              Name: 'Test Draft'
+            }
+          }
+        })
+      })
+
+      test('drafts', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/visualization-drafts\.umm_json/)
+          .reply(200, {
+            hits: 2,
+            items: [{
+              meta: {
+                'concept-id': 'VISD00000-EDSC',
+                'concept-type': 'visualization-draft',
+                deleted: false,
+                'native-id': 'test-guid',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-27T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft'
+              }
+            }, {
+              meta: {
+                'concept-id': 'VISD00001-EDSC',
+                'concept-type': 'visualization-draft',
+                deleted: false,
+                'native-id': 'test-guid-1',
+                'provider-id': 'EDSC',
+                'revision-date': '2022-05-29T15:18:00.920Z',
+                'revision-id': '1'
+              },
+              umm: {
+                Name: 'Test Draft 2'
+              }
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Visualization'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              count
+              items {
+                conceptId
+                previewMetadata {
+                  ... on Visualization {
+                    conceptId
+                    name
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data, errors } = response.body.singleResult
+
+        expect(errors).toBeUndefined()
+
+        expect(data).toEqual({
+          drafts: {
+            count: 2,
+            items: [{
+              conceptId: 'VISD00000-EDSC',
+              previewMetadata: {
+                conceptId: 'VISD00000-EDSC',
+                name: 'Test Draft'
+              }
+            }, {
+              conceptId: 'VISD00001-EDSC',
+              previewMetadata: {
+                conceptId: 'VISD00001-EDSC',
+                name: 'Test Draft 2'
+              }
+            }]
+          }
+        })
+      })
+
+      describe('draft', () => {
+        describe('with results', () => {
+          test('returns results', async () => {
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Hits': 1,
+                'CMR-Took': 7,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get('/search/visualization-drafts.json?concept_id=VISD00000-EDSC')
+              .reply(200, {
+                items: [{
+                  concept_id: 'VISD00000-EDSC'
+                }]
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'VISD00000-EDSC',
+                  conceptType: 'Visualization'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: {
+                conceptId: 'VISD00000-EDSC'
+              }
+            })
+          })
+        })
+
+        describe('with no results', () => {
+          test('returns no results', async () => {
+            nock(/example-cmr/)
+              .defaultReplyHeaders({
+                'CMR-Took': 0,
+                'CMR-Request-Id': 'abcd-1234-efgh-5678'
+              })
+              .get('/search/visualization-drafts.json?concept_id=VISD00000-EDSC')
+              .reply(200, {
+                items: []
+              })
+
+            const response = await server.executeOperation({
+              variables: {
+                params: {
+                  conceptId: 'VISD00000-EDSC',
+                  conceptType: 'Visualization'
+                }
+              },
+              query: `query Draft($params: DraftInput) {
+                draft(params: $params) {
+                  conceptId
+                }
+              }`
+            }, {
+              contextValue
+            })
+
+            const { data } = response.body.singleResult
+
+            expect(data).toEqual({
+              draft: null
+            })
+          })
+        })
+      })
+    })
+
+    describe('Mutation', () => {
+      describe('ingestDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example-cmr/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/providers\/EDSC\/visualization-drafts\/visualization-1/)
+            .reply(201, {
+              'concept-id': 'VISD00000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Visualization',
+              metadata: {
+                Name: 'Mock Visualization'
+              },
+              nativeId: 'visualization-1',
+              providerId: 'EDSC',
+              ummVersion: '1.0.0'
+            },
+            query: `mutation IngestDraft(
+              $conceptType: DraftConceptType!
+              $metadata: JSON!
+              $nativeId: String!
+              $providerId: String!
+              $ummVersion: String!
+            ) {
+              ingestDraft(
+                conceptType: $conceptType
+                metadata: $metadata
+                nativeId: $nativeId
+                providerId: $providerId
+                ummVersion: $ummVersion
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            ingestDraft: {
+              conceptId: 'VISD00000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('deleteDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example-cmr/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .delete(/ingest\/providers\/EDSC\/visualization-drafts\/visualization-1/)
+            .reply(201, {
+              'concept-id': 'VISD00000-EDSC',
+              'revision-id': '2'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              conceptType: 'Visualization',
+              nativeId: 'visualization-1',
+              providerId: 'EDSC'
+            },
+            query: `mutation DeleteDraft(
+              $conceptType: DraftConceptType!
+              $nativeId: String!
+              $providerId: String!
+            ) {
+              deleteDraft(
+                conceptType: $conceptType
+                nativeId: $nativeId
+                providerId: $providerId
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            deleteDraft: {
+              conceptId: 'VISD00000-EDSC',
+              revisionId: '2',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+
+      describe('publishDraft', () => {
+        test('returns the cmr result', async () => {
+          nock(/example-cmr/, {
+            reqheaders: {
+              accept: 'application/json',
+              'client-id': 'eed-test-graphql',
+              'content-type': 'application/vnd.nasa.cmr.umm+json; version=1.0.0',
+              'cmr-request-id': 'abcd-1234-efgh-5678'
+            }
+          })
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .put(/ingest\/publish\/VISD00000-EDSC\/visualization-1/)
+            .reply(201, {
+              'concept-id': 'V100000-EDSC',
+              'revision-id': '1'
+            })
+
+          const response = await server.executeOperation({
+            variables: {
+              draftConceptId: 'VISD00000-EDSC',
+              nativeId: 'visualization-1',
+              ummVersion: '1.0.0'
+            },
+            query: `mutation PublishDraft(
+              $draftConceptId: String!
+              $nativeId: String!
+              $ummVersion: String!
+            ) {
+              publishDraft(
+                draftConceptId: $draftConceptId
+                nativeId: $nativeId
+                ummVersion: $ummVersion
+              ) {
+                conceptId
+                revisionId
+                warnings
+                existingErrors
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            publishDraft: {
+              conceptId: 'V100000-EDSC',
+              revisionId: '1',
+              warnings: null,
+              existingErrors: null
+            }
+          })
+        })
+      })
+    })
+  })
+
   describe('PreviewMetadata', () => {
     describe('__resolveType', () => {
       test('returns Collection when the conceptId starts with CD', () => {
@@ -1801,6 +2242,14 @@ describe('Draft', () => {
 
         const result = resolveType({ conceptId: 'VD' })
         expect(result).toEqual('Variable')
+      })
+
+      test('returns Visualization when the conceptId starts with VID', () => {
+        const { PreviewMetadata: previewMetadata } = resolvers
+        const { __resolveType: resolveType } = previewMetadata
+
+        const result = resolveType({ conceptId: 'VISD' })
+        expect(result).toEqual('Visualization')
       })
 
       test('returns null when the conceptId is not a draft', () => {

--- a/src/resolvers/__tests__/draft.test.js
+++ b/src/resolvers/__tests__/draft.test.js
@@ -2244,7 +2244,7 @@ describe('Draft', () => {
         expect(result).toEqual('Variable')
       })
 
-      test('returns Visualization when the conceptId starts with VID', () => {
+      test('returns Visualization when the conceptId starts with VISD', () => {
         const { PreviewMetadata: previewMetadata } = resolvers
         const { __resolveType: resolveType } = previewMetadata
 

--- a/src/resolvers/__tests__/visualization.test.js
+++ b/src/resolvers/__tests__/visualization.test.js
@@ -1,0 +1,920 @@
+import nock from 'nock'
+
+import { buildContextValue, server } from './__mocks__/mockServer'
+
+const contextValue = buildContextValue()
+
+describe('Visualization', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+
+    process.env.cmrRootUrl = 'http://example-cmr.com'
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  describe('Query', () => {
+    test('all visualization fields', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 1,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/visualizations\.json/)
+        .reply(200, {
+          hits: 1,
+          took: 9,
+          items: [
+            {
+              concept_id: 'VIS100000-EDSC',
+              revision_id: 3,
+              provider_id: 'EDSC',
+              native_id: 'tiles',
+              name: 'MODIS_Terra_Corrected_Reflectance_TrueColor',
+              id: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+              associations: {},
+              association_details: {}
+            }
+          ]
+        })
+
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 1,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get(/visualizations\.umm_json/)
+        .reply(200, {
+          items: [{
+            meta: {
+              'revision-id': 3,
+              deleted: false,
+              'provider-id': 'EDSC',
+              'user-id': 'ECHO_SYS',
+              associations: {},
+              'native-id': 'tiles',
+              'association-details': {},
+              'concept-id': 'VIS100000-EDSC',
+              'revision-date': '2025-03-18VIS19:22:44.814Z',
+              'concept-type': 'visualization'
+            },
+            umm: {
+              ConceptIds: [
+                {
+                  Type: 'STD',
+                  Value: 'C1000000001-EARTHDATA',
+                  DataCenter: 'MODAPS',
+                  ShortName: 'MODIS_Terra_CorrectedReflectance',
+                  Title: 'MODIS/Terra Corrected Reflectance True Color',
+                  Version: '6.1'
+                }
+              ],
+              SpatialExtent: {
+                GranuleSpatialRepresentation: 'GEODETIC',
+                HorizontalSpatialDomain: {
+                  Geometry: {
+                    CoordinateSystem: 'GEODETIC',
+                    BoundingRectangles: [
+                      {
+                        WestBoundingCoordinate: -180,
+                        NorthBoundingCoordinate: 90,
+                        EastBoundingCoordinate: 180,
+                        SouthBoundingCoordinate: -90
+                      }
+                    ]
+                  }
+                }
+              },
+              VisualizationType: 'tiles',
+              Title: 'FOO UPDATE MODIS Terra Corrected Reflectance (True Color)',
+              ScienceKeywords: [
+                {
+                  Category: 'EARTH SCIENCE',
+                  Topic: 'SPECTRAL/ENGINEERING',
+                  Term: 'VISIBLE WAVELENGTHS',
+                  VariableLevel1: 'REFLECTANCE'
+                },
+                {
+                  Category: 'EARTH SCIENCE',
+                  Topic: 'ATMOSPHERIC OPTICS',
+                  Term: 'ATMOSPHERIC TRANSMITTANCE',
+                  VariableLevel1: 'ATMOSPHERIC TRANSPARENCY'
+                }
+              ],
+              TemporalExtents: [
+                {
+                  RangeDateTimes: [
+                    {
+                      BeginningDateTime: '2002-05-01T00:00:00Z',
+                      EndingDateTime: '2023-12-31T23:59:59Z'
+                    }
+                  ],
+                  EndsAtPresentFlag: true
+                }
+              ],
+              Specification: {
+                ProductIdentification: {
+                  InternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  StandardOrNRTExternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  BestAvailableExternalIdentifier: 'MODIS_Terra_CorrectedReflectance',
+                  GIBSTitle: 'Corrected Reflectance (True Color)',
+                  WorldviewTitle: 'Corrected Reflectance (True Color)',
+                  WorldviewSubtitle: 'Terra / MODIS'
+                },
+                ProductMetadata: {
+                  ParameterUnits: [
+                    null
+                  ],
+                  InternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  SourceDatasets: [
+                    'C1000000001-EARTHDATA'
+                  ],
+                  TemporalCoverage: '2002-05-01/P1D',
+                  RepresentingDatasets: [
+                    'C1000000001-EARTHDATA'
+                  ],
+                  'wmts:Dimension': {
+                    Identifier: 'Time',
+                    UOM: 'ISO8601',
+                    Default: '2023-12-31',
+                    Current: true,
+                    Value: [
+                      '2002-05-01/2023-12-31/P1D'
+                    ]
+                  },
+                  OrbitDirection: [
+                    'descending'
+                  ],
+                  Measurement: 'Corrected Reflectance',
+                  ScienceParameters: [
+                    'reflectance'
+                  ],
+                  AscendingOrDescending: 'Both',
+                  Daynight: [
+                    'day'
+                  ],
+                  NativeSpatialCoverage: [
+                    -90,
+                    -180,
+                    90,
+                    180
+                  ],
+                  'wmts:Format': [
+                    'image/jpeg'
+                  ],
+                  UpdateInterval: 180,
+                  OrbitTracks: [
+                    'OrbitTracks_Terra_Descending'
+                  ],
+                  LayerPeriod: 'Daily',
+                  Ongoing: true,
+                  'ows:Metadata': [
+                    {
+                      'xlink:Href': 'https://gibs.earthdata.nasa.gov/colormaps/v1.3/MODIS_Corrected_Reflectance_TrueColor.xml',
+                      'xlink:Role': 'http://earthdata.nasa.gov/gibs/metadata-type/colormap/1.3',
+                      'xlink:Title': 'GIBS Color Map: Data - RGB Mapping',
+                      'xlink:Type': 'simple'
+                    }
+                  ],
+                  'ows:Identifier': 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  WGS84SpatialCoverage: [
+                    -90,
+                    -180,
+                    90,
+                    180
+                  ],
+                  GranuleOrComposite: 'Granule',
+                  ColorMap: 'MODIS_Corrected_Reflectance_TrueColor',
+                  DataDayBreak: '00:00:00Z',
+                  VisualizationLatency: '4 hours',
+                  'wmts:TileMatrixSetLink': {
+                    TileMatrixSet: '250m'
+                  },
+                  RetentionPeriod: 365
+                }
+              },
+              Generation: {
+                SourceProjection: 'EPSG:4326',
+                SourceResolution: 'Native',
+                SourceFormat: 'GeoTIFF',
+                SourceColorModel: 'Full-Color RGB',
+                SourceCoverage: 'Granule',
+                OutputProjection: 'EPSG:4326',
+                OutputResolution: '250m',
+                OutputFormat: 'JPEG'
+              },
+              Description: 'MODIS Terra Corrected Reflectance True Color imagery shows land surface, ocean and atmospheric features by combining three different channels (bands) of the sensor data. The image has been enhanced through processing, including atmospheric correction for aerosols, to improve the visual depiction of the land surface while maintaining realistic colors.',
+              Subtitle: 'Terra / MODIS',
+              Name: 'MODIS_Terra_Corrected_Reflectance_TrueColor',
+              Identifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+              MetadataSpecification: {
+                URL: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
+                Name: 'Visualization',
+                Version: '1.1.0'
+              }
+            }
+          }]
+        })
+
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Hits': 2,
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/visualizations.umm_json?all_revisions=true&concept_id=VIS100000-EDSC')
+        .reply(200, {
+          items: [{
+            meta: {
+              'concept-id': 'VIS100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '2'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }, {
+            meta: {
+              'concept-id': 'VIS100000-EDSC',
+              'native-id': 'test-guid',
+              'revision-id': '1'
+            },
+            umm: {
+              Name: 'Cras mattis consectetur purus sit amet fermentum.'
+            }
+          }]
+        })
+
+      const response = await server.executeOperation({
+        variables: {},
+        query: `{
+          visualizations {
+            count
+            items {
+              conceptId
+              description
+              generation
+              identifier
+              metadataSpecification
+              name
+              nativeId
+              revisionDate
+              revisionId
+              revisions {
+                count
+                items {
+                  revisionId
+                }
+              }
+              scienceKeywords
+              spatialExtent
+              specification
+              subtitle
+              temporalExtent
+              title
+              ummMetadata
+              visualizationType
+              collections {
+                count
+              }
+            }
+          }
+        }`
+      }, {
+        contextValue
+      })
+
+      const { data, errors } = response.body.singleResult
+
+      expect(errors).toBeUndefined()
+
+      expect(data).toEqual({
+        visualizations: {
+          count: 1,
+          items: [{
+            conceptId: 'VIS100000-EDSC',
+            description: 'MODIS Terra Corrected Reflectance True Color imagery shows land surface, ocean and atmospheric features by combining three different channels (bands) of the sensor data. The image has been enhanced through processing, including atmospheric correction for aerosols, to improve the visual depiction of the land surface while maintaining realistic colors.',
+            generation: {
+              sourceProjection: 'EPSG:4326',
+              sourceResolution: 'Native',
+              sourceFormat: 'GeoTIFF',
+              sourceColorModel: 'Full-Color RGB',
+              sourceCoverage: 'Granule',
+              outputProjection: 'EPSG:4326',
+              outputResolution: '250m',
+              outputFormat: 'JPEG'
+            },
+            identifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+            metadataSpecification: {
+              url: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
+              name: 'Visualization',
+              version: '1.1.0'
+            },
+            name: 'MODIS_Terra_Corrected_Reflectance_TrueColor',
+            nativeId: 'tiles',
+            revisionDate: '2025-03-18VIS19:22:44.814Z',
+            revisionId: '3',
+            revisions: {
+              count: 2,
+              items: [{ revisionId: '2' }, { revisionId: '1' }]
+            },
+            scienceKeywords: null,
+            spatialExtent: {
+              granuleSpatialRepresentation: 'GEODETIC',
+              horizontalSpatialDomain: {
+                geometry: {
+                  coordinateSystem: 'GEODETIC',
+                  boundingRectangles: [{
+                    westBoundingCoordinate: -180,
+                    northBoundingCoordinate: 90,
+                    eastBoundingCoordinate: 180,
+                    southBoundingCoordinate: -90
+                  }]
+                }
+              }
+            },
+            specification: {
+              productIdentification: {
+                internalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                standardOrNrtExternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                bestAvailableExternalIdentifier: 'MODIS_Terra_CorrectedReflectance',
+                gibsTitle: 'Corrected Reflectance (True Color)',
+                worldviewTitle: 'Corrected Reflectance (True Color)',
+                worldviewSubtitle: 'Terra / MODIS'
+              },
+              productMetadata: {
+                parameterUnits: [null],
+                internalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                sourceDatasets: ['C1000000001-EARTHDATA'],
+                temporalCoverage: '2002-05-01/P1D',
+                representingDatasets: ['C1000000001-EARTHDATA'],
+                'wmts:dimension': {
+                  identifier: 'Time',
+                  uom: 'ISO8601',
+                  default: '2023-12-31',
+                  current: true,
+                  value: ['2002-05-01/2023-12-31/P1D']
+                },
+                orbitDirection: ['descending'],
+                measurement: 'Corrected Reflectance',
+                scienceParameters: ['reflectance'],
+                ascendingOrDescending: 'Both',
+                daynight: ['day'],
+                nativeSpatialCoverage: [-90, -180, 90, 180],
+                'wmts:format': ['image/jpeg'],
+                updateInterval: 180,
+                orbitTracks: ['OrbitTracks_Terra_Descending'],
+                layerPeriod: 'Daily',
+                ongoing: true,
+                'ows:metadata': [{
+                  'xlink:href': 'https://gibs.earthdata.nasa.gov/colormaps/v1.3/MODIS_Corrected_Reflectance_TrueColor.xml',
+                  'xlink:role': 'http://earthdata.nasa.gov/gibs/metadata-type/colormap/1.3',
+                  'xlink:title': 'GIBS Color Map: Data - RGB Mapping',
+                  'xlink:type': 'simple'
+                }],
+                'ows:identifier': 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                wgs84SpatialCoverage: [-90, -180, 90, 180],
+                granuleOrComposite: 'Granule',
+                colorMap: 'MODIS_Corrected_Reflectance_TrueColor',
+                dataDayBreak: '00:00:00Z',
+                visualizationLatency: '4 hours',
+                'wmts:tileMatrixSetLink': { tileMatrixSet: '250m' },
+                retentionPeriod: 365
+              }
+            },
+            subtitle: 'Terra / MODIS',
+            temporalExtent: null,
+            title: 'FOO UPDATE MODIS Terra Corrected Reflectance (True Color)',
+            ummMetadata: {
+              ConceptIds: [{
+                Type: 'STD',
+                Value: 'C1000000001-EARTHDATA',
+                DataCenter: 'MODAPS',
+                ShortName: 'MODIS_Terra_CorrectedReflectance',
+                Title: 'MODIS/Terra Corrected Reflectance True Color',
+                Version: '6.1'
+              }],
+              SpatialExtent: {
+                GranuleSpatialRepresentation: 'GEODETIC',
+                HorizontalSpatialDomain: {
+                  Geometry: {
+                    CoordinateSystem: 'GEODETIC',
+                    BoundingRectangles: [{
+                      WestBoundingCoordinate: -180,
+                      NorthBoundingCoordinate: 90,
+                      EastBoundingCoordinate: 180,
+                      SouthBoundingCoordinate: -90
+                    }]
+                  }
+                }
+              },
+              VisualizationType: 'tiles',
+              Title: 'FOO UPDATE MODIS Terra Corrected Reflectance (True Color)',
+              ScienceKeywords: [{
+                Category: 'EARTH SCIENCE',
+                Topic: 'SPECTRAL/ENGINEERING',
+                Term: 'VISIBLE WAVELENGTHS',
+                VariableLevel1: 'REFLECTANCE'
+              }, {
+                Category: 'EARTH SCIENCE',
+                Topic: 'ATMOSPHERIC OPTICS',
+                Term: 'ATMOSPHERIC TRANSMITTANCE',
+                VariableLevel1: 'ATMOSPHERIC TRANSPARENCY'
+              }],
+              TemporalExtents: [{
+                RangeDateTimes: [{
+                  BeginningDateTime: '2002-05-01T00:00:00Z',
+                  EndingDateTime: '2023-12-31T23:59:59Z'
+                }],
+                EndsAtPresentFlag: true
+              }],
+              Specification: {
+                ProductIdentification: {
+                  InternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  StandardOrNRTExternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  BestAvailableExternalIdentifier: 'MODIS_Terra_CorrectedReflectance',
+                  GIBSTitle: 'Corrected Reflectance (True Color)',
+                  WorldviewTitle: 'Corrected Reflectance (True Color)',
+                  WorldviewSubtitle: 'Terra / MODIS'
+                },
+                ProductMetadata: {
+                  ParameterUnits: [null],
+                  InternalIdentifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  SourceDatasets: ['C1000000001-EARTHDATA'],
+                  TemporalCoverage: '2002-05-01/P1D',
+                  RepresentingDatasets: ['C1000000001-EARTHDATA'],
+                  'wmts:Dimension': {
+                    Identifier: 'Time',
+                    UOM: 'ISO8601',
+                    Default: '2023-12-31',
+                    Current: true,
+                    Value: ['2002-05-01/2023-12-31/P1D']
+                  },
+                  OrbitDirection: ['descending'],
+                  Measurement: 'Corrected Reflectance',
+                  ScienceParameters: ['reflectance'],
+                  AscendingOrDescending: 'Both',
+                  Daynight: ['day'],
+                  NativeSpatialCoverage: [-90, -180, 90, 180],
+                  'wmts:Format': ['image/jpeg'],
+                  UpdateInterval: 180,
+                  OrbitTracks: ['OrbitTracks_Terra_Descending'],
+                  LayerPeriod: 'Daily',
+                  Ongoing: true,
+                  'ows:Metadata': [{
+                    'xlink:Href': 'https://gibs.earthdata.nasa.gov/colormaps/v1.3/MODIS_Corrected_Reflectance_TrueColor.xml',
+                    'xlink:Role': 'http://earthdata.nasa.gov/gibs/metadata-type/colormap/1.3',
+                    'xlink:Title': 'GIBS Color Map: Data - RGB Mapping',
+                    'xlink:Type': 'simple'
+                  }],
+                  'ows:Identifier': 'MODIS_Terra_CorrectedReflectance_TrueColor',
+                  WGS84SpatialCoverage: [-90, -180, 90, 180],
+                  GranuleOrComposite: 'Granule',
+                  ColorMap: 'MODIS_Corrected_Reflectance_TrueColor',
+                  DataDayBreak: '00:00:00Z',
+                  VisualizationLatency: '4 hours',
+                  'wmts:TileMatrixSetLink': { TileMatrixSet: '250m' },
+                  RetentionPeriod: 365
+                }
+              },
+              Generation: {
+                SourceProjection: 'EPSG:4326',
+                SourceResolution: 'Native',
+                SourceFormat: 'GeoTIFF',
+                SourceColorModel: 'Full-Color RGB',
+                SourceCoverage: 'Granule',
+                OutputProjection: 'EPSG:4326',
+                OutputResolution: '250m',
+                OutputFormat: 'JPEG'
+              },
+              Description: 'MODIS Terra Corrected Reflectance True Color imagery shows land surface, ocean and atmospheric features by combining three different channels (bands) of the sensor data. The image has been enhanced through processing, including atmospheric correction for aerosols, to improve the visual depiction of the land surface while maintaining realistic colors.',
+              Subtitle: 'Terra / MODIS',
+              Name: 'MODIS_Terra_Corrected_Reflectance_TrueColor',
+              Identifier: 'MODIS_Terra_CorrectedReflectance_TrueColor',
+              MetadataSpecification: {
+                URL: 'https://cdn.earthdata.nasa.gov/umm/visualization/v1.1.0',
+                Name: 'Visualization',
+                Version: '1.1.0'
+              }
+            },
+            visualizationType: 'tiles',
+            collections: {
+              count: 0
+            }
+          }]
+        }
+      })
+    })
+
+    test('visualizations', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .get('/search/visualizations.json?page_size=2')
+        .reply(200, {
+          items: [{
+            concept_id: 'VIS100000-EDSC'
+          }, {
+            concept_id: 'VIS100001-EDSC'
+          }]
+        })
+
+      const response = await server.executeOperation({
+        variables: {},
+        query: `{
+          visualizations (params: { limit:2 }) {
+            items {
+              conceptId
+            }
+          }
+        }`
+      }, {
+        contextValue
+      })
+
+      const { data, errors } = response.body.singleResult
+
+      expect(errors).toBeUndefined()
+
+      expect(data).toEqual({
+        visualizations: {
+          items: [{
+            conceptId: 'VIS100000-EDSC'
+          }, {
+            conceptId: 'VIS100001-EDSC'
+          }]
+        }
+      })
+    })
+
+    describe('visualization', () => {
+      describe('with results', () => {
+        test('returns results', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/visualizations.json?concept_id=VIS100000-EDSC')
+            .reply(200, {
+              items: [{
+                concept_id: 'VIS100000-EDSC'
+              }]
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              visualization (params: { conceptId: "VIS100000-EDSC" }) {
+                conceptId
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            visualization: {
+              conceptId: 'VIS100000-EDSC'
+            }
+          })
+        })
+      })
+
+      describe('with no results', () => {
+        test('returns no results', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 0,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/visualizations.json?concept_id=VIS100000-EDSC')
+            .reply(200, {
+              items: []
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              visualization (params: { conceptId: "VIS100000-EDSC" }) {
+                conceptId
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            visualization: null
+          })
+        })
+      })
+    })
+  })
+
+  describe('Mutation', () => {
+    describe('restoreVisualizationRevision', () => {
+      test('restores an old version of a visualization', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get('/search/visualizations.umm_json?concept_id=VIS100000-EDSC&all_revisions=true')
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'VIS100000-EDSC',
+                'native-id': '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+                'revision-id': 1
+              },
+              umm: {
+                EntryTitle: 'Tortor Elit Fusce Quam Risus'
+              }
+            }, {
+              meta: {
+                'concept-id': 'VIS100000-EDSC',
+                'native-id': '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed',
+                'revision-id': 2
+              },
+              umm: {
+                EntryTitle: 'Adipiscing Cras Etiam Venenatis'
+              }
+            }]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .put('/ingest/providers/EDSC/visualizations/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed')
+          .reply(200, {
+            'concept-id': 'VIS100000-EDSC',
+            'revision-id': '3'
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            revisionId: '1',
+            conceptId: 'VIS100000-EDSC'
+          },
+          query: `mutation RestoreVisualizationRevision (
+              $conceptId: String!
+              $revisionId: String!
+            ) {
+              restoreVisualizationRevision (
+                conceptId: $conceptId
+                revisionId: $revisionId
+              ) {
+                  conceptId
+                  revisionId
+                }
+              }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          restoreVisualizationRevision: {
+            conceptId: 'VIS100000-EDSC',
+            revisionId: '3'
+          }
+        })
+      })
+    })
+
+    test('deleteVisualization', async () => {
+      nock(/example-cmr/)
+        .defaultReplyHeaders({
+          'CMR-Took': 7,
+          'CMR-Request-Id': 'abcd-1234-efgh-5678'
+        })
+        .delete(/ingest\/providers\/EDSC\/visualizations\/test-guid/)
+        .reply(201, {
+          'concept-id': 'VIS100000-EDSC',
+          'revision-id': '2'
+        })
+
+      const response = await server.executeOperation({
+        variables: {
+          nativeId: 'test-guid',
+          providerId: 'EDSC'
+        },
+        query: `mutation DeleteVisualization (
+          $providerId: String!
+          $nativeId: String!
+        ) {
+          deleteVisualization (
+            providerId: $providerId
+            nativeId: $nativeId
+          ) {
+              conceptId
+              revisionId
+            }
+          }`
+      }, {
+        contextValue
+      })
+
+      const { data } = response.body.singleResult
+
+      expect(data).toEqual({
+        deleteVisualization: {
+          conceptId: 'VIS100000-EDSC',
+          revisionId: '2'
+        }
+      })
+    })
+  })
+
+  describe('Visualization', () => {
+    describe('collections', () => {
+      test('returns collections when querying a published record', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/visualizations\.json/)
+          .reply(200, {
+            items: [{
+              concept_id: 'VIS100000-EDSC',
+              association_details: {
+                collections: [
+                  {
+                    data: {
+                      association_type: 'visualization'
+                    },
+                    concept_id: 'C100000-EDSC'
+                  }
+                ]
+              }
+            }, {
+              concept_id: 'VIS100001-EDSC',
+              association_details: {
+                collections: [
+                  {
+                    data: {
+                      association_type: 'visualization'
+                    },
+                    concept_id: 'C100001-EDSC'
+                  }
+                ]
+              }
+            }]
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get('/search/collections.json?concept_id[]=C100000-EDSC&page_size=20')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100000-EDSC'
+              }]
+            }
+          })
+
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get('/search/collections.json?concept_id[]=C100001-EDSC&page_size=20')
+          .reply(200, {
+            feed: {
+              entry: [{
+                id: 'C100001-EDSC'
+              }]
+            }
+          })
+
+        const response = await server.executeOperation({
+          variables: {},
+          query: `{
+            visualizations {
+              items {
+                conceptId
+                collections {
+                  items {
+                    conceptId
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data, errors } = response.body.singleResult
+
+        expect(errors).toBeUndefined()
+
+        expect(data).toEqual({
+          visualizations: {
+            items: [{
+              conceptId: 'VIS100000-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100000-EDSC'
+                }]
+              }
+            }, {
+              conceptId: 'VIS100001-EDSC',
+              collections: {
+                items: [{
+                  conceptId: 'C100001-EDSC'
+                }]
+              }
+            }]
+          }
+        })
+      })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/visualization-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'VISD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'VISD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Visualization'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                previewMetadata {
+                  ... on Visualization {
+                    collections {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data, errors } = response.body.singleResult
+
+        expect(errors).toBeUndefined()
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              previewMetadata: {
+                collections: null
+              }
+            }, {
+              previewMetadata: {
+                collections: null
+              }
+            }]
+          }
+        })
+      })
+    })
+  })
+})

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -303,6 +303,36 @@ export default {
         conceptId: variableConceptIds,
         ...handlePagingParams(args)
       }, context, parseResolveInfo(info))
+    },
+    visualizations: async (source, args, context, info) => {
+      const {
+        associationDetails = {},
+        conceptId
+      } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (isDraftConceptId(conceptId, 'collection')) return null
+
+      const { dataSources } = context
+
+      const { visualizations = [] } = associationDetails
+
+      const visualizationConceptIds = visualizations.map(
+        ({ conceptId: visualizationId }) => visualizationId
+      )
+
+      if (!visualizations.length) {
+        return {
+          count: 0,
+          items: []
+        }
+      }
+
+      return dataSources.visualizationSourceFetch({
+        conceptId: visualizationConceptIds,
+        ...handlePagingParams(args)
+      }, context, parseResolveInfo(info))
     }
   },
   Relationship: {

--- a/src/resolvers/draft.js
+++ b/src/resolvers/draft.js
@@ -68,6 +68,7 @@ export default {
       if (isDraftConceptId(conceptId, 'service')) return 'Service'
       if (isDraftConceptId(conceptId, 'tool')) return 'Tool'
       if (isDraftConceptId(conceptId, 'variable')) return 'Variable'
+      if (isDraftConceptId(conceptId, 'visualization')) return 'Visualization'
 
       return null
     }

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -21,6 +21,7 @@ import toolDraftResolver from './toolDraft'
 import toolResolver from './tool'
 import variableDraftResolver from './variableDraft'
 import variableResolver from './variable'
+import visualizationResolver from './visualization'
 
 const resolvers = [
   aclResolver,
@@ -43,7 +44,8 @@ const resolvers = [
   toolDraftResolver,
   toolResolver,
   variableDraftResolver,
-  variableResolver
+  variableResolver,
+  visualizationResolver
 ]
 
 export default mergeResolvers(resolvers)

--- a/src/resolvers/visualization.js
+++ b/src/resolvers/visualization.js
@@ -82,7 +82,7 @@ export default {
       // Find the associated collections
       const { collections = [] } = associationDetails
 
-      // If there are no associations to collections for this order option
+      // If there are no associations to collections for this visualization
       if (!collections.length) {
         return {
           count: 0,

--- a/src/resolvers/visualization.js
+++ b/src/resolvers/visualization.js
@@ -1,0 +1,103 @@
+import { parseResolveInfo } from 'graphql-parse-resolve-info'
+
+import { handlePagingParams } from '../utils/handlePagingParams'
+import { isDraftConceptId } from '../utils/isDraftConceptId'
+
+export default {
+  Query: {
+    visualizations: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.visualizationSourceFetch(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    },
+    visualization: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const result = await dataSources.visualizationSourceFetch(
+        args,
+        context,
+        parseResolveInfo(info)
+      )
+
+      const [firstResult] = result
+
+      return firstResult
+    }
+  },
+
+  Mutation: {
+    restoreVisualizationRevision: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.visualizationSourceRestoreRevision(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
+    deleteVisualization: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.visualizationSourceDelete(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    }
+  },
+
+  Visualization: {
+    revisions: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const { conceptId } = source
+
+      return dataSources.visualizationSourceFetch(
+        {
+          conceptId,
+          allRevisions: true
+        },
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
+    collections: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      const {
+        associationDetails = {},
+        conceptId
+      } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (isDraftConceptId(conceptId, 'visualization')) return null
+
+      // Find the associated collections
+      const { collections = [] } = associationDetails
+
+      // If there are no associations to collections for this order option
+      if (!collections.length) {
+        return {
+          count: 0,
+          items: []
+        }
+      }
+
+      const collectionConceptIds = collections.map((collection) => collection.conceptId)
+
+      const requestedParams = handlePagingParams({
+        conceptId: collectionConceptIds,
+        ...args
+      })
+
+      return dataSources.collectionSourceFetch(requestedParams, context, parseResolveInfo(info))
+    }
+  }
+}

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -414,6 +414,11 @@ type Collection {
     name: String @deprecated(reason: "Use `params.name`")
   ): VariableList
 
+  visualizations (
+    "Visualizations query parameters"
+    params: VisualizationsInput
+  ): VisualizationList
+
   "Generates variable drafts on the collection using earthdata-varinfo"
   generateVariableDrafts: VariableDraftList
 

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -414,6 +414,7 @@ type Collection {
     name: String @deprecated(reason: "Use `params.name`")
   ): VariableList
 
+  "Returns a list of associated visualizations."
   visualizations (
     "Visualizations query parameters"
     params: VisualizationsInput

--- a/src/types/draft.graphql
+++ b/src/types/draft.graphql
@@ -1,5 +1,5 @@
-"PreviewMetadata can be either a Collection, Service, Tool or Variable."
-union PreviewMetadata = Collection | Service | Tool | Variable
+"PreviewMetadata can be either a Collection, Service, Tool, Variable, or Visualization."
+union PreviewMetadata = Collection | Service | Tool | Variable | Visualization
 
 "DraftConceptType must be one of the enum values."
 enum DraftConceptType {
@@ -7,6 +7,7 @@ enum DraftConceptType {
   Service
   Tool
   Variable
+  Visualization
 }
 
 type DraftMutationResponse {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -23,6 +23,7 @@ import tool from './tool.graphql'
 import toolDraft from './toolDraft.graphql'
 import variable from './variable.graphql'
 import variableDraft from './variableDraft.graphql'
+import visualization from './visualization.graphql'
 
 export default mergeTypeDefs(
   [
@@ -48,7 +49,8 @@ export default mergeTypeDefs(
     tool,
     toolDraft,
     variable,
-    variableDraft
+    variableDraft,
+    visualization
   ],
   { all: true },
 )

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -20,10 +20,10 @@ type Visualization {
   "The native id of a visualization."
   nativeId: String
 
-  "Date which the Tool was last updated."
+  "Date which the Visualization was last updated."
   revisionDate: String
 
-  "The revision id of the Tool."
+  "The revision id of the Visualization."
   revisionId: String
 
   "The list of revisions for the visualization."
@@ -47,7 +47,7 @@ type Visualization {
   "A short descriptive title of the visualization."
   title: String
 
-  "Raw UMM Metadata of the Tool Record."
+  "Raw UMM Metadata of the Visualization Record."
   ummMetadata: JSON
 
   "The type of visualization, `tiles` or `maps`."

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -1,0 +1,158 @@
+type Visualization {
+  "The unique concept id assigned to the visualization."
+  conceptId: String!
+
+  "A human readable description of the visualization written using HTML notation for advanced text.  The goal is to create descriptions for the science-minded public that may have an interest in finding out what the visualization shows, why it’s important, how it was created, etc..."
+  description: String
+
+  "How this visualization is generated."
+  generation: JSON
+
+  "The unique identifier for the visualization."
+  identifier: String
+
+  "Requires the client, or user, to add in schema information into every visualization record. It includes the schema's name, version, and URL location. The information is controlled through enumerations at the end of this schema."
+  metadataSpecification: JSON
+
+  "A name of the visualization."
+  name: String
+
+  "The native id of a visualization."
+  nativeId: String
+
+  "Date which the Tool was last updated."
+  revisionDate: String
+
+  "The revision id of the Tool."
+  revisionId: String
+
+  "The list of revisions for the visualization."
+  revisions: VisualizationRevisionList
+
+  "Earth Science keywords that are representative of the data being visualized. The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS)."
+  scienceKeywords: JSON
+
+  "TBD"
+  spatialExtent: JSON
+
+  "Identify and specify visualization product."
+  specification: JSON
+
+  "A short descriptive subtitle of the visualization."
+  subtitle: String
+
+  "This class contains attributes which describe the temporal range of a specific layer. Temporal Extent includes a specification of the Temporal Range Type of the collection, which is one of Range Date Time, Single Date Time, or Periodic Date Time"
+  temporalExtent: JSON
+
+  "A short descriptive title of the visualization."
+  title: String
+
+  "Raw UMM Metadata of the Tool Record."
+  ummMetadata: JSON
+
+  "TBD"
+  visualizationType: String
+
+  collections (
+    "Collections query parameters"
+    params: CollectionsInput
+  ): CollectionList
+}
+
+type VisualizationRevisionList {
+  "The number of hits for a given search."
+  count: Int
+
+  "The list of visualization search results."
+  items: [Visualization]
+}
+
+type VisualizationList {
+  "The number of hits for a given search."
+  count: Int
+
+  "Cursor that points to a specific position in a list of requested records."
+  cursor: String
+
+  "The list of visualization search results."
+  items: [Visualization]
+}
+
+input VisualizationsInput {
+  "The unique concept id assigned to the visualization."
+  conceptId: [String]
+
+  "Cursor that points to a specific position in a list of requested records."
+  cursor: String
+
+  "The number of visualizations requested by the user."
+  limit: Int
+
+  "The native id of the visualization."
+  nativeId: String
+
+  "The name of the visualization."
+  name: String
+
+  "Zero based offset of individual results."
+  offset: Int
+
+  options: JSON
+
+  "The name of the provider associated with the visualization."
+  provider: String
+
+  "One or more sort keys can be specified to impact searching. Fields can be prepended with a '-' to sort in descending order. Ascending order is the default but + can be used to explicitly request ascending."
+  sortKey: [String]
+
+  "The title of the visualization."
+  title: String
+
+  "The type of visualization."
+  visualizationType: String
+}
+
+input VisualizationInput {
+  "The concept id of the visualization."
+  conceptId: String!
+}
+
+type Query {
+  "Get a list of visualizations."
+  visualizations (
+    "Visualization query parameters"
+    params: VisualizationsInput
+  ): VisualizationList!
+
+  "Get a visualization."
+  visualization (
+    "Visualization query parameters"
+    params: VisualizationInput
+  ): Visualization
+}
+
+type Mutation {
+  restoreVisualizationRevision (
+    "The unique concept id assigned to the visualization."
+    conceptId: String!
+
+    "The revision of the visualization."
+    revisionId: String!
+  ): VisualizationMutationResponse
+
+  deleteVisualization (
+    "Provider ID of the visualization."
+    providerId: String!
+
+    "The native id of a visualization."
+    nativeId: String!
+  ): VisualizationMutationResponse
+}
+
+type VisualizationMutationResponse {
+  "The unique concept id assigned to the visualization."
+  conceptId: String!
+
+  "The revision of the visualization."
+  revisionId: String!
+}

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -32,7 +32,7 @@ type Visualization {
   "Earth Science keywords that are representative of the data being visualized. The controlled vocabulary for Science Keywords is maintained in the Keyword Management System (KMS)."
   scienceKeywords: JSON
 
-  "TBD"
+  "The spatial extent of the visualization."
   spatialExtent: JSON
 
   "Identify and specify visualization product."
@@ -50,9 +50,10 @@ type Visualization {
   "Raw UMM Metadata of the Tool Record."
   ummMetadata: JSON
 
-  "TBD"
+  "The type of visualization, `tiles` or `maps`."
   visualizationType: String
 
+  "Returns a list of associated collections."
   collections (
     "Collections query parameters"
     params: CollectionsInput
@@ -96,8 +97,6 @@ input VisualizationsInput {
 
   "Zero based offset of individual results."
   offset: Int
-
-  options: JSON
 
   "The name of the provider associated with the visualization."
   provider: String

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -133,6 +133,7 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
         || requestedFields.includes('relatedCollections')
         || requestedFields.includes('revisions')
         || requestedFields.includes('subscriptions')
+        || requestedFields.includes('visualizations')
       )
        && !requestedFields.includes('conceptId')) {
       requestedFields.push('conceptId')

--- a/src/utils/umm/tagKeyMap.json
+++ b/src/utils/umm/tagKeyMap.json
@@ -12,6 +12,5 @@
     "description": "umm.Description",
     "revisionId": "meta.revision-id",
     "originatorId": "umm.OriginatorId"
-
   }
 }

--- a/src/utils/umm/visualizationKeyMap.json
+++ b/src/utils/umm/visualizationKeyMap.json
@@ -1,0 +1,28 @@
+{
+  "sharedKeys": [
+    "conceptId",
+    "longName",
+    "name"
+  ],
+  "ummKeyMappings": {
+    "associationDetails": "meta.association-details",
+    "conceptId": "meta.concept-id",
+    "description": "umm.Description",
+    "generation": "umm.Generation",
+    "identifier": "umm.Identifier",
+    "metadataSpecification": "umm.MetadataSpecification",
+    "name": "umm.Name",
+    "nativeId": "meta.native-id",
+    "provider": "meta.provider",
+    "revisionDate": "meta.revision-date",
+    "revisionId": "meta.revision-id",
+    "spatialExtent": "umm.SpatialExtent",
+    "specification": "umm.Specification",
+    "subtitle": "umm.Subtitle",
+    "temporalExtent": "umm.TemporalExtent",
+    "title": "umm.Title",
+    "ummMetadata": "umm",
+    "userId": "meta.user-id",
+    "visualizationType": "umm.VisualizationType"
+  }
+}


### PR DESCRIPTION
# Overview

### What is the feature?

Adds UMM-Vis

### What areas of the application does this impact?

New queries and mutations for UMM-Vis

# Testing

```
query Visualizations($params: VisualizationsInput) {
  visualizations(params: $params) {
    count
    items {
      conceptId
      revisionId
      name
      title
    }
  }
}
```

```
query Visualization($params: VisualizationInput) {
  visualization(params: $params) {
    conceptId
    description
    generation
    identifier
    metadataSpecification
    name
    nativeId
    revisionDate
    revisionId
    revisions {
      count
    }
    scienceKeywords
    spatialExtent
    specification
    subtitle
    temporalExtent
    title
    ummMetadata
    visualizationType
    collections {
      count
    }
  }
}
```

```
query Drafts($params: DraftsInput) {
  drafts(params: $params) {
    count
    items {
      conceptId
      name
      previewMetadata {
        ... on Visualization {
          name
        }
      }
    }
  }
}
```

```
mutation IngestDraftMutation(
  $conceptType: DraftConceptType!
  $metadata: JSON!
  $nativeId: String!
  $providerId: String!
  $ummVersion: String!
) {
  ingestDraft(
    conceptType: $conceptType
    metadata: $metadata
    nativeId: $nativeId
    providerId: $providerId
    ummVersion: $ummVersion
  ) {
    conceptId
    revisionId
    warnings
    existingErrors
  }
}
```

```
mutation DeleteVisualization($providerId: String!, $nativeId: String!) {
  deleteVisualization(providerId: $providerId, nativeId: $nativeId) {
    conceptId
    revisionId
  }
}
```

```
mutation RestoreVisualizationRevision($conceptId: String!, $revisionId: String!) {
  restoreVisualizationRevision(conceptId: $conceptId, revisionId: $revisionId) {
    conceptId
    revisionId
  }
}
```
# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
