### PR TITLE
GQL-114: Some collections are not selectable on MMT

### DIFF
--- a/src/cmr/concepts/collection.js
+++ b/src/cmr/concepts/collection.js
@@ -335,8 +335,9 @@ export default class Collection extends Concept {
    */
   normalizeUmmItem(item) {
     const { umm = {} } = item
+    const ummObject = umm == null ? {} : umm
 
-    const { ArchiveAndDistributionInformation: archiveAndDistributionInformation = {} } = umm
+    const { ArchiveAndDistributionInformation: archiveAndDistributionInformation = {} } = ummObject
 
     let fileDistributionInformation = [];
 

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -813,6 +813,111 @@ describe('Collection', () => {
           })
         })
       })
+
+      describe('when retrieving revisions that may contain umm:null', () => {
+        test('includes them in the results', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 1,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/collections\.json/)
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100001-EDSC'
+                }],
+                facets: {}
+              }
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Hits': 3,
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/collections.umm_json?all_revisions=true&concept_id=C100001-EDSC')
+            .reply(200, {
+              items: [{
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '3',
+                  deleted: false
+                },
+                umm: {
+                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+                }
+              }, {
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '2',
+                  deleted: false
+                },
+                umm: null
+              }, {
+                meta: {
+                  'concept-id': 'C100001-EDSC',
+                  'revision-id': '1',
+                  deleted: false
+                },
+                umm: {
+                  Abstract: 'Cras mattis consectetur purus sit amet fermentum.'
+                }
+              }]
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              collections {
+                count
+                facets
+                items {
+                  conceptId
+                  revisions {
+                    count
+                    items {
+                      revisionId
+                    }
+                  }
+                }
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data, errors } = response.body.singleResult
+
+          expect(errors).toBeUndefined()
+
+          expect(data).toEqual({
+            collections: {
+              count: 1,
+              facets: {},
+              items: [{
+                conceptId: 'C100001-EDSC',
+                revisions: {
+                  count: 3,
+                  items: [
+                    {
+                      revisionId: '3'
+                    },
+                    {
+                      revisionId: '2'
+                    },
+                    {
+                      revisionId: '1'
+                    }
+                  ]
+                }
+              }]
+            }
+          })
+        })
+      })
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

User is able to access collection in CMR:https://cmr.earthdata.nasa.gov/search/concepts/C2768943270-CDDIS.html
But not in MMT: https://mmt.earthdata.nasa.gov/collections/C2768943270-CDDIS

### What is the Solution?

Sometimes, the umm: null. See "revision-id" : 3, on this page: https://cmr.earthdata.nasa.gov/search/collections.umm_json?conceptId=C2768943270-CDDIS&allRevisions=true&pretty=true

Needed to edit the normalizeUmmItem function in order to account for this use case.

### What areas of the application does this impact?

Collection.js under concepts

# Testing

### Reproduction steps

- **Environment for testing: PROD
- **Collection to test with: C2768943270-CDDIS and C2799465428-POCLOUD

1. Point local cmr-graphql to PROD and MAKE SURE THE CHANGE graphql-stack.ts line 41 to 1.18.3 (1.18.4 is not in production yet)
2. Call only revisions on one of the collections above, they should now return. Commenting out my one line change will reveal the original error. 

### Attachments
<img width="1653" alt="Screenshot 2025-05-21 at 3 54 09 PM" src="https://github.com/user-attachments/assets/43c084e0-312a-48a8-9bba-c4ff187dd768" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
