### PR TITLE
GQL-145: Update transient dependency for @apollo/protobufjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@apollo/server": "^5.5.0",
+        "@apollo/server": "^5.5.1",
         "@as-integrations/aws-lambda": "^4.0.1",
         "@aws-sdk/client-lambda": "^3.540.0",
         "@aws-sdk/client-s3": "^3.540.0",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.0.tgz",
-      "integrity": "sha512-vWtodBOK/SZwBTJzItECOmLfL8E8pn/IdvP7pnxN5g2tny9iW4+9sxdajE798wV1H2+PYp/rRcl/soSHIBKMPw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
+      "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
@@ -140,7 +140,6 @@
         "loglevel": "^1.6.8",
         "lru-cache": "^11.1.0",
         "negotiator": "^1.0.0",
-        "uuid": "^11.1.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -334,19 +333,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,10 +91,11 @@
       }
     },
     "node_modules/@apollo/protobufjs": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
-      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.8.tgz",
+      "integrity": "sha512-r7xNeUqZX+eBBEmyvaPw0/cSz6zgf5jdH8mjUz8ynKpNs/GU7vi2T7sNcZINk2ZID7wwjG91FCgdpCrQuJ8rzA==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   "overrides": {
     "graphql-parse-resolve-info": {
       "graphql": "$graphql"
-    }
+    },
+    "@apollo/protobufjs": "1.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
-    "@apollo/server": "^5.5.0",
+    "@apollo/server": "^5.5.1",
     "@as-integrations/aws-lambda": "^4.0.1",
     "@aws-sdk/client-lambda": "^3.540.0",
     "@aws-sdk/client-s3": "^3.540.0",


### PR DESCRIPTION
# Overview

### What is the feature?

Update transient dependency to fix CVE

### What is the Solution?

Override the version for the transient dependency that apollo-server uses
**You can see in the ticket description why its okay to do this**

### What areas of the application does this impact?

Apollo server

# Testing

### Reproduction steps

- **Environment for testing:*any*
- **Collection to test with:*any*

1. Ensure CVE is closed
2. Regression test graphql a bit to ensure no issues starting up graphql server and making CMR request

### Attachments


# Checklist

- [NA] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
