### PR TITLE
MMT-4100: Support New UMM-C Schema Version 1.18.5

### DIFF
--- a/cdk/graphql/lib/graphql-stack.ts
+++ b/cdk/graphql/lib/graphql-stack.ts
@@ -41,7 +41,7 @@ const environment = {
   stellateKey: process.env.STELLATE_KEY!,
   lambdaTimeout: process.env.LAMBDA_TIMEOUT || '30',
   ummCitationVersion: '1.0.0',
-  ummCollectionVersion: '1.18.4',
+  ummCollectionVersion: '1.18.5',
   ummGranuleVersion: '1.6.5',
   ummOrderOptionVersion: '1.0.0',
   ummServiceVersion: '1.5.4',


### PR DESCRIPTION
# Overview

### What is the feature?

Support UMM-C schema version 1.18.5 (Added new enum 'VIIRS Rotated Sinusoidal Tiling System' in 'Tiling Identification System')

### What is the Solution?

Update version number to 1.18.5

### What areas of the application does this impact?

This only required a single version bump in GQL without any other changes.

# Testing

### Reproduction steps

Ingest a collection draft
Fetching it returns the correct schema version 1.18.5 in "MetadataSpecification"

### Attachments

N/A

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
