### PR TITLE
GQL-111: Update CMR-GraphQL To Support CMR Changes for 'IsDescribedBy' As a UMM-C/AssociatedDOIs Enumeration

### DIFF
--- a/cdk/graphql/lib/graphql-stack.ts
+++ b/cdk/graphql/lib/graphql-stack.ts
@@ -38,7 +38,7 @@ const environment = {
   stellateAppName: process.env.STELLATE_APP_NAME!,
   stellateKey: process.env.STELLATE_KEY!,
   lambdaTimeout: process.env.LAMBDA_TIMEOUT || '30',
-  ummCollectionVersion: '1.18.3',
+  ummCollectionVersion: '1.18.4',
   ummGranuleVersion: '1.6.5',
   ummOrderOptionVersion: '1.0.0',
   ummServiceVersion: '1.5.3',


### PR DESCRIPTION
# Overview

### What is the feature?

Update UMM-C schema version from 1.18.3 to 1.18.4: https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/collection/v1.18.4

### What is the Solution?

UMM-C schema added a new enum value "IsDescribedBy" under AssociatedDOIs.

Since AssociatedDOIs is a JSON object in we only need to update the version number.

### What areas of the application does this impact?

This only required a single version bump in GQL without any other changes.

# Testing

### Reproduction steps

- **Environment for testing: local**
- **Collection to test with: local **

1. Ingest a valid collection draft with this `associatedDois`:
```
      "associatedDois": [
        {
          "doi": "Test DOI",
          "title": "Some DOI Title",
          "authority": "test",
          "type": "IsDescribedBy"
        }
      ]
```
2. Retrieve published collection and verify the MetadataSpecification version is 1.18.4 and you seen the enum type for associatedDOIs.



Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.
![image](https://github.com/user-attachments/assets/21c5d967-c64c-41cf-a119-76368d94e195)

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
