### PR TITLE
CMR-10520: fixes multi depth filtered queries for associated citations

### DIFF
--- a/src/datasources/__tests__/__mocks__/associatedCitations.depth2MultiFilter.graphdbResponse.mocks.js
+++ b/src/datasources/__tests__/__mocks__/associatedCitations.depth2MultiFilter.graphdbResponse.mocks.js
@@ -1,0 +1,269 @@
+export default {
+  result: {
+    data: {
+      '@type': 'g:List',
+      '@value': [
+        {
+          '@type': 'g:Map',
+          '@value': [
+            'citations',
+            {
+              '@type': 'g:List',
+              '@value': [
+                {
+                  '@type': 'g:Map',
+                  '@value': [
+                    'citationData',
+                    {
+                      '@type': 'g:Map',
+                      '@value': [
+                        {
+                          '@type': 'g:T',
+                          '@value': 'id'
+                        },
+                        {
+                          '@type': 'g:Int64',
+                          '@value': 567
+                        },
+                        {
+                          '@type': 'g:T',
+                          '@value': 'label'
+                        },
+                        'citation',
+                        'identifier',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'ark:/13030/tf7p17501'
+                          ]
+                        },
+                        'providerId',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'PROV2'
+                          ]
+                        },
+                        'name',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Archival Earth Science Resource 7'
+                          ]
+                        },
+                        'id',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'CIT1200000034-PROV2'
+                          ]
+                        },
+                        'identifierType',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'ARK'
+                          ]
+                        },
+                        'abstract',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:36.650Z.'
+                          ]
+                        },
+                        'title',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Archival Earth Science Resource 7 - Research Publication 7'
+                          ]
+                        }
+                      ]
+                    },
+                    'associationLevel',
+                    {
+                      '@type': 'g:Double',
+                      '@value': 1
+                    },
+                    'relationshipType',
+                    'Cites'
+                  ]
+                },
+                {
+                  '@type': 'g:Map',
+                  '@value': [
+                    'citationData',
+                    {
+                      '@type': 'g:Map',
+                      '@value': [
+                        {
+                          '@type': 'g:T',
+                          '@value': 'id'
+                        },
+                        {
+                          '@type': 'g:Int64',
+                          '@value': 671
+                        },
+                        {
+                          '@type': 'g:T',
+                          '@value': 'label'
+                        },
+                        'citation',
+                        'identifier',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            '10.5067/SAMPLE/DATA.14.1750175978'
+                          ]
+                        },
+                        'providerId',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'PROV2'
+                          ]
+                        },
+                        'name',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Earth Science Dataset 14'
+                          ]
+                        },
+                        'id',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'CIT1200000041-PROV2'
+                          ]
+                        },
+                        'identifierType',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'DOI'
+                          ]
+                        },
+                        'abstract',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:38.462Z.'
+                          ]
+                        },
+                        'title',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Earth Science Dataset 14 - Research Publication 14'
+                          ]
+                        }
+                      ]
+                    },
+                    'associationLevel',
+                    {
+                      '@type': 'g:Double',
+                      '@value': 1
+                    },
+                    'relationshipType',
+                    'Cites'
+                  ]
+                },
+                {
+                  '@type': 'g:Map',
+                  '@value': [
+                    'citationData',
+                    {
+                      '@type': 'g:Map',
+                      '@value': [
+                        {
+                          '@type': 'g:T',
+                          '@value': 'id'
+                        },
+                        {
+                          '@type': 'g:Int64',
+                          '@value': 684
+                        },
+                        {
+                          '@type': 'g:T',
+                          '@value': 'label'
+                        },
+                        'citation',
+                        'identifier',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            '10.5067/SAMPLE/DATA.4.1750175975'
+                          ]
+                        },
+                        'providerId',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'PROV2'
+                          ]
+                        },
+                        'name',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Earth Science Dataset 4'
+                          ]
+                        },
+                        'id',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'CIT1200000031-PROV2'
+                          ]
+                        },
+                        'identifierType',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'DOI'
+                          ]
+                        },
+                        'abstract',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:35.909Z.'
+                          ]
+                        },
+                        'title',
+                        {
+                          '@type': 'g:List',
+                          '@value': [
+                            'Earth Science Dataset 4 - Research Publication 4'
+                          ]
+                        }
+                      ]
+                    },
+                    'associationLevel',
+                    {
+                      '@type': 'g:Double',
+                      '@value': 2
+                    },
+                    'relationshipType',
+                    'Cites'
+                  ]
+                }
+              ]
+            },
+            'totalCount',
+            {
+              '@type': 'g:Int64',
+              '@value': 3
+            }
+          ]
+        }
+      ]
+    },
+    meta: {
+      '@type': 'g:Map',
+      '@value': []
+    }
+  }
+}

--- a/src/datasources/__tests__/__mocks__/associatedCitations.depth2MultiFilter.response.mocks.js
+++ b/src/datasources/__tests__/__mocks__/associatedCitations.depth2MultiFilter.response.mocks.js
@@ -1,0 +1,38 @@
+export default {
+  count: 3,
+  items: [
+    {
+      id: 'CIT1200000034-PROV2',
+      identifier: 'ark:/13030/tf7p17501',
+      identifierType: 'ARK',
+      name: 'Archival Earth Science Resource 7',
+      title: 'Archival Earth Science Resource 7 - Research Publication 7',
+      abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:36.650Z.',
+      providerId: 'PROV2',
+      associationLevel: 1,
+      relationshipType: 'Cites'
+    },
+    {
+      id: 'CIT1200000041-PROV2',
+      identifier: '10.5067/SAMPLE/DATA.14.1750175978',
+      identifierType: 'DOI',
+      name: 'Earth Science Dataset 14',
+      title: 'Earth Science Dataset 14 - Research Publication 14',
+      abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:38.462Z.',
+      providerId: 'PROV2',
+      associationLevel: 1,
+      relationshipType: 'Cites'
+    },
+    {
+      id: 'CIT1200000031-PROV2',
+      identifier: '10.5067/SAMPLE/DATA.4.1750175975',
+      identifierType: 'DOI',
+      name: 'Earth Science Dataset 4',
+      title: 'Earth Science Dataset 4 - Research Publication 4',
+      abstract: 'This is a randomly generated citation for demonstration purposes. Created at 2025-06-17T15:59:35.909Z.',
+      providerId: 'PROV2',
+      associationLevel: 2,
+      relationshipType: 'Cites'
+    }
+  ]
+}

--- a/src/datasources/graphDbAssociatedCitations.js
+++ b/src/datasources/graphDbAssociatedCitations.js
@@ -70,10 +70,10 @@ export default async (
         .as('lastEdge')
         .otherV()
         .hasLabel('citation')
-        ${citationFilters.length > 0 ? `.${citationFilters.join('.')}` : ''}
       )
       .times(${Math.min(depth, 3)})
       .emit()
+      ${citationFilters.length > 0 ? `.${citationFilters.join('.')}` : ''}
       .dedup()
       .as('allCitations')
       .aggregate('totalCount')
@@ -88,7 +88,7 @@ export default async (
       .project('citations', 'totalCount')
       .by()
       .by(cap('totalCount').count(local))
-    `
+  `
   })
 
   const { data } = await cmrGraphDb({


### PR DESCRIPTION
# Overview

### What is the feature?

Multi level filtering was failing to properly filter past depth 1

### What is the Solution?

Move the filtering component of the traversal outside of the repeat.

### What areas of the application does this impact?

associated citations query for collections

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Step 1
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
