### PR TITLE
GQL-108: Adding providerId to Visualization

### DIFF
--- a/src/resolvers/__tests__/visualization.test.js
+++ b/src/resolvers/__tests__/visualization.test.js
@@ -264,6 +264,7 @@ describe('Visualization', () => {
               metadataSpecification
               name
               nativeId
+              providerId
               revisionDate
               revisionId
               revisions {
@@ -318,6 +319,7 @@ describe('Visualization', () => {
             },
             name: 'MODIS_Terra_Corrected_Reflectance_TrueColor',
             nativeId: 'tiles',
+            providerId: 'EDSC',
             revisionDate: '2025-03-18VIS19:22:44.814Z',
             revisionId: '3',
             revisions: {

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -20,6 +20,9 @@ type Visualization {
   "The native id of a visualization."
   nativeId: String
 
+  "Provider ID of the Visualization."
+  providerId: String
+
   "Date which the Visualization was last updated."
   revisionDate: String
 


### PR DESCRIPTION
# Overview

### What is the feature?

Adding providerId to Visualization

### What is the Solution?

Adding providerId to Visualization

### What areas of the application does this impact?

Visualization

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: Get_Visualizations query

1. The GET_VISUALIZATIONS query we will use to load the All Visualizations page is below. Copy and paste it into gql to ensure providerId returns

query Visualizations($params: VisualizationsInput) {
  visualizations(params: $params) {
    count
    items {
      conceptId
      name
      title
      revisionId
      providerId
      revisionDate
    }
  }
}

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
