### PR TITLE
GQL-130: Exposing associated citations from CMR on Collection and disable associatedCitations from graphdb for now

### DIFF
--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -2711,7 +2711,7 @@ describe('Collection', () => {
       })
 
       describe('when citation associations are present in the metadata', () => {
-        test.only('queries for and returns citations', async () => {
+        test('queries for and returns citations', async () => {
           nock(/example-cmr/)
             .defaultReplyHeaders({
               'CMR-Took': 7,

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -10,7 +10,7 @@ import duplicateCollectionsGraphdbResponseMocks from './__mocks__/duplicateColle
 import duplicateCollectionsResponseMocks from './__mocks__/duplicateCollections.response.mocks'
 import relatedCollectionsGraphdbResponseMocks from './__mocks__/relatedCollections.graphdbResponse.mocks'
 import relatedCollectionsResponseMocks from './__mocks__/relatedCollections.response.mocks'
-// Commenting out associatedCitations until futher notice
+// Commenting out until advanced Citation associations are worked out
 // import associatedCitationsCollectionResolverGraphdbResponseMocks from './__mocks__/associatedCitations.collectionResolver.graphdbResponse.mocks'
 // import associatedCitationsCollectionResolverResponseMocks from './__mocks__/associatedCitations.collectionResolver.response.mocks'
 
@@ -3428,6 +3428,7 @@ describe('Collection', () => {
       })
     })
 
+    // Commenting out until advanced Citation associations are worked out
     // Describe('associatedCitations', () => {
     //   test('returns exception when depth is invalid', async () => {
     //     nock(/example-cmr/)

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -2591,6 +2591,286 @@ describe('Collection', () => {
       })
     })
 
+    describe('citations', () => {
+      describe('no associations are present in the metadata', () => {
+        test('doesn\'t query for or return citations', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/collections\.json/)
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100000-EDSC'
+                }, {
+                  id: 'C100001-EDSC'
+                }]
+              }
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              collections {
+                items {
+                  conceptId
+                  citations {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            collections: {
+              items: [{
+                conceptId: 'C100000-EDSC',
+                citations: {
+                  items: []
+                }
+              }, {
+                conceptId: 'C100001-EDSC',
+                citations: {
+                  items: []
+                }
+              }]
+            }
+          })
+        })
+      })
+
+      describe('associations are present in the metadata but not citation associations', () => {
+        test('doesn\'t query for or return citations', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/collections\.json/)
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100000-EDSC',
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
+                  }
+                }, {
+                  id: 'C100001-EDSC',
+                  association_details: {
+                    variables: [{ concept_id: 'V100000-EDSC' }]
+                  }
+                }]
+              }
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              collections {
+                items {
+                  conceptId
+                  citations {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            collections: {
+              items: [{
+                conceptId: 'C100000-EDSC',
+                citations: {
+                  items: []
+                }
+              }, {
+                conceptId: 'C100001-EDSC',
+                citations: {
+                  items: []
+                }
+              }]
+            }
+          })
+        })
+      })
+
+      describe('when citation associations are present in the metadata', () => {
+        test.only('queries for and returns citations', async () => {
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get(/collections\.json/)
+            .reply(200, {
+              feed: {
+                entry: [{
+                  id: 'C100000-EDSC',
+                  association_details: {
+                    citations: [{ concept_id: 'CIT100000-EDSC' }, { concept_id: 'CIT100001-EDSC' }]
+                  }
+                }, {
+                  id: 'C100001-EDSC',
+                  association_details: {
+                    citations: [{ concept_id: 'CIT100002-EDSC' }, { concept_id: 'CIT100003-EDSC' }]
+                  }
+                }]
+              }
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/citations.json?concept_id[]=CIT100000-EDSC&concept_id[]=CIT100001-EDSC&page_size=20')
+            .reply(200, {
+              items: [{
+                concept_id: 'CIT100000-EDSC'
+              }, {
+                concept_id: 'CIT100001-EDSC'
+              }]
+            })
+
+          nock(/example-cmr/)
+            .defaultReplyHeaders({
+              'CMR-Took': 7,
+              'CMR-Request-Id': 'abcd-1234-efgh-5678'
+            })
+            .get('/search/citations.json?concept_id[]=CIT100002-EDSC&concept_id[]=CIT100003-EDSC&page_size=20')
+            .reply(200, {
+              items: [{
+                concept_id: 'CIT100002-EDSC'
+              }, {
+                concept_id: 'CIT100003-EDSC'
+              }]
+            })
+
+          const response = await server.executeOperation({
+            variables: {},
+            query: `{
+              collections {
+                items {
+                  conceptId
+                  citations {
+                    items {
+                      conceptId
+                    }
+                  }
+                }
+              }
+            }`
+          }, {
+            contextValue
+          })
+
+          const { data } = response.body.singleResult
+
+          expect(data).toEqual({
+            collections: {
+              items: [{
+                conceptId: 'C100000-EDSC',
+                citations: {
+                  items: [{
+                    conceptId: 'CIT100000-EDSC'
+                  }, {
+                    conceptId: 'CIT100001-EDSC'
+                  }]
+                }
+              }, {
+                conceptId: 'C100001-EDSC',
+                citations: {
+                  items: [{
+                    conceptId: 'CIT100002-EDSC'
+                  }, {
+                    conceptId: 'CIT100003-EDSC'
+                  }]
+                }
+              }]
+            }
+          })
+        })
+      })
+
+      test('returns null when querying a draft', async () => {
+        nock(/example-cmr/)
+          .defaultReplyHeaders({
+            'CMR-Hits': 2,
+            'CMR-Took': 7,
+            'CMR-Request-Id': 'abcd-1234-efgh-5678'
+          })
+          .get(/collection-drafts\.umm_json/)
+          .reply(200, {
+            items: [{
+              meta: {
+                'concept-id': 'CD100000-EDSC'
+              },
+              umm: {}
+            }, {
+              meta: {
+                'concept-id': 'CD100001-EDSC'
+              },
+              umm: {}
+            }]
+          })
+
+        const response = await server.executeOperation({
+          variables: {
+            params: {
+              conceptType: 'Collection'
+            }
+          },
+          query: `query Drafts($params: DraftsInput) {
+            drafts(params: $params) {
+              items {
+                previewMetadata {
+                  ... on Collection {
+                    citations {
+                      count
+                    }
+                  }
+                }
+              }
+            }
+          }`
+        }, {
+          contextValue
+        })
+
+        const { data } = response.body.singleResult
+
+        expect(data).toEqual({
+          drafts: {
+            items: [{
+              previewMetadata: {
+                citations: null
+              }
+            }, {
+              previewMetadata: {
+                citations: null
+              }
+            }]
+          }
+        })
+      })
+    })
+
     describe('data-quality-summaries', () => {
       describe('no associations are present in the metadata', () => {
         test('doesn\'t query for or return data-quality-summaries', async () => {

--- a/src/resolvers/__tests__/collection.test.js
+++ b/src/resolvers/__tests__/collection.test.js
@@ -10,8 +10,9 @@ import duplicateCollectionsGraphdbResponseMocks from './__mocks__/duplicateColle
 import duplicateCollectionsResponseMocks from './__mocks__/duplicateCollections.response.mocks'
 import relatedCollectionsGraphdbResponseMocks from './__mocks__/relatedCollections.graphdbResponse.mocks'
 import relatedCollectionsResponseMocks from './__mocks__/relatedCollections.response.mocks'
-import associatedCitationsCollectionResolverGraphdbResponseMocks from './__mocks__/associatedCitations.collectionResolver.graphdbResponse.mocks'
-import associatedCitationsCollectionResolverResponseMocks from './__mocks__/associatedCitations.collectionResolver.response.mocks'
+// Commenting out associatedCitations until futher notice
+// import associatedCitationsCollectionResolverGraphdbResponseMocks from './__mocks__/associatedCitations.collectionResolver.graphdbResponse.mocks'
+// import associatedCitationsCollectionResolverResponseMocks from './__mocks__/associatedCitations.collectionResolver.response.mocks'
 
 const contextValue = buildContextValue()
 
@@ -3427,224 +3428,224 @@ describe('Collection', () => {
       })
     })
 
-    describe('associatedCitations', () => {
-      test('returns exception when depth is invalid', async () => {
-        nock(/example-cmr/)
-          .defaultReplyHeaders({
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          })
-          .get(/collections\.json/)
-          .reply(200, {
-            feed: {
-              entry: [{
-                id: 'C100000-EDSC'
-              }]
-            }
-          })
+    // Describe('associatedCitations', () => {
+    //   test('returns exception when depth is invalid', async () => {
+    //     nock(/example-cmr/)
+    //       .defaultReplyHeaders({
+    //         'CMR-Took': 7,
+    //         'CMR-Request-Id': 'abcd-1234-efgh-5678'
+    //       })
+    //       .get(/collections\.json/)
+    //       .reply(200, {
+    //         feed: {
+    //           entry: [{
+    //             id: 'C100000-EDSC'
+    //           }]
+    //         }
+    //       })
 
-        const response = await server.executeOperation({
-          variables: {},
-          query: `{
-            collections (
-              conceptId: "C100000-EDSC"
-            ) {
-              items {
-                conceptId
-                associatedCitations(params: { depth: 4 }) {
-                  count
-                  items {
-                    id
-                  }
-                }
-              }
-            }
-          }`
-        }, {
-          contextValue
-        })
+    //     const response = await server.executeOperation({
+    //       variables: {},
+    //       query: `{
+    //         collections (
+    //           conceptId: "C100000-EDSC"
+    //         ) {
+    //           items {
+    //             conceptId
+    //             associatedCitations(params: { depth: 4 }) {
+    //               count
+    //               items {
+    //                 id
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }`
+    //     }, {
+    //       contextValue
+    //     })
 
-        expect(response.body.kind).toBe('single')
-        expect(response.body.singleResult.errors).toBeDefined()
-        expect(response.body.singleResult.errors[0].message).toBe('Depth must be between 1 and 3')
-      })
+    //     expect(response.body.kind).toBe('single')
+    //     expect(response.body.singleResult.errors).toBeDefined()
+    //     expect(response.body.singleResult.errors[0].message).toBe('Depth must be between 1 and 3')
+    //   })
 
-      test('queries CMR GraphDB for associated citations', async () => {
-        nock(/example-cmr/)
-          .defaultReplyHeaders({
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          })
-          .get(/collections\.json/)
-          .reply(200, {
-            feed: {
-              entry: [{
-                id: 'C100000-EDSC'
-              }]
-            }
-          })
+    //   test('queries CMR GraphDB for associated citations', async () => {
+    //     nock(/example-cmr/)
+    //       .defaultReplyHeaders({
+    //         'CMR-Took': 7,
+    //         'CMR-Request-Id': 'abcd-1234-efgh-5678'
+    //       })
+    //       .get(/collections\.json/)
+    //       .reply(200, {
+    //         feed: {
+    //           entry: [{
+    //             id: 'C100000-EDSC'
+    //           }]
+    //         }
+    //       })
 
-        nock(/example-graphdb/)
-          .post(() => true)
-          .reply(200, associatedCitationsCollectionResolverGraphdbResponseMocks)
+    //     nock(/example-graphdb/)
+    //       .post(() => true)
+    //       .reply(200, associatedCitationsCollectionResolverGraphdbResponseMocks)
 
-        const response = await server.executeOperation({
-          variables: {},
-          query: `{
-            collections (
-              conceptId: "C100000-EDSC"
-            ) {
-              items {
-                conceptId
-                associatedCitations {
-                  count
-                  items {
-                    id
-                    identifier
-                    identifierType
-                    name
-                    title
-                    abstract
-                  }
-                }
-              }
-            }
-          }`
-        }, {
-          contextValue
-        })
+    //     const response = await server.executeOperation({
+    //       variables: {},
+    //       query: `{
+    //         collections (
+    //           conceptId: "C100000-EDSC"
+    //         ) {
+    //           items {
+    //             conceptId
+    //             associatedCitations {
+    //               count
+    //               items {
+    //                 id
+    //                 identifier
+    //                 identifierType
+    //                 name
+    //                 title
+    //                 abstract
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }`
+    //     }, {
+    //       contextValue
+    //     })
 
-        const { data } = response.body.singleResult
+    //     const { data } = response.body.singleResult
 
-        expect(data).toEqual(associatedCitationsCollectionResolverResponseMocks.data)
-      })
+    //     expect(data).toEqual(associatedCitationsCollectionResolverResponseMocks.data)
+    //   })
 
-      describe('when graphdb is not enabled', () => {
-        test('returns an empty no associated citations response ', async () => {
-          process.env.graphdbEnabled = 'false'
+    //   describe('when graphdb is not enabled', () => {
+    //     test('returns an empty no associated citations response ', async () => {
+    //       process.env.graphdbEnabled = 'false'
 
-          nock(/example-cmr/)
-            .defaultReplyHeaders({
-              'CMR-Took': 7,
-              'CMR-Request-Id': 'abcd-1234-efgh-5678'
-            })
-            .get(/collections\.json/)
-            .reply(200, {
-              feed: {
-                entry: [{
-                  id: 'C100000-EDSC'
-                }]
-              }
-            })
+    //       nock(/example-cmr/)
+    //         .defaultReplyHeaders({
+    //           'CMR-Took': 7,
+    //           'CMR-Request-Id': 'abcd-1234-efgh-5678'
+    //         })
+    //         .get(/collections\.json/)
+    //         .reply(200, {
+    //           feed: {
+    //             entry: [{
+    //               id: 'C100000-EDSC'
+    //             }]
+    //           }
+    //         })
 
-          // No nock to graphdb since we are disabling it
+    //       // No nock to graphdb since we are disabling it
 
-          const response = await server.executeOperation({
-            variables: {},
-            query: `{
-              collections (
-                conceptId: "C100000-EDSC"
-              ) {
-                items {
-                  conceptId
-                  associatedCitations {
-                    count
-                    items {
-                      id
-                      identifier
-                      identifierType
-                      name
-                      title
-                      abstract
-                    }
-                  }
-                }
-              }
-            }`
-          }, {
-            contextValue
-          })
+    //       const response = await server.executeOperation({
+    //         variables: {},
+    //         query: `{
+    //           collections (
+    //             conceptId: "C100000-EDSC"
+    //           ) {
+    //             items {
+    //               conceptId
+    //               associatedCitations {
+    //                 count
+    //                 items {
+    //                   id
+    //                   identifier
+    //                   identifierType
+    //                   name
+    //                   title
+    //                   abstract
+    //                 }
+    //               }
+    //             }
+    //           }
+    //         }`
+    //       }, {
+    //         contextValue
+    //       })
 
-          const { data } = response.body.singleResult
+    //       const { data } = response.body.singleResult
 
-          expect(data).toEqual({
-            collections: {
-              items: [
-                {
-                  conceptId: 'C100000-EDSC',
-                  associatedCitations: {
-                    count: 0,
-                    items: []
-                  }
-                }
-              ]
-            }
-          })
-        })
-      })
+    //       expect(data).toEqual({
+    //         collections: {
+    //           items: [
+    //             {
+    //               conceptId: 'C100000-EDSC',
+    //               associatedCitations: {
+    //                 count: 0,
+    //                 items: []
+    //               }
+    //             }
+    //           ]
+    //         }
+    //       })
+    //     })
+    //   })
 
-      test('returns null when querying a draft', async () => {
-        nock(/example-cmr/)
-          .defaultReplyHeaders({
-            'CMR-Hits': 2,
-            'CMR-Took': 7,
-            'CMR-Request-Id': 'abcd-1234-efgh-5678'
-          })
-          .get(/collection-drafts\.umm_json/)
-          .reply(200, {
-            items: [{
-              meta: {
-                'concept-id': 'CD100000-EDSC'
-              },
-              umm: {}
-            }, {
-              meta: {
-                'concept-id': 'CD100001-EDSC'
-              },
-              umm: {}
-            }]
-          })
+    //   test('returns null when querying a draft', async () => {
+    //     nock(/example-cmr/)
+    //       .defaultReplyHeaders({
+    //         'CMR-Hits': 2,
+    //         'CMR-Took': 7,
+    //         'CMR-Request-Id': 'abcd-1234-efgh-5678'
+    //       })
+    //       .get(/collection-drafts\.umm_json/)
+    //       .reply(200, {
+    //         items: [{
+    //           meta: {
+    //             'concept-id': 'CD100000-EDSC'
+    //           },
+    //           umm: {}
+    //         }, {
+    //           meta: {
+    //             'concept-id': 'CD100001-EDSC'
+    //           },
+    //           umm: {}
+    //         }]
+    //       })
 
-        const response = await server.executeOperation({
-          variables: {
-            params: {
-              conceptType: 'Collection'
-            }
-          },
-          query: `query Drafts($params: DraftsInput) {
-            drafts(params: $params) {
-              items {
-                previewMetadata {
-                  ... on Collection {
-                    associatedCitations {
-                      count
-                    }
-                  }
-                }
-              }
-            }
-          }`
-        }, {
-          contextValue
-        })
+    //     const response = await server.executeOperation({
+    //       variables: {
+    //         params: {
+    //           conceptType: 'Collection'
+    //         }
+    //       },
+    //       query: `query Drafts($params: DraftsInput) {
+    //         drafts(params: $params) {
+    //           items {
+    //             previewMetadata {
+    //               ... on Collection {
+    //                 associatedCitations {
+    //                   count
+    //                 }
+    //               }
+    //             }
+    //           }
+    //         }
+    //       }`
+    //     }, {
+    //       contextValue
+    //     })
 
-        const { data } = response.body.singleResult
+    //     const { data } = response.body.singleResult
 
-        expect(data).toEqual({
-          drafts: {
-            items: [{
-              previewMetadata: {
-                associatedCitations: null
-              }
-            }, {
-              previewMetadata: {
-                associatedCitations: null
-              }
-            }]
-          }
-        })
-      })
-    })
+    //     expect(data).toEqual({
+    //       drafts: {
+    //         items: [{
+    //           previewMetadata: {
+    //             associatedCitations: null
+    //           }
+    //         }, {
+    //           previewMetadata: {
+    //             associatedCitations: null
+    //           }
+    //         }]
+    //       }
+    //     })
+    //   })
+    // })
 
     describe('duplicateCollections', () => {
       test('queries CMR GraphDB for relationships', async () => {

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -391,6 +391,37 @@ export default {
         conceptId: visualizationConceptIds,
         ...handlePagingParams(args)
       }, context, parseResolveInfo(info))
+    },
+
+    citations: async (source, args, context, info) => {
+      const {
+        associationDetails = {},
+        conceptId
+      } = source
+
+      // If the concept being returned is a draft, there will be no associations,
+      // return null to avoid an extra call to CMR
+      if (isDraftConceptId(conceptId, 'collection')) return null
+
+      const { dataSources } = context
+
+      const { citations = [] } = associationDetails
+
+      const citationConceptIds = citations.map(
+        ({ conceptId: citationId }) => citationId
+      )
+
+      if (!citations.length) {
+        return {
+          count: 0,
+          items: []
+        }
+      }
+
+      return dataSources.citationSourceFetch({
+        conceptId: citationConceptIds,
+        ...handlePagingParams(args)
+      }, context, parseResolveInfo(info))
     }
   },
   Relationship: {

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -62,7 +62,6 @@ export default {
         parseResolveInfo(info)
       )
     },
-
     granules: async (source, args, context, info) => {
       const { dataSources } = context
 
@@ -184,7 +183,7 @@ export default {
         ...handlePagingParams(args, dataQualitySummaryConceptIds.length)
       }, context, parseResolveInfo(info))
     },
-    // Commenting out until further notice
+    // Commenting out until advanced Citation associations are worked out
     // associatedCitations: async (source, args, context) => {
     //   const {
     //     graphdbEnabled
@@ -393,7 +392,6 @@ export default {
         ...handlePagingParams(args)
       }, context, parseResolveInfo(info))
     },
