### PR TITLE
GQL-125: Add RestoreCitationRevision mutation

### DIFF
--- a/src/datasources/citation.js
+++ b/src/datasources/citation.js
@@ -1,7 +1,10 @@
 import citationKeyMap from '../utils/umm/citationKeyMap.json'
-
-import { parseRequestedFields } from '../utils/parseRequestedFields'
 import Citation from '../cmr/concepts/citation'
+
+import { cmrQuery } from '../utils/cmrQuery'
+import { findPreviousRevision } from '../utils/findPreviousRevision'
+import { getProviderFromConceptId } from '../utils/getProviderFromConceptId'
+import { parseRequestedFields } from '../utils/parseRequestedFields'
 
 export const fetchCitations = async (params, context, parsedInfo) => {
   const { headers } = context
@@ -18,6 +21,56 @@ export const fetchCitations = async (params, context, parsedInfo) => {
 
   // Return a formatted JSON response
   return citation.getFormattedResponse()
+}
+
+export const restoreCitationRevision = async (args, context, parsedInfo) => {
+  const { headers } = context
+
+  const requestInfo = parseRequestedFields(parsedInfo, citationKeyMap, 'citation')
+
+  const {
+    ingestKeys
+  } = requestInfo
+
+  const citation = new Citation(headers, requestInfo, args)
+
+  const {
+    conceptId,
+    revisionId
+  } = args
+
+  const previousRevisions = await cmrQuery({
+    conceptType: 'citations',
+    options: {
+      format: 'umm_json'
+    },
+    params: {
+      conceptId,
+      allRevisions: true
+    }
+  })
+
+  const { data: responseData } = previousRevisions
+
+  // Find the requested revision for the provided concept
+  const previousRevision = findPreviousRevision(responseData, revisionId)
+
+  const { meta, umm } = previousRevision
+
+  const { 'native-id': nativeId } = meta
+
+  // Query CMR
+  citation.ingest({
+    nativeId,
+    providerId: getProviderFromConceptId(conceptId),
+    ...umm
+  }, ingestKeys, headers)
+
+  // Parse the response from CMR
+  await citation.parseIngest(requestInfo)
+
+  // Return a formatted JSON response
+  return citation.getFormattedIngestResponse()
 }
 
 export const deleteCitation = async (args, context, parsedInfo) => {

--- a/src/graphql/handler.js
+++ b/src/graphql/handler.js
@@ -55,7 +55,8 @@ import {
 
 import {
   deleteCitation as citationSourceDelete,
-  fetchCitations as citationSourceFetch
+  fetchCitations as citationSourceFetch,
+  restoreCitationRevision as citationSourceRestoreRevision
 } from '../datasources/citation'
 
 import {
@@ -235,6 +236,7 @@ export default startServerAndCreateLambdaHandler(
           associationSourceDelete,
           citationSourceDelete,
           citationSourceFetch,
+          citationSourceRestoreRevision,
           collectionDraftProposalSource,
           collectionDraftSource,
           collectionSourceDelete,

--- a/src/resolvers/citation.js
+++ b/src/resolvers/citation.js
@@ -27,6 +27,16 @@ export default {
   },
 
   Mutation: {
+    restoreCitationRevision: async (source, args, context, info) => {
+      const { dataSources } = context
+
+      return dataSources.citationSourceRestoreRevision(
+        handlePagingParams(args),
+        context,
+        parseResolveInfo(info)
+      )
+    },
+
     deleteCitation: async (source, args, context, info) => {
       const { dataSources } = context
 

--- a/src/types/citation.graphql
+++ b/src/types/citation.graphql
@@ -152,6 +152,14 @@ type Query {
 }
 
 type Mutation {
+  restoreCitationRevision (
+    "The unique concept id assigned to the citation."
+    conceptId: String!
+
+    "The revision of the citation."
+    revisionId: String!
+  ): CitationMutationResponse
+
   deleteCitation (
     "Provider ID of the citation."
     providerId: String!


### PR DESCRIPTION
# Overview

### What is the feature?

Adding RestoreCitationRevision mutation to CMR-graphQL

### What is the Solution?

Added restoreCitationRevision mutation and appropriate code to graphQL

### What areas of the application does this impact?

mutations for Citations

# Testing

### Reproduction steps

`mutation RestoreCitationRevision($conceptId: String!, $revisionId: String!) {
  restoreCitationRevision(conceptId: $conceptId, revisionId: $revisionId) {
    conceptId
    revisionId
  }
}`

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
