### PR TITLE
GQL-116: Adding UserId to Visualization

### DIFF
--- a/src/resolvers/__tests__/visualization.test.js
+++ b/src/resolvers/__tests__/visualization.test.js
@@ -235,7 +235,8 @@ describe('Visualization', () => {
             meta: {
               'concept-id': 'VIS100000-EDSC',
               'native-id': 'test-guid',
-              'revision-id': '2'
+              'revision-id': '2',
+              'user-id': 'test user'
             },
             umm: {
               Name: 'Cras mattis consectetur purus sit amet fermentum.'
@@ -244,7 +245,8 @@ describe('Visualization', () => {
             meta: {
               'concept-id': 'VIS100000-EDSC',
               'native-id': 'test-guid',
-              'revision-id': '1'
+              'revision-id': '1',
+              'user-id': 'test user'
             },
             umm: {
               Name: 'Cras mattis consectetur purus sit amet fermentum.'
@@ -272,6 +274,7 @@ describe('Visualization', () => {
                 count
                 items {
                   revisionId
+                  userId
                 }
               }
               scienceKeywords
@@ -325,7 +328,13 @@ describe('Visualization', () => {
             revisionId: '3',
             revisions: {
               count: 2,
-              items: [{ revisionId: '2' }, { revisionId: '1' }]
+              items: [{
+                revisionId: '2',
+                userId: 'test user'
+              }, {
+                revisionId: '1',
+                userId: 'test user'
+              }]
             },
             scienceKeywords: [
               {

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -53,6 +53,9 @@ type Visualization {
   "Raw UMM Metadata of the Visualization Record."
   ummMetadata: JSON
 
+  "Id of the user who modified/published record"
+  userId: String
+
   "The type of visualization, `tiles` or `maps`."
   visualizationType: String
 
@@ -117,6 +120,8 @@ input VisualizationsInput {
 input VisualizationInput {
   "The concept id of the visualization."
   conceptId: String!
+
+  revisionId: String
 }
 
 type Query {

--- a/src/types/visualization.graphql
+++ b/src/types/visualization.graphql
@@ -120,8 +120,6 @@ input VisualizationsInput {
 input VisualizationInput {
   "The concept id of the visualization."
   conceptId: String!
-
-  revisionId: String
 }
 
 type Query {


### PR DESCRIPTION
# Overview

### What is the feature?

Adding userId to Visualization so that I can call userId on past revisions

### What is the Solution?

Added userId to visualization

### What areas of the application does this impact?

visualization.graphql

# Testing

### Reproduction steps

- **Environment for testing:SIT
- **Collection to test with: VIS1200485038-MMT_1

1. Call userId on revisions under Visualization, should come up with whomever made the changes to a particular revision.

### Attachments
<img width="1397" alt="Screenshot 2025-06-10 at 11 15 00 AM" src="https://github.com/user-attachments/assets/c2555f83-0fb6-4c12-8175-ae56238b9e39" />

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
