### PR TITLE
GQL-145: Fix deployment of magic-docs by pinning pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs": "magidoc dev --clean --package-manager npm",
     "deploy-infrastructure": "cd cdk/graphql-infrastructure && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
     "deploy-application": "cd cdk/graphql && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never",
-    "predeploy-static": "npm ci --include=dev && npm i -g pnpm && npx @magidoc/cli@6.2.0 generate --clean true --stacktrace && node bin/build-landing-page.js",
+    "predeploy-static": "npm ci --include=dev && npm i -g pnpm@10.33.2 && npx @magidoc/cli@6.2.0 generate --clean true --stacktrace && node bin/build-landing-page.js",
     "deploy-static": "cd cdk/graphql-docs && npm ci --include=dev && npm run cdk deploy -- --progress events --require-approval never"
   },
   "devDependencies": {


### PR DESCRIPTION
# Overview

### What is the feature?

This fixes a deployment issue where generating the magic-doc was failing. This is due to them recently upgrading the `v11` and we were not pinning to an older version. I now pin the install to the latest stable version prior to the breaking changes in `v11`

### What is the Solution?

Pin the version of `pnpm` to the last release before the v11 become the default rollout

### What areas of the application does this impact?

graphql static-content on the documentation page

# Testing

### Reproduction steps

- **Environment for testing:*NA*
- **Collection to test with:*NA*

1. Make sure the deployment is successful
2. Ensure that magic-docs continue to generate on https://graphql.sit.earthdata.nasa.gov/docs/introduction/introduction/

### Attachments

NA

# Checklist

- [NA] I have added automated tests that prove my fix is effective or that my feature works
- [NA] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