-
     citations: async (source, args, context, info) => {
       const {
         associationDetails = {},

--- a/src/resolvers/collection.js
+++ b/src/resolvers/collection.js
@@ -184,37 +184,38 @@ export default {
         ...handlePagingParams(args, dataQualitySummaryConceptIds.length)
       }, context, parseResolveInfo(info))
     },
-    associatedCitations: async (source, args, context) => {
-      const {
-        graphdbEnabled
-      } = process.env
+    // Commenting out until further notice
+    // associatedCitations: async (source, args, context) => {
+    //   const {
+    //     graphdbEnabled
+    //   } = process.env
 
-      if (graphdbEnabled === 'false') {
-        return {
-          count: 0,
-          items: []
-        }
-      }
+    //   if (graphdbEnabled === 'false') {
+    //     return {
+    //       count: 0,
+    //       items: []
+    //     }
+    //   }
 
-      const { dataSources } = context
-      const { conceptId } = source
-      const { params = {} } = args
-      const { depth = 1 } = params
+    //   const { dataSources } = context
+    //   const { conceptId } = source
+    //   const { params = {} } = args
+    //   const { depth = 1 } = params
 
-      // If the concept being returned is a draft, there will be no associations,
-      // return null to avoid an extra call to CMR
-      if (isDraftConceptId(conceptId, 'collection')) return null
+    //   // If the concept being returned is a draft, there will be no associations,
+    //   // return null to avoid an extra call to CMR
+    //   if (isDraftConceptId(conceptId, 'collection')) return null
 
-      if (depth < 1 || depth > 3) {
-        throw new Error('Depth must be between 1 and 3')
-      }
+    //   if (depth < 1 || depth > 3) {
+    //     throw new Error('Depth must be between 1 and 3')
+    //   }
 
-      return dataSources.graphDbAssociatedCitations(
-        source,
-        args,
-        context
-      )
-    },
+    //   return dataSources.graphDbAssociatedCitations(
+    //     source,
+    //     args,
+    //     context
+    //   )
+    // },
     duplicateCollections: async (source, args, context) => {
       const {
         graphdbEnabled

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -452,6 +452,7 @@ type Collection {
     params: DataQualitySummariesInput
   ): DataQualitySummaryList
 
+# Commenting out until advanced Citation associations are worked out
   # "Returns the list of associated citations from graphDB."
   # associatedCitations(
   #   "Associated citations query parameters"

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -437,6 +437,12 @@ type Collection {
     params: VisualizationsInput
   ): VisualizationList
 
+  "Returns a list of associated citations from CMR."
+  citations (
+    "Citations query parameters"
+    params: CitationsInput
+  ): CitationList
+
   "Generates variable drafts on the collection using earthdata-varinfo"
   generateVariableDrafts: VariableDraftList
 
@@ -446,7 +452,7 @@ type Collection {
     params: DataQualitySummariesInput
   ): DataQualitySummaryList
 
-  "Returns the list of associated citations."
+  "Returns the list of associated citations from graphDB."
   associatedCitations(
     "Associated citations query parameters"
     params: AssociatedCitationsInput

--- a/src/types/collection.graphql
+++ b/src/types/collection.graphql
@@ -452,35 +452,35 @@ type Collection {
     params: DataQualitySummariesInput
   ): DataQualitySummaryList
 
-  "Returns the list of associated citations from graphDB."
-  associatedCitations(
-    "Associated citations query parameters"
-    params: AssociatedCitationsInput
-  ): AssociatedCitationsList
+  # "Returns the list of associated citations from graphDB."
+  # associatedCitations(
+  #   "Associated citations query parameters"
+  #   params: AssociatedCitationsInput
+  # ): AssociatedCitationsList
 }
 
-input AssociatedCitationsInput {
-  "Cursor for pagination"
-  cursor: String
+# input AssociatedCitationsInput {
+#   "Cursor for pagination"
+#   cursor: String
   
-  "Number of citations to return"
-  limit: Int
+#   "Number of citations to return"
+#   limit: Int
   
-  "Offset for pagination" 
-  offset: Int
+#   "Offset for pagination" 
+#   offset: Int
   
-  "Depth of citation association traversal (1-3)"
-  depth: Int 
+#   "Depth of citation association traversal (1-3)"
+#   depth: Int 
   
-  "Filter by identifier type"
-  identifierType: [String]
+#   "Filter by identifier type"
+#   identifierType: [String]
 
-  "Filter by relationship type"
-  relationshipType: [String]
+#   "Filter by relationship type"
+#   relationshipType: [String]
   
-  "Filter by provider ID"
-  providerId: [String]
-}
+#   "Filter by provider ID"
+#   providerId: [String]
+# }
 
 type DuplicateCollection {
   "The unique concept id assigned to the collection."
@@ -504,42 +504,43 @@ type DuplicateCollectionList {
   items: [DuplicateCollection]
 }
 
-type AssociatedCitation {
-  "The unique concept id assigned to the citation."
-  id: String
+# These types are connected to graphDB which is not the source of truth for associations
+# type AssociatedCitation {
+#   "The unique concept id assigned to the citation."
+#   id: String
 
-  "The identifier of the citation."
-  identifier: String
+#   "The identifier of the citation."
+#   identifier: String
 
-  "The identifier type of the citation."
-  identifierType: String
+#   "The identifier type of the citation."
+#   identifierType: String
 
-  "The title of the citation."
-  title: String
+#   "The title of the citation."
+#   title: String
 
-  "The abstract of the citation."
-  abstract: String
+#   "The abstract of the citation."
+#   abstract: String
 
-  "The name of the citation."
-  name: String
+#   "The name of the citation."
+#   name: String
 
-  "The provider of the citation."
-  providerId: String
+#   "The provider of the citation."
+#   providerId: String
 
-  "The type of relationship between the citation and the collection."
-  relationshipType: String
+#   "The type of relationship between the citation and the collection."
+#   relationshipType: String
 
-  "The level of association for the citation."
-  associationLevel: String
-}
+#   "The level of association for the citation."
+#   associationLevel: String
+# }
 
-type AssociatedCitationsList {
-  "The number of associated citations available."
-  count: Int
+# type AssociatedCitationsList {
+#   "The number of associated citations available."
+#   count: Int
 
-  "The list of associated citations."
-  items: [AssociatedCitation]
-}
+#   "The list of associated citations."
+#   items: [AssociatedCitation]
+# }
 
 input RelatedCollectionsInput {
   "The size of the range GraphDB searches on. Defaults to 5"

--- a/src/utils/parseRequestedFields.js
+++ b/src/utils/parseRequestedFields.js
@@ -143,6 +143,7 @@ export const parseRequestedFields = (parsedInfo, keyMap, conceptName) => {
         || requestedFields.includes('revisions')
         || requestedFields.includes('subscriptions')
         || requestedFields.includes('visualizations')
+        || requestedFields.includes('citations')
       )
        && !requestedFields.includes('conceptId')) {
       requestedFields.push('conceptId')


### PR DESCRIPTION
# Overview

### What is the feature?

You can query for associatedCitations on a Collection and receive back a valid response. As is the case with Collection: C1200484122-MMT_2. It is associated with [CIT1200485865-MMT_2](http://localhost:5000/citations/CIT1200485865-MMT_2) however you won't see that association in [cmr ](http://example.com/)anywhere as it only exists in graphdb. 

In graphql, we need to expose the citations that are found in the associationDetails/cmr like we do for variables, services, and tools.

### What is the Solution?

Added citations to collection.graphql and created the resolver

### What areas of the application does this impact?

Collection.graphql
collection/resolver

# Testing

### Reproduction steps

- **Environment for testing: SIT
- **Collection to test with: 
Collection to associate to: C1200411035-ARCTEST
Citation to associate to above Collection: CIT1200485769-MMT_1

1. In graphql, query for collection.citations and collection.associatedDetails
2. Make sure the conceptIds in associatedDetails corrolate with what's in collection.citations

### Attachments

<img width="1352" height="694" alt="Screenshot 2025-09-24 at 7 59 18 AM" src="https://github.com/user-attachments/assets/55ba8c15-8429-4e31-b386-5a0857f649ff" />

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
